### PR TITLE
Update react-tap-event-plugin to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-redux": "~4.4.5",
     "react-router": "~2.8.1",
     "react-router-redux": "~4.0.6",
-    "react-tap-event-plugin": "~1.0.0",
+    "react-tap-event-plugin": "~2.0.0",
     "redux": "~3.6.0",
     "redux-form": "~6.1.0",
     "redux-saga": "~0.12.0"


### PR DESCRIPTION
... to fix React 15.4.0 compatibility). 

[react-v15.4.0](https://facebook.github.io/react/blog/2016/11/16/react-v15.4.0.html) broke `react-tap-event-plugin@v1`, which got updated to 2.0.1. just now at https://github.com/zilverline/react-tap-event-plugin/pull/82. See the change set here: https://github.com/zilverline/react-tap-event-plugin/pull/82/files. It only changes the paths to `react-dom`.

https://www.npmjs.com/package/react-tap-event-plugin