### PR TITLE
Add support for navigation via browserHistory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
+build
 es6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-on-rest",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A frontend Framework for building admin applications on top of REST services, using ES6, React and Material UI",
   "files": [
     "*.md",
@@ -10,7 +10,9 @@
   ],
   "main": "lib/index",
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "build": "webpack",
+    "start": "babel src -d lib --ignore '*.spec.js'"
   },
   "authors": [
     "François Zaninotto"

--- a/src/CrudRoute.js
+++ b/src/CrudRoute.js
@@ -5,7 +5,7 @@ import { createRoutesFromReactChildren } from 'react-router/lib//RouteUtils';
 const CrudRoute = () => <div>&lt;CrudRoute&gt; elements are for configuration only and should not be rendered</div>;
 
 CrudRoute.createRouteFromReactElement = (element, parentRoute) => {
-    const { path, list, edit, create, remove, options } = element.props;
+    const { name, path, list, edit, create, remove, options } = element.props;
     // dynamically add crud routes
     const crudRoute = createRoutesFromReactChildren(
         <Route path={path}>
@@ -20,7 +20,7 @@ CrudRoute.createRouteFromReactElement = (element, parentRoute) => {
     crudRoute.component = ({ children }) => (
         <div>
             {React.Children.map(children, child => React.cloneElement(child, {
-                resource: path,
+                resource: name,
                 options,
                 hasList: !!list,
                 hasEdit: !!edit,

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -10,8 +10,8 @@ import Menu from './Menu';
 
 injectTapEventPlugin();
 
-const Layout = ({ isLoading, children, route, title }) => {
-    const Title = <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
+const Layout = ({ isLoading, children, route, title, basePath }) => {
+    const Title = <Link to={`/${basePath}`} style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
     const RightElement = isLoading ? <CircularProgress color="#fff" size={0.5} /> : <span />;
 
     return (
@@ -20,7 +20,7 @@ const Layout = ({ isLoading, children, route, title }) => {
                 <AppBar title={Title} iconElementRight={RightElement} />
                 <div className="body" style={{ display: 'flex', flex: '1', backgroundColor: '#edecec' }}>
                     <div style={{ flex: 1 }}>{children}</div>
-                    <Menu resources={route.resources} />
+                    <Menu resources={route.resources} basePath={basePath} />
                 </div>
                 <Notification />
             </div>
@@ -33,6 +33,7 @@ Layout.propTypes = {
     children: PropTypes.node,
     route: PropTypes.object.isRequired,
     title: PropTypes.string.isRequired,
+    basePath: PropTypes.string
 };
 
 function mapStateToProps(state) {

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -4,11 +4,11 @@ import Paper from 'material-ui/Paper';
 import { List, ListItem } from 'material-ui/List';
 import { Link } from 'react-router';
 
-const Menu = ({ resources }) => (
+const Menu = ({ resources, basePath }) => (
     <Paper style={{ flex: '0 0 15em', order: -1 }}>
         <List>
             {resources.map(resource =>
-                <ListItem key={resource.name} containerElement={<Link to={`/${resource.name}`} />} primaryText={resource.options.label || inflection.humanize(inflection.pluralize(resource.name))} leftIcon={<resource.icon />} />
+                <ListItem key={resource.name} containerElement={<Link to={basePath?`/${basePath}/${resource.name}`:`/${resource.name}`} />} primaryText={resource.options.label || inflection.humanize(inflection.pluralize(resource.name))} leftIcon={<resource.icon />} />
             )}
         </List>
     </Paper>
@@ -16,6 +16,7 @@ const Menu = ({ resources }) => (
 
 Menu.propTypes = {
     resources: PropTypes.array.isRequired,
+    basePath: PropTypes.string
 };
 
 export default Menu;

--- a/src/mui/layout/withAppTitle.js
+++ b/src/mui/layout/withAppTitle.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default title => LayoutComponent => props => (
-    <LayoutComponent title={title} {...props} />
-);

--- a/src/mui/layout/withProps.js
+++ b/src/mui/layout/withProps.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default additionalProps => LayoutComponent => props => (
+	<LayoutComponent {...additionalProps} {...props} />
+);

--- a/src/util/formatBasePath.js
+++ b/src/util/formatBasePath.js
@@ -1,0 +1,14 @@
+// finalBasePath will be a string (with no starting or ending forward slashes)
+const formatBasePath = basePath => {
+    // ensure basePath exists and is a string
+    if (typeof basePath !== 'string') return ''
+    // ensure basePath is not empty
+    if (!basePath.length) return ''
+    // ensure basePath does not start with a '/'
+    if (basePath.length == 1 && basePath.charAt(0) == '/') return ''
+    if (basePath.length > 1 && basePath.charAt(0) == '/') basePath = basePath.substring(1, basePath.length)
+    // ensure basePath does contain a trailing '/'
+    if (basePath.length > 1 && basePath.slice(-1) == '/') basePath = basePath.substring(0, basePath.length - 1)
+    return basePath
+}
+export default formatBasePath


### PR DESCRIPTION
Users can supply a history object to the Admin component, in order to support using React Router's browserHistory (to make things slightly prettier).

In this case, user's can also supply a basePath string value to the Admin object to use as a entry point to the admin-on-rest UI.

For example, my website is located at http://testwebsite.com. I've set the basePath value to 'admin', so that now I can access the primary client-facing site at http://testwebsite.com and perform administration activities at http://testwebsite.com/admin.
