### PR TITLE
add headers to options

### DIFF
--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,6 +1,7 @@
 export const fetchJson = (url, options = {}) => {
     const requestHeaders = new Headers({
         Accept: 'application/json',
+        ...options.headers
     });
     if (!(options && options.body && options.body instanceof FormData)) {
         requestHeaders.set('Content-Type', 'application/json');


### PR DESCRIPTION
I know it's possible to overwrite the entire `restClient` promise as stated in documentation, but this PR hopes to make customizing the rest client simpler: allow to pass in headers as part of the options. It happens that in my rest client uses other headers for authorization, and others might find it useful to send other headers without overwriting the entire `fetch.js`. 