### PR TITLE
Crud improvement for Authentication

### DIFF
--- a/src/CrudRoute.js
+++ b/src/CrudRoute.js
@@ -5,14 +5,14 @@ import { createRoutesFromReactChildren } from 'react-router/lib/RouteUtils';
 const CrudRoute = () => <div>&lt;CrudRoute&gt; elements are for configuration only and should not be rendered</div>;
 
 CrudRoute.createRouteFromReactElement = (element, parentRoute) => {
-    const { path, list, edit, create, remove, options } = element.props;
+    const { path, list, edit, create, remove, options ,onEnter, onLeave } = element.props;
     // dynamically add crud routes
     const crudRoute = createRoutesFromReactChildren(
         <Route path={path}>
-            {list ? <IndexRoute component={list} /> : null}
-            {create ? <Route path="create" component={create} /> : null}
-            {edit ? <Route path=":id" component={edit} /> : null}
-            {remove ? <Route path=":id/delete" component={remove} /> : null}
+            {list ? <IndexRoute component={list} onEnter={onEnter} onLeave={onLeave} /> : null}
+            {create ? <Route path="create" component={create} onEnter={onEnter} onLeave={onLeave} /> : null}
+            {edit ? <Route path=":id" component={edit} onEnter={onEnter} onLeave={onLeave} /> : null}
+            {remove ? <Route path=":id/delete" component={remove} onEnter={onEnter} onLeave={onLeave} /> : null}
         </Route>,
         parentRoute
     )[0];

--- a/src/mui/field/ReferenceManyField.js
+++ b/src/mui/field/ReferenceManyField.js
@@ -50,7 +50,7 @@ export class ReferenceManyField extends Component {
         const referenceBasePath = basePath.replace(resource, reference); // FIXME obviously very weak
         return React.cloneElement(children, {
             resource: reference,
-            ids: Object.keys(referenceRecords).map(id => parseInt(id, 10)),
+            ids: Object.keys(referenceRecords),
             data: referenceRecords,
             basePath: referenceBasePath,
             currentSort: {},

--- a/src/mui/field/ReferenceManyField.spec.js
+++ b/src/mui/field/ReferenceManyField.spec.js
@@ -77,4 +77,32 @@ describe('<ReferenceManyField />', () => {
         assert.deepEqual(SingleFieldListElement.at(0).prop('data'), {});
         assert.deepEqual(SingleFieldListElement.at(0).prop('ids'), []);
     });
+
+    it('should support record with string identifier', () => {
+        const referenceRecords = {
+            "abc-1": { id: "abc-1", title: 'hello' },
+            "abc-2": { id: "abc-2", title: 'world' },
+        };
+        const wrapper = shallow(
+            <ReferenceManyField
+                resource="foo"
+                reference="bar"
+                target="foo_id"
+                basePath=""
+                referenceRecords={referenceRecords}
+                crudGetManyReference={() => {}}
+            >
+                <SingleFieldList>
+                    <TextField source="title" />
+                </SingleFieldList>
+            </ReferenceManyField>
+        );
+        const ProgressElements = wrapper.find('LinearProgress');
+        assert.equal(ProgressElements.length, 0);
+        const SingleFieldListElement = wrapper.find('SingleFieldList');
+        assert.equal(SingleFieldListElement.length, 1);
+        assert.equal(SingleFieldListElement.at(0).prop('resource'), 'bar');
+        assert.deepEqual(SingleFieldListElement.at(0).prop('data'), referenceRecords);
+        assert.deepEqual(SingleFieldListElement.at(0).prop('ids'), ["abc-1", "abc-2"]);
+    });
 });

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -37,7 +37,7 @@ const Datagrid = ({ resource, children, ids, data, currentSort, basePath, select
 );
 
 Datagrid.propTypes = {
-    ids: PropTypes.arrayOf(PropTypes.number).isRequired,
+    ids: PropTypes.arrayOf(PropTypes.any).isRequired,
     resource: PropTypes.string,
     selectable: PropTypes.bool,
     data: PropTypes.object.isRequired,


### PR DESCRIPTION
Following the #66 question, I'm proposing to expose onEnter and onLeave property from the React-Router in the CrudRoute component so that we can leverage them  for authentication as shown in the auth0 tutorial 

[https://auth0.com/docs/quickstart/spa/react/01-login](url)
