### PR TITLE
[RFR] Move quill as dependency

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -184,12 +184,6 @@ import { RichTextInput } from 'admin-on-rest/mui';
 
 ![RichTextInput](./img/rich-text-input.png)
 
-*Tip*: `quill` is only specified as a peer dependency in the `package.json`. If you want to use the `<RichTextInput>` component in your app, you'll have to add `quill` to your app:
-
-```sh
-npm install --save-dev quill
-```
-
 You can customize the rich text editor toolbar using the `toolbar` attribute, as described on the [Quill official toolbar documentation](https://quilljs.com/docs/modules/toolbar/).
 
 ```js

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-      "quill": "^1.0.4"
   },
   "devDependencies": {
     "babel-plugin-transform-react-jsx": "^6.8.0",

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -17,7 +17,6 @@ module.exports = {
     resolve: {
         alias: {
             'admin-on-rest': path.join(__dirname, '..', 'src'),
-            quill: path.join(__dirname, 'node_modules/quill'),
         },
     },
 };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.0.8",
     "material-ui": "~0.15.4",
+    "quill": "^1.0.4",
     "react": "~15.3.1",
     "react-dom": "~15.3.1",
     "react-redux": "~4.4.5",
@@ -64,8 +65,5 @@
     "redux": "~3.6.0",
     "redux-form": "^6.0.5",
     "redux-saga": "~0.11.1"
-  },
-  "peerDependencies": {
-    "quill": "^1.0.4"
   }
 }


### PR DESCRIPTION
Using `peerDependencies` is too much hassle for the user, and the number of admins *without* rich text editing is probably not worth it. Let's move `quill` to `dependencies`.

Closes #89 
Supersedes #90 