### PR TITLE
[RFR][BC Break] Make Datagrid usage explicit in <List>

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,19 @@ The `<Resource>` component is a configuration component that allows to define su
 ```js
 // in posts.js
 import React from 'react';
-import { List, Edit, Create, DateField, TextField, EditButton, DisabledInput, TextInput, LongTextInput, DateInput } from 'admin-on-rest/lib/mui';
+import { List, Edit, Create, Datagrid, DateField, TextField, EditButton, DisabledInput, TextInput, LongTextInput, DateInput } from 'admin-on-rest/lib/mui';
 export PostIcon from 'material-ui/svg-icons/action/book';
 
 export const PostList = (props) => (
     <List {...props}>
-        <TextField label="id" source="id" />
-        <TextField label="title" source="title" />
-        <DateField label="published_at" source="published_at" />
-        <TextField label="average_note" source="average_note" />
-        <TextField label="views" source="views" />
-        <EditButton basePath="/posts" />
+        <Datagrid>
+            <TextField label="id" source="id" />
+            <TextField label="title" source="title" />
+            <DateField label="published_at" source="published_at" />
+            <TextField label="average_note" source="average_note" />
+            <TextField label="views" source="views" />
+            <EditButton basePath="/posts" />
+        </Datagrid>
     </List>
 );
 

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -51,18 +51,22 @@ The `<Admin>` component contains `<Resource>` components, each resource being ma
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField } from 'admin-on-rest/lib/mui';
 
 export const PostList = (props) => (
     <List {...props}>
-        <TextField label="id" source="id" />
-        <TextField label="title" source="title" />
-        <TextField label="body" source="body" />
+        <Datagrid>
+            <TextField label="id" source="id" />
+            <TextField label="title" source="title" />
+            <TextField label="body" source="body" />
+        </Datagrid>
     </List>
 );
 ```
 
-Notice that the components we use here are from `admin-on-rest/lib/mui` - these are Material UI components. The lists consists of a `<List>` with a bunch of `<TextField>` components, each mapping a different source field in the API response.
+Notice that the components we use here are from `admin-on-rest/lib/mui` - these are Material UI components.
+
+The main component of the post list is a `<List>` component, responsible for grabbing the information from the url, displaying the page title, and handling pagination. This list then delegates the display of the actual list of posts to a `<Datagrid>`, responsible for displaying a table with one row for each post. As for which columns should be displayed in this table, that's what the bunch of `<TextField>` components are for, each mapping a different source field in the API response.
 
 That should be enough to display the post list:
 
@@ -77,14 +81,16 @@ So far, you've only seen `<TextField>`, but if the API sends resources with othe
 ```js
 // in src/users.js
 import React from 'react';
-import { List, EmailField, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, EmailField, TextField } from 'admin-on-rest/lib/mui';
 
 export const UserList = (props) => (
     <List title="All users" {...props}>
-        <TextField label="id" source="id" />
-        <TextField label="name" source="name" />
-        <TextField label="username" source="username" />
-        <EmailField label="email" source="email" />
+        <Datagrid>
+            <TextField label="id" source="id" />
+            <TextField label="name" source="name" />
+            <TextField label="username" source="username" />
+            <EmailField label="email" source="email" />
+        </Datagrid>
     </List>
 );
 ```
