### PR TITLE
[RFR] Datagrid cells default to white-space: normal instead of nowrap

### DIFF
--- a/example/posts.js
+++ b/example/posts.js
@@ -35,7 +35,7 @@ export const PostList = (props) => (
     <List {...props} filter={<PostFilter />}>
         <Datagrid>
             <TextField source="id" />
-            <TextField source="title" type="email" style={{ maxWidth: '20em', overflow: 'hidden', textOverflow: 'ellipsis' }}/>
+            <TextField source="title" style={{ maxWidth: '20em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}/>
             <DateField source="published_at" style={{ fontStyle: 'italic' }} />
             <BooleanField label="Commentable" source="commentable" />
             <NumberField source="views" />

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -29,9 +29,11 @@ const defaultStyles = {
     cell: {
         td: {
             padding: '0 12px',
+            whiteSpace: 'normal',
         },
         'td:first-child': {
             padding: '0 12px 0 16px',
+            whiteSpace: 'normal',
         },
     },
 };


### PR DESCRIPTION
Fixes #144 

Before:

![image](https://cloud.githubusercontent.com/assets/99944/21391226/0cb813c4-c78b-11e6-91f5-283e882b7f90.png)

After:

![image](https://cloud.githubusercontent.com/assets/99944/21391213/efdb8b96-c78a-11e6-817b-c26afbf2dd28.png)
