### PR TITLE
Use mui drawer for menu

### DIFF
--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -10,23 +10,67 @@ import Menu from './Menu';
 
 injectTapEventPlugin();
 
-const Layout = ({ isLoading, children, route, title }) => {
-    const Title = <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
-    const RightElement = isLoading ? <CircularProgress color="#fff" size={0.5} /> : <span />;
+class Layout extends Component {
 
-    return (
-        <MuiThemeProvider>
-            <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-                <AppBar title={Title} iconElementRight={RightElement} />
-                <div className="body" style={{ display: 'flex', flex: '1', backgroundColor: '#edecec' }}>
-                    <div style={{ flex: 1 }}>{children}</div>
-                    <Menu resources={route.resources} />
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            menu: {
+                open: false,
+                selectedItem: 0,
+            },
+        };
+    }
+
+    toggleMenu = () => {
+        const open = this.state.menu.open;
+        this.setState({
+            menu: {
+                ...this.state.menu,
+                open: !open,
+            },
+        });
+    };
+
+    handleMenuRequestChange = (open) => {
+        this.setState({
+            menu: {
+                ...this.state.menu,
+                open,
+            },
+        });
+    };
+
+    handleMenuSelectionChange = (e, index) => {
+        this.setState({
+            menu: {
+                open: false,
+                selectedItem: index,
+            },
+        });
+    };
+
+    render() {
+        const { isLoading, children, route, title } = this.props;
+        const { menu: { open, selectedItem } } = this.state;
+        const Title = <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
+        const RightElement = isLoading ? <CircularProgress color="#fff" size={0.5} /> : <span />;
+
+        return (
+            <MuiThemeProvider>
+                <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+                    <AppBar title={Title} iconElementRight={RightElement} onLeftIconButtonTouchTap={this.toggleMenu} />
+                    <div className="body" style={{ flex: '1', backgroundColor: '#edecec' }}>
+                        <div>{children}</div>
+                        <Menu resources={route.resources} open={open} selectedItem={selectedItem} handleSelectionChange={this.handleMenuSelectionChange} handleRequestChange={this.handleMenuRequestChange} />
+                    </div>
+                    <Notification />
                 </div>
-                <Notification />
-            </div>
-        </MuiThemeProvider>
-    );
-};
+            </MuiThemeProvider>
+        );
+    }
+}
 
 Layout.propTypes = {
     isLoading: PropTypes.bool.isRequired,

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -1,21 +1,27 @@
 import React, { PropTypes } from 'react';
 import inflection from 'inflection';
-import Paper from 'material-ui/Paper';
-import { List, ListItem } from 'material-ui/List';
+import Drawer from 'material-ui/Drawer';
+import { List, ListItem, MakeSelectable } from 'material-ui/List';
 import { Link } from 'react-router';
 
-const Menu = ({ resources }) => (
-    <Paper style={{ flex: '0 0 15em', order: -1 }}>
-        <List>
-            {resources.map(resource =>
-                <ListItem key={resource.name} containerElement={<Link to={`/${resource.name}`} />} primaryText={resource.options.label || inflection.humanize(inflection.pluralize(resource.name))} leftIcon={<resource.icon />} />
+const SelectableList = MakeSelectable(List);
+
+const Menu = ({ resources, open = false, selectedItem, handleSelectionChange, handleRequestChange }) => (
+    <Drawer docked={false} open={open} onRequestChange={handleRequestChange}>
+        <SelectableList value={selectedItem} onChange={handleSelectionChange}>
+            {resources.map((resource, index) =>
+                <ListItem value={index} key={resource.name} containerElement={<Link to={`/${resource.name}`} />} primaryText={resource.options.label || inflection.humanize(inflection.pluralize(resource.name))} leftIcon={<resource.icon />} />
             )}
-        </List>
-    </Paper>
+        </SelectableList>
+    </Drawer>
 );
 
 Menu.propTypes = {
     resources: PropTypes.array.isRequired,
+    open: PropTypes.bool,
+    selectedItem: PropTypes.number.isRequired,
+    handleSelectionChange: PropTypes.func.isRequired,
+    handleRequestChange: PropTypes.func.isRequired,
 };
 
 export default Menu;


### PR DESCRIPTION
Replaces the menu with a drawer. I don't know if this is desired, but since you already have the hamburger menu button in the app bar (which does nothing at the moment), I thought it makes sense. Also gives more space to the actual content, see the screenshots below. When the drawer is open, it closes when you select an item, click anywhere outside of it or press ESC.

Drawer closed:
<img width="1277" alt="drawer_closed" src="https://cloud.githubusercontent.com/assets/9258694/18608269/0b53a160-7ce5-11e6-8635-61181bffb79f.png">

Drawer open:
<img width="1274" alt="drawer_open" src="https://cloud.githubusercontent.com/assets/9258694/18608268/0548a96e-7ce5-11e6-8e10-f7a67d5c1f4b.png">
