### PR TITLE
[RFR] Fix and speedup filters

### DIFF
--- a/src/mui/list/FilterForm.js
+++ b/src/mui/list/FilterForm.js
@@ -6,12 +6,13 @@ import ActionHide from 'material-ui/svg-icons/action/highlight-off';
 
 export class FilterForm extends Component {
     getShownFilters() {
-        const { filters, displayedFilters, currentFilters } = this.props;
+        const { filters, displayedFilters, currentFilters, initialValues } = this.props;
         return filters
             .filter(filterElement =>
                 filterElement.props.alwaysOn ||
                 displayedFilters[filterElement.props.source] ||
-                currentFilters[filterElement.props.source]
+                currentFilters[filterElement.props.source] ||
+                initialValues[filterElement.props.source]
             );
     }
 
@@ -50,6 +51,7 @@ FilterForm.propTypes = {
     filters: PropTypes.arrayOf(PropTypes.node).isRequired,
     displayedFilters: PropTypes.object.isRequired,
     hideFilter: PropTypes.func.isRequired,
+    initialValues: PropTypes.object,
 };
 
 FilterForm.defaultProps = {

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -55,6 +55,11 @@ export class List extends Component {
         return this.props.location.pathname;
     }
 
+    refresh = (event) => {
+        event.stopPropagation();
+        this.updateData();
+    }
+
     getQuery() {
         return (Object.keys(this.props.query).length > 0) ? this.props.query : { ...this.props.params };
     }
@@ -67,11 +72,6 @@ export class List extends Component {
     updateSort = (event) => {
         event.stopPropagation();
         this.changeParams({ type: SET_SORT, payload: event.currentTarget.dataset.sort });
-    }
-
-    refresh = (event) => {
-        event.stopPropagation();
-        this.updateData();
     }
 
     setPage = (page) => this.changeParams({ type: SET_PAGE, payload: page });

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -37,6 +37,7 @@ export class List extends Component {
             const nextFilters = nextProps.filters;
             Object.keys(nextFilters).forEach(filterName => {
                 if (nextFilters[filterName] === '') {
+                    // remove empty filter from query
                     delete nextFilters[filterName];
                 }
             });

--- a/src/reducer/resource/list/queryReducer.js
+++ b/src/reducer/resource/list/queryReducer.js
@@ -33,19 +33,7 @@ export default (previousState, { type, payload }) => {
         return { ...previousState, page: payload };
 
     case SET_FILTER: {
-        const filter = { ...previousState.filter };
-
-        if (typeof payload.value === 'undefined' || payload.value.length === 0) {
-            delete filter[payload.field];
-        } else {
-            filter[payload.field] = payload.value;
-        }
-
-        return {
-            ...previousState,
-            page: 1,
-            filter,
-        };
+        return { ...previousState, page: 1, filter: payload };
     }
 
     default:

--- a/src/reducer/resource/list/queryReducer.spec.js
+++ b/src/reducer/resource/list/queryReducer.spec.js
@@ -6,12 +6,8 @@ describe('Query Reducer', () => {
         it('should add new filter with given value when set', () => {
             const updatedState = queryReducer({}, {
                 type: 'SET_FILTER',
-                payload: {
-                    field: 'title',
-                    value: 'foo',
-                },
+                payload: { title: 'foo' },
             });
-
             assert.deepEqual(updatedState.filter, { title: 'foo' });
         });
 
@@ -22,45 +18,10 @@ describe('Query Reducer', () => {
                 },
             }, {
                 type: 'SET_FILTER',
-                payload: {
-                    field: 'title',
-                    value: 'bar',
-                },
+                payload: { title: 'bar' },
             });
 
             assert.deepEqual(updatedState.filter, { title: 'bar' });
-        });
-
-        it('should remove existing filter if value is empty', () => {
-            const updatedState = queryReducer({
-                filter: {
-                    title: '',
-                },
-            }, {
-                type: 'SET_FILTER',
-                payload: {
-                    field: 'title',
-                    value: '',
-                },
-            });
-
-            assert.deepEqual(updatedState.filter, {});
-        });
-
-        it('should remove existing filter if value is undefined', () => {
-            const updatedState = queryReducer({
-                filter: {
-                    title: 'foo',
-                },
-            }, {
-                type: 'SET_FILTER',
-                payload: {
-                    field: 'title',
-                    value: undefined,
-                },
-            });
-
-            assert.deepEqual(updatedState.filter, {});
         });
 
         it('should reset page to 1', () => {

--- a/src/sideEffect/saga/crudFetch.js
+++ b/src/sideEffect/saga/crudFetch.js
@@ -34,11 +34,11 @@ const crudFetch = (restClient, successSideEffects = () => [], failureSideEffects
             }
         }
         const sideEffects = successSideEffects(type, meta.resource, payload, response);
-        yield put({ type: FETCH_END });
         yield [
             ...sideEffects.map(a => put(a)),
             put({ type: `${type}_SUCCESS`, payload: response, meta }),
         ];
+        yield put({ type: FETCH_END });
     }
 
     return function *watchCrudFetch() {


### PR DESCRIPTION
- [x] Dispatch only one action when filters are updated (and not one per filter)
- [x] Correctly handle filter persistence (filters are preserved during navigation)
- [x] Correctly handle filter removal
- [x] Avoid many List rerenders

There is one weird bug remaining, linked to redux-form: sometimes, when emptying a filter form, the list doesn't refresh. I've traced that down to the call to `getFormValues('filterForm')(state)` returning undefined in some cases (?), therefore defaulting to the previous filter value. To be treated in a future PR.