### PR TITLE
[RFR] Real table

### DIFF
--- a/example/posts.js
+++ b/example/posts.js
@@ -30,7 +30,7 @@ export const PostList = (props) => (
     <List {...props} filter={PostFilter}>
         <Datagrid>
             <TextField source="id" />
-            <TextField source="title" type="email" style={{ display: 'inline-block', maxWidth: '15em', overflow: 'hidden', textOverflow: 'ellipsis' }}/>
+            <TextField source="title" type="email" style={{ display: 'inline-block', maxWidth: '20em', overflow: 'hidden', textOverflow: 'ellipsis' }}/>
             <DateField source="published_at" style={{ fontStyle: 'italic' }} />
             <TextField source="average_note" />
             <TextField source="views" />

--- a/example/posts.js
+++ b/example/posts.js
@@ -30,8 +30,7 @@ export const PostList = (props) => (
     <List {...props} filter={PostFilter}>
         <Datagrid>
             <TextField source="id" />
-            <TextField source="title" type="email" />
-            <RichTextField source="body" stripTags={true} />
+            <TextField source="title" type="email" style={{ display: 'inline-block', maxWidth: '15em', overflow: 'hidden', textOverflow: 'ellipsis' }}/>
             <DateField source="published_at" style={{ fontStyle: 'italic' }} />
             <TextField source="average_note" />
             <TextField source="views" />
@@ -81,7 +80,7 @@ export const PostEdit = (props) => (
         <DateInput label="Publication date" source="published_at" />
         <TextInput source="average_note" validation={{ min: 0 }} />
         <ReferenceManyField label="Comments" reference="comments" target="post_id">
-            <Datagrid selectable={false}>
+            <Datagrid>
                 <TextField source="body" />
                 <DateField source="created_at" />
                 <EditButton />

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -11,13 +11,13 @@ class Datagrid extends Component {
     }
 
     render() {
-        const { resource, children, ids, data, currentSort, basePath, selectable, updateSort } = this.props;
+        const { resource, children, ids, data, currentSort, basePath, updateSort } = this.props;
         return (
-            <Table multiSelectable={selectable}>
-                <TableHeader adjustForCheckbox={selectable} displaySelectAll={selectable}>
-                    <TableRow>
+            <table>
+                <thead>
+                    <tr>
                         {React.Children.toArray(children).map(field => (
-                            <TableHeaderColumn key={field.props.label || 'no-key'}>
+                            <TableHeaderColumn key={field.props.label || field.props.source || 'no-key'}>
                                 {(field.props.label || field.props.source) &&
                                     <FlatButton
                                         labelPosition="before"
@@ -29,20 +29,20 @@ class Datagrid extends Component {
                                 }
                             </TableHeaderColumn>
                         ))}
-                    </TableRow>
-                </TableHeader>
-                <TableBody showRowHover displayRowCheckbox={selectable}>
+                    </tr>
+                </thead>
+                <tbody>
                     {ids.map(id => (
-                        <TableRow key={id}>
+                        <tr key={id}>
                             {React.Children.toArray(children).map(field => (
                                 <TableRowColumn key={`${id}-${field.props.source}`}>
                                     <field.type {...field.props} record={data[id]} basePath={basePath} resource={resource} />
                                 </TableRowColumn>
                             ))}
-                        </TableRow>
+                        </tr>
                     ))}
-                </TableBody>
-            </Table>
+                </tbody>
+            </table>
         );
     }
 }
@@ -50,7 +50,6 @@ class Datagrid extends Component {
 Datagrid.propTypes = {
     ids: PropTypes.arrayOf(PropTypes.any).isRequired,
     resource: PropTypes.string,
-    selectable: PropTypes.bool,
     data: PropTypes.object.isRequired,
     currentSort: PropTypes.shape({
         sort: PropTypes.string,
@@ -63,7 +62,6 @@ Datagrid.propTypes = {
 Datagrid.defaultProps = {
     data: {},
     ids: [],
-    selectable: true,
 };
 
 export default Datagrid;

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -34,8 +34,8 @@ class Datagrid extends Component {
             <table style={styles.table}>
                 <thead>
                     <tr style={styles.tr}>
-                        {React.Children.toArray(children).map(field => (
-                            <TableHeaderColumn key={field.props.label || field.props.source || 'no-key'}>
+                        {React.Children.map(children, (field, index) => (
+                            <TableHeaderColumn key={field.props.label || field.props.source || index}>
                                 {(field.props.label || field.props.source) &&
                                     <FlatButton
                                         labelPosition="before"

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -1,8 +1,26 @@
 import React, { Component, PropTypes } from 'react';
-import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
+import { TableHeaderColumn, TableRowColumn } from 'material-ui/Table';
 import FlatButton from 'material-ui/FlatButton';
 import ContentSort from 'material-ui/svg-icons/content/sort';
 import title from '../../util/title';
+
+const styles = {
+    table: {
+        backgroundColor: '#fff',
+        padding: '0px 24px',
+        width: '100%',
+        borderCollapse: 'collapse',
+        borderSpacing: 0,
+    },
+    tbody: {
+        height: 'inherit',
+    },
+    tr: {
+        borderBottom: '1px solid rgb(224, 224, 224)',
+        color: 'rgba(0, 0, 0, 0.870588)',
+        height: 48,
+    },
+};
 
 class Datagrid extends Component {
     updateSort = (event) => {
@@ -13,9 +31,9 @@ class Datagrid extends Component {
     render() {
         const { resource, children, ids, data, currentSort, basePath, updateSort } = this.props;
         return (
-            <table>
+            <table style={styles.table}>
                 <thead>
-                    <tr>
+                    <tr style={styles.tr}>
                         {React.Children.toArray(children).map(field => (
                             <TableHeaderColumn key={field.props.label || field.props.source || 'no-key'}>
                                 {(field.props.label || field.props.source) &&
@@ -31,9 +49,9 @@ class Datagrid extends Component {
                         ))}
                     </tr>
                 </thead>
-                <tbody>
+                <tbody style={styles.tbody}>
                     {ids.map(id => (
-                        <tr key={id}>
+                        <tr style={styles.tr} key={id}>
                             {React.Children.toArray(children).map(field => (
                                 <TableRowColumn key={`${id}-${field.props.source}`}>
                                     <field.type {...field.props} record={data[id]} basePath={basePath} resource={resource} />


### PR DESCRIPTION
Replace Material UI's `<Table>` component with a native table, to let the browser compute column dimensions based on content.

Before: 

![image](https://cloud.githubusercontent.com/assets/99944/19964229/e15850ee-a1c0-11e6-95c3-20728dc37ee1.png)

After: 

![image](https://cloud.githubusercontent.com/assets/99944/19964220/ce5b95f0-a1c0-11e6-9e91-a84084ddad01.png)
