### PR TITLE
Update quill version to fix yarn engine `node` incompatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash.debounce": "~4.0.8",
     "lodash.get": "~4.4.2",
     "material-ui": "0.16.1",
-    "quill": "~1.0.4",
+    "quill": "~1.1.5",
     "react": "~15.3.2",
     "react-dom": "~15.3.2",
     "react-redux": "~4.4.5",


### PR DESCRIPTION
When we install `admin-on-rest` with yarn, we're currently facing with this error:
```
error parchment@1.0.1: The engine "node" is incompatible with this module. Expected version "^5.3".
error Found incompatible module
```
The root cause comes from the dependency `quill`. Now, this issue was fixed as mentioned [here](https://github.com/quilljs/quill/issues/1041) and [here](https://github.com/yarnpkg/yarn/issues/812#issuecomment-253190930) as well as released in the latest version of `quill`.

Please consider upgrading the dependency `quill` to latest version `1.1.5`.