### PR TITLE
Revert "Update react-tap-event-plugin to 2.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-redux": "~4.4.5",
     "react-router": "~2.8.1",
     "react-router-redux": "~4.0.6",
-    "react-tap-event-plugin": "~2.0.0",
+    "react-tap-event-plugin": "~1.0.0",
     "redux": "~3.6.0",
     "redux-form": "~6.1.0",
     "redux-saga": "~0.12.0"


### PR DESCRIPTION
Reverts marmelab/admin-on-rest#153

The npm install warns against semver incompatibilities:

```
npm WARN react-tap-event-plugin@2.0.1 requires a peer of react@^15.4.0-0 but none was installed.
npm WARN react-tap-event-plugin@2.0.1 requires a peer of react-dom@^15.4.0-0 but none was installed.
npm WARN react-addons-create-fragment@15.4.0 requires a peer of react@^15.4.0 but none was installed.
npm WARN react-addons-transition-group@15.4.0 requires a peer of react@^15.4.0 but none was installed.
npm WARN react-addons-shallow-compare@15.4.0 requires a peer of react@^15.4.0 but none was installed.
npm WARN eslint-config-airbnb@12.0.0 requires a peer of eslint-plugin-import@^1.16.0 but none was installed.
npm WARN eslint-config-airbnb-base@8.0.0 requires a peer of eslint-plugin-import@^1.16.0 but none was installed.
```

We can't update react-tap-event-plugin without updating react as well.