### PR TITLE
[RFR] Adding optionValue as key for MenuItem iteration.

### DIFF
--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -46,7 +46,7 @@ class SelectInput extends Component {
                     <MenuItem value={null} primaryText="" />
                 }
                 {choices.map(choice =>
-                    <MenuItem key={choice[optionText]} primaryText={choice[optionText]} value={choice[optionValue]} />
+                    <MenuItem key={choice[optionValue]} primaryText={choice[optionText]} value={choice[optionValue]} />
                 )}
             </SelectField>
         );


### PR DESCRIPTION
This PR is a proposal to use optionValue as key for the iteration of choices in the SelectInput UI component. Since this UI element is also used for Foreign Key selection it is not guaranteed that the `optionText` is different which will lead to a duplicate key error in React. Since `optionValue` is already used in the comments for containing a unique id value it would be a better choice for the `key`