### PR TITLE
[RFR] Fix Pagination when list has no filter

### DIFF
--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -1,41 +1,51 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import FlatButton from 'material-ui/FlatButton';
 import ContentSort from 'material-ui/svg-icons/content/sort';
 import title from '../../util/title';
 
-const Datagrid = ({ resource, children, ids, data, currentSort, basePath, selectable, updateSort }) => (
-    <Table multiSelectable={selectable}>
-        <TableHeader adjustForCheckbox={selectable} displaySelectAll={selectable}>
-            <TableRow>
-                {React.Children.toArray(children).map(field => (
-                    <TableHeaderColumn key={field.props.label || 'no-key'}>
-                        {(field.props.label || field.props.source) &&
-                            <FlatButton
-                                labelPosition="before"
-                                onClick={updateSort}
-                                data-sort={field.props.source}
-                                label={title(field.props.label, field.props.source)}
-                                icon={field.props.source === currentSort.sort ? <ContentSort style={currentSort.order === 'ASC' ? { transform: 'rotate(180deg)' } : {}} /> : false}
-                            />
-                        }
-                    </TableHeaderColumn>
-                ))}
-            </TableRow>
-        </TableHeader>
-        <TableBody showRowHover displayRowCheckbox={selectable}>
-            {ids.map(id => (
-                <TableRow key={id}>
-                    {React.Children.toArray(children).map(field => (
-                        <TableRowColumn key={`${id}-${field.props.source}`}>
-                            <field.type {...field.props} record={data[id]} basePath={basePath} resource={resource} />
-                        </TableRowColumn>
+class Datagrid extends Component {
+    updateSort = (event) => {
+        event.stopPropagation();
+        this.props.setSort(event.currentTarget.dataset.sort);
+    }
+
+    render() {
+        const { resource, children, ids, data, currentSort, basePath, selectable, updateSort } = this.props;
+        return (
+            <Table multiSelectable={selectable}>
+                <TableHeader adjustForCheckbox={selectable} displaySelectAll={selectable}>
+                    <TableRow>
+                        {React.Children.toArray(children).map(field => (
+                            <TableHeaderColumn key={field.props.label || 'no-key'}>
+                                {(field.props.label || field.props.source) &&
+                                    <FlatButton
+                                        labelPosition="before"
+                                        onClick={this.updateSort}
+                                        data-sort={field.props.source}
+                                        label={title(field.props.label, field.props.source)}
+                                        icon={field.props.source === currentSort.sort ? <ContentSort style={currentSort.order === 'ASC' ? { transform: 'rotate(180deg)' } : {}} /> : false}
+                                    />
+                                }
+                            </TableHeaderColumn>
+                        ))}
+                    </TableRow>
+                </TableHeader>
+                <TableBody showRowHover displayRowCheckbox={selectable}>
+                    {ids.map(id => (
+                        <TableRow key={id}>
+                            {React.Children.toArray(children).map(field => (
+                                <TableRowColumn key={`${id}-${field.props.source}`}>
+                                    <field.type {...field.props} record={data[id]} basePath={basePath} resource={resource} />
+                                </TableRowColumn>
+                            ))}
+                        </TableRow>
                     ))}
-                </TableRow>
-            ))}
-        </TableBody>
-    </Table>
-);
+                </TableBody>
+            </Table>
+        );
+    }
+}
 
 Datagrid.propTypes = {
     ids: PropTypes.arrayOf(PropTypes.any).isRequired,
@@ -47,7 +57,7 @@ Datagrid.propTypes = {
         order: PropTypes.string,
     }),
     basePath: PropTypes.string,
-    updateSort: PropTypes.func,
+    setSort: PropTypes.func,
 };
 
 Datagrid.defaultProps = {

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -72,20 +72,13 @@ export class List extends Component {
         this.props.crudGetList(this.props.resource, { page, perPage }, { field: sort, order }, filter);
     }
 
-    updateSort = (event) => {
-        event.stopPropagation();
-        this.changeParams({ type: SET_SORT, payload: event.currentTarget.dataset.sort });
-    }
+    setSort = sort => this.changeParams({ type: SET_SORT, payload: sort });
 
-    setPage = (page) => this.changeParams({ type: SET_PAGE, payload: page });
+    setPage = page => this.changeParams({ type: SET_PAGE, payload: page });
 
-    setFilters = (filters) => {
-        this.changeParams({ type: SET_FILTER, payload: filters });
-    }
+    setFilters = filters => this.changeParams({ type: SET_FILTER, payload: filters });
 
-    showFilter = (filterName) => {
-        this.setState({ [filterName]: true });
-    };
+    showFilter = filterName => this.setState({ [filterName]: true });
 
     hideFilter = (filterName) => {
         this.setState({ [filterName]: false });
@@ -131,7 +124,7 @@ export class List extends Component {
                     data,
                     currentSort: query,
                     basePath,
-                    updateSort: this.updateSort,
+                    setSort: this.setSort,
                 })}
                 <Pagination resource={resource} page={parseInt(query.page, 10)} perPage={parseInt(query.perPage, 10)} total={total} setPage={this.setPage} />
             </Card>

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -165,7 +165,9 @@ function mapStateToProps(state, props) {
     const resourceState = state.admin[props.resource];
     const query = props.location.query;
     if (query.filter && typeof query.filter === 'string') {
-        query.filter = JSON.parse(query.filter);
+        // if the List has no filter component, the filter is always "{}"
+        // avoid deserialization and keep identity by using a constant
+        query.filter = props.filter ? JSON.parse(query.filter) : resourceState.list.params.filter;
     }
 
     return {

--- a/src/reducer/resource/list/queryReducer.spec.js
+++ b/src/reducer/resource/list/queryReducer.spec.js
@@ -2,6 +2,28 @@ import assert from 'assert';
 import queryReducer from './queryReducer';
 
 describe('Query Reducer', () => {
+    describe('SET_PAGE action', () => {
+        it('should update the page', () => {
+            const updatedState = queryReducer({
+                page: 1,
+            }, {
+                type: 'SET_PAGE',
+                payload: 2,
+            });
+            assert.equal(updatedState.page, 2);
+        });
+        it('should not update the filter', () => {
+            const initialFilter = {};
+            const updatedState = queryReducer({
+                filter: initialFilter,
+                page: 1,
+            }, {
+                type: 'SET_PAGE',
+                payload: 2,
+            });
+            assert.equal(updatedState.filter, initialFilter);
+        });
+    });
     describe('SET_FILTER action', () => {
         it('should add new filter with given value when set', () => {
             const updatedState = queryReducer({}, {


### PR DESCRIPTION
   The filter equality test in componentWillReceiveProps() failed when
   there was no filter attribute passed to the List component because then
   the filter value was taken from the URL instead of the filter form. In
   that case, the filter value is always "{}", but deserializing it leads
   to a new object every time, forcing a setFilter() which resets the page.

Closes #103