### PR TITLE
[RR] Add ability to intercept HTTP request and add custom headers

### DIFF
--- a/docs/RestClients.md
+++ b/docs/RestClients.md
@@ -99,6 +99,49 @@ const App = () => (
 export default App;
 ```
 
+### Adding Custom Headers
+
+Both the `simpleRestClient` and the `jsonServerRestClient` functions accept an http client function as second argument. By default, they use admin-on-rest's `fetchUtils.fetchJson()` as http client. It's similar to HTML5 `fetch()`, except it handles JSON decoding and HTTP error codes automatically.
+
+That means that if you need to add custom headers to your requests, you just need to *wrap* the `fetchJson()` call inside your own function:
+
+```js
+import { simpleRestClient, fetchUtils, Admin, Resource } from 'admin-on-rest';
+const httpClient = (url, options) => {
+    if (!options.headers) {
+        options.headers = new Headers({ Accept: 'application/json' });
+    }
+    // add your own headers here
+    options.headers.set('X-Custom-Header', 'foobar');
+    return fetchUtils.fetchJson(url, options);
+}
+const restClient = simpleRestClient('http://localhost:3000', httpClient);
+
+render(
+    <Admin restClient={restClient} title="Example Admin">
+       ...
+    </Admin>,
+    document.getElementById('root')
+);
+```
+
+Now all the requests to the REST API will contain the `X-Custom-Header: foobar` header.
+
+**Tip**: The most common usage of custom headers is for authentication. `fetchJson` has built-on support for the `Authorization` token header:
+
+```js
+const httpClient = (url, options) => {
+    options.user = {
+        authenticated: true,
+        token: 'SRTRDFVESGNJYTUKTYTHRG'
+    }
+    return fetchUtils.fetchJson(url, options);
+}
+```
+
+Now all the requests to the REST API will contain the `Authorization: SRTRDFVESGNJYTUKTYTHRG` header.
+
+
 ## Writing your own REST client
 
 Quite often, none of the the core REST clients match your API exactly. In such cases, you'll have to write your own REST client. But don't be afraid, it's easy!

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -77,6 +77,9 @@
                                     <a href="#jsonserver-rest">JSON Server REST</a>
                                 </li>
                                 <li class="chapter">
+                                    <a href="#adding-custom-headers">Adding Custom Headers</a>
+                                </li>
+                                <li class="chapter">
                                     <a href="#writing-your-own-rest-client">Writing your own REST client</a>
                                 </li>
                             </ul>

--- a/src/rest/jsonServer.js
+++ b/src/rest/jsonServer.js
@@ -23,7 +23,7 @@ import {
  * CREATE       => POST http://my.api.url/posts/123
  * DELETE       => DELETE http://my.api.url/posts/123
  */
-export default (apiUrl) => {
+export default (apiUrl, httpClient = fetchJson) => {
     /**
      * @param {String} type One of the constants appearing at the top if this file, e.g. 'UPDATE'
      * @param {String} resource Name of the resource to fetch, e.g. 'posts'
@@ -112,7 +112,7 @@ export default (apiUrl) => {
                 .then(responses => responses.map(response => response.json));
         }
         const { url, options } = convertRESTRequestToHTTP(type, resource, params);
-        return fetchJson(url, options)
+        return httpClient(url, options)
             .then(response => convertHTTPResponseToREST(response, type, resource, params));
     };
 };

--- a/src/rest/simple.js
+++ b/src/rest/simple.js
@@ -24,7 +24,7 @@ import {
  * CREATE       => POST http://my.api.url/posts/123
  * DELETE       => DELETE http://my.api.url/posts/123
  */
-export default (apiUrl) => {
+export default (apiUrl, httpClient = fetchJson) => {
     /**
      * @param {String} type One of the constants appearing at the top if this file, e.g. 'UPDATE'
      * @param {String} resource Name of the resource to fetch, e.g. 'posts'
@@ -120,7 +120,7 @@ export default (apiUrl) => {
      */
     return (type, resource, params) => {
         const { url, options } = convertRESTRequestToHTTP(type, resource, params);
-        return fetchJson(url, options)
+        return httpClient(url, options)
             .then(response => convertHTTPResponseToREST(response, type, resource, params));
     };
 };

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,15 +1,15 @@
 export const fetchJson = (url, options = {}) => {
-    const requestHeaders = new Headers({
+    const requestHeaders = options.headers || new Headers({
         Accept: 'application/json',
     });
     if (!(options && options.body && options.body instanceof FormData)) {
         requestHeaders.set('Content-Type', 'application/json');
     }
-    if (options.user && options.user.authenticated && options.user.authenticated) {
+    if (options.user && options.user.authenticated && options.user.token) {
         requestHeaders.set('Authorization', options.user.token);
     }
 
-    return fetch(url, { ...options, headers: requestHeaders, credentials: 'include' })
+    return fetch(url, { ...options, headers: requestHeaders })
         .then(response => response.text().then(text => ({
             status: response.status,
             statusText: response.statusText,


### PR DESCRIPTION
Closes #127

Both the `simpleRestClient` and the `jsonServerRestClient` functions now accept an http client function as second argument. By default, they use admin-on-rest's `fetchUtils.fetchJson()` as http client. It's similar to HTML5 `fetch()`, except it handles JSON decoding and HTTP error codes automatically.

That means that if you need to add custom headers to your requests, you just need to *wrap* the `fetchJson()` call inside your own function:

```js
import { simpleRestClient, fetchUtils, Admin, Resource } from 'admin-on-rest';
const httpClient = (url, options) => {
    if (!options.headers) {
        options.headers = new Headers({ Accept: 'application/json' });
    }
    // add your own headers here
    options.headers.set('X-Custom-Header', 'foobar');
    return fetchUtils.fetchJson(url, options);
}
const restClient = simpleRestClient('http://localhost:3000', httpClient);

render(
    <Admin restClient={restClient} title="Example Admin">
       ...
    </Admin>,
    document.getElementById('root')
);
```

Now all the requests to the REST API will contain the `X-Custom-Header: foobar` header.

**Tip**: The most common usage of custom headers is for authentication. `fetchJson` has built-on support for the `Authorization` token header:

```js
const httpClient = (url, options) => {
    options.user = {
        authenticated: true,
        token: 'SRTRDFVESGNJYTUKTYTHRG'
    }
    return fetchUtils.fetchJson(url, options);
}
```

Now all the requests to the REST API will contain the `Authorization: SRTRDFVESGNJYTUKTYTHRG` header.
