### PR TITLE
[RFR] Remove required props warnings

### DIFF
--- a/src/mui/field/ReferenceManyField.js
+++ b/src/mui/field/ReferenceManyField.js
@@ -68,11 +68,8 @@ ReferenceManyField.propTypes = {
     reference: PropTypes.string.isRequired,
     referenceRecords: PropTypes.object,
     resource: PropTypes.string.isRequired,
+    source: PropTypes.string.isRequired,
     target: PropTypes.string.isRequired,
-};
-
-ReferenceManyField.defaultProps = {
-    includesLabel: false,
 };
 
 function mapStateToProps(state, props) {
@@ -82,6 +79,13 @@ function mapStateToProps(state, props) {
     };
 }
 
-export default connect(mapStateToProps, {
+const ConnectedReferenceManyField = connect(mapStateToProps, {
     crudGetManyReference: crudGetManyReferenceAction,
 })(ReferenceManyField);
+
+ConnectedReferenceManyField.defaultProps = {
+    includesLabel: false,
+    source: '',
+};
+
+export default ConnectedReferenceManyField;

--- a/src/mui/input/Labeled.js
+++ b/src/mui/input/Labeled.js
@@ -30,7 +30,7 @@ Labeled.propTypes = {
     basePath: PropTypes.string,
     children: PropTypes.element,
     input: PropTypes.object,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.string,
     onChange: PropTypes.func,
     record: PropTypes.object,
     resource: PropTypes.string,

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -57,7 +57,7 @@ SelectInput.propTypes = {
     options: PropTypes.object,
     optionText: PropTypes.string.isRequired,
     optionValue: PropTypes.string.isRequired,
-    source: PropTypes.string.isRequired,
+    source: PropTypes.string,
 };
 
 SelectInput.defaultProps = {


### PR DESCRIPTION
React checks the presence of required props before render. Since we
clone some components and pass them the required props at render time,
this creates alerts while there shouldn't be. The solution is to remove
the requirements in PropTypes.