@@ -144,16 +150,18 @@ Admin-on-REST knows how to take advantage of these foreign keys to fetch referen
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, TextField, EmailField, ReferenceField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField, EmailField, ReferenceField } from 'admin-on-rest/lib/mui';
 
 export const PostList = (props) => (
     <List {...props}>
-        <TextField label="id" source="id" />
-        <ReferenceField label="User" source="userId" reference="users">
-            <TextField source="name" />
-        </ReferenceField>
-        <TextField label="title" source="title" />
-        <TextField label="body" source="body" />
+        <Datagrid>
+            <TextField label="id" source="id" />
+            <ReferenceField label="User" source="userId" reference="users">
+                <TextField source="name" />
+            </ReferenceField>
+            <TextField label="title" source="title" />
+            <TextField label="body" source="body" />
+        </Datagrid>
     </List>
 );
 ```
@@ -171,17 +179,19 @@ An admin interface is usually for more than seeing remote data - it's for editin
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Edit, Create, ReferenceField, TextField, EditButton, DisabledInput, LongTextInput, ReferenceInput, SelectInput, TextInput } from 'admin-on-rest/lib/mui';
+import { List, Edit, Create, Datagrid, ReferenceField, TextField, EditButton, DisabledInput, LongTextInput, ReferenceInput, SelectInput, TextInput } from 'admin-on-rest/lib/mui';
 
 export const PostList = (props) => (
     <List {...props}>
-        <TextField label="id" source="id" />
-        <ReferenceField label="User" source="userId" reference="users">
-            <TextField source="name" />
-        </ReferenceField>
-        <TextField label="title" source="title" />
-        <TextField label="body" source="body" />
-        <EditButton />
+        <Datagrid>
+            <TextField label="id" source="id" />
+            <ReferenceField label="User" source="userId" reference="users">
+                <TextField source="name" />
+            </ReferenceField>
+            <TextField label="title" source="title" />
+            <TextField label="body" source="body" />
+            <EditButton />
+        </Datagrid>
     </List>
 );
 

--- a/example/comments.js
+++ b/example/comments.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List, Filter, Edit, Create, DateField, ReferenceField, TextField, EditButton, DisabledInput, DateInput, LongTextInput, SelectInput, ReferenceInput } from 'admin-on-rest/mui';
+import { List, Filter, Edit, Create, Datagrid, DateField, ReferenceField, TextField, EditButton, DisabledInput, DateInput, LongTextInput, SelectInput, ReferenceInput } from 'admin-on-rest/mui';
 
 export CommentIcon from 'material-ui/svg-icons/communication/chat-bubble';
 
@@ -13,12 +13,14 @@ const CommentFilter = (props) => (
 
 export const CommentList = (props) => (
     <List title="All comments" {...props} filter={CommentFilter}>
-        <TextField label="id" source="id" />
-        <ReferenceField label="Post" source="post_id" reference="posts">
-            <TextField source="title" />
-        </ReferenceField>
-        <DateField label="date" source="created_at" />
-        <EditButton />
+        <Datagrid>
+            <TextField label="id" source="id" />
+            <ReferenceField label="Post" source="post_id" reference="posts">
+                <TextField source="title" />
+            </ReferenceField>
+            <DateField label="date" source="created_at" />
+            <EditButton />
+        </Datagrid>
     </List>
 );
 

--- a/example/posts.js
+++ b/example/posts.js
@@ -12,12 +12,14 @@ const PostFilter = (props) => (
 
 export const PostList = (props) => (
     <List {...props} filter={PostFilter}>
-        <TextField label="id" source="id" />
-        <TextField label="title" source="title" />
-        <DateField label="published_at" source="published_at" />
-        <TextField label="average_note" source="average_note" />
-        <TextField label="views" source="views" />
-        <EditButton />
+        <Datagrid>
+            <TextField label="id" source="id" />
+            <TextField label="title" source="title" />
+            <DateField label="published_at" source="published_at" />
+            <TextField label="average_note" source="average_note" />
+            <TextField label="views" source="views" />
+            <EditButton />
+        </Datagrid>
     </List>
 );
 

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -7,7 +7,6 @@ import NavigationRefresh from 'material-ui/svg-icons/navigation/refresh';
 import inflection from 'inflection';
 import queryReducer, { SET_SORT, SET_PAGE, SET_FILTER } from '../../reducer/resource/list/queryReducer';
 import Title from '../layout/Title';
-import Datagrid from './Datagrid';
 import Pagination from './Pagination';
 import CreateButton from '../button/CreateButton';
 import { crudGetList as crudGetListAction } from '../../actions/dataActions';
@@ -111,9 +110,14 @@ class List extends Component {
                     displayedFilters: this.state,
                     context: 'form',
                 })}
-                <Datagrid resource={resource} ids={ids} data={data} currentSort={query} basePath={basePath} updateSort={this.updateSort}>
-                    {children}
-                </Datagrid>
+                {React.cloneElement(children, {
+                    resource,
+                    ids,
+                    data,
+                    currentSort: query,
+                    basePath,
+                    updateSort: this.updateSort,
+                })}
                 <Pagination resource={resource} page={parseInt(query.page, 10)} perPage={parseInt(query.perPage, 10)} total={total} setPage={this.setPage} />
             </Card>
         );
@@ -139,6 +143,7 @@ List.propTypes = {
     isLoading: PropTypes.bool.isRequired,
     crudGetList: PropTypes.func.isRequired,
     changeListParams: PropTypes.func.isRequired,
+    children: PropTypes.element.isRequired,
     push: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
Pros:
* Explicit
* Same structure as for `<ReferenceManyField>`
* Allows using another view (like a thumbnail list)

Cons:
* More verbose
* Longer to explain/understand

Before:

```html
export const PostList = (props) => (
    <List {...props} filter={PostFilter}>
        <TextField label="id" source="id" />
        <TextField label="title" source="title" />
        <DateField label="published_at" source="published_at" />
        <TextField label="average_note" source="average_note" />
        <TextField label="views" source="views" />
        <EditButton />
    </List>
);
```

After:

```html
export const PostList = (props) => (
    <List {...props} filter={PostFilter}>
        <Datagrid>
            <TextField label="id" source="id" />
            <TextField label="title" source="title" />
            <DateField label="published_at" source="published_at" />
            <TextField label="average_note" source="average_note" />
            <TextField label="views" source="views" />
            <EditButton />
        </Datagrid>
    </List>
);
```