### PR TITLE
Cannot resolve module 'babel-runtime/helpers/extends'

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
+    "babel-runtime": "^6.11.6",
     "inflection": "1.10.0",
     "material-ui": "0.15.4",
     "react": "15.2.1",


### PR DESCRIPTION
## How to reproduce the error

1) Install
```
create-react-app foo
cd foo
npm install --save admin-on-rest
```
	
2) Edit `src/App.js`:

```javascript
import React, {Component} from "react";
import {jsonServerRestClient, Admin, Resource} from "admin-on-rest";

const App = () => (
	<Admin restClient={jsonServerRestClient('http://jsonplaceholder.typicode.com')}>
		<Resource name="posts" />
	</Admin>
);

export default App;
```

3) `npm start`

You get lots of errors like this one:

```
Error in ./~/admin-on-rest/lib/util/fetch.js
Module not found: Error: Cannot resolve module 'babel-runtime/helpers/extends' in d:\foo\node_modules\admin-on-rest\lib\util
 @ ./~/admin-on-rest/lib/util/fetch.js 8:16-56
```

## How to fix it

```
npm install --save babel-runtime
```

As the documentation of Babel says:

> In most cases, you should install babel-plugin-transform-runtime as a development dependency (with --save-dev) and babel-runtime as a production dependency (with --save).
>
> https://babeljs.io/docs/plugins/transform-runtime/
