### PR TITLE
[RFR] Improve <ReferenceInput> field

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -76,10 +76,22 @@ export const PostEdit = (props) => (
 You can also customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
 
 ```js
-<AutocompleteInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
+const choices = [
     { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
     { _id: 456, full_name: 'Jane Austen', sex: 'F' },
-]} />
+];
+<AutocompleteInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
+```
+
+`optionText` also accepts a function, so you can shape the option text at will:
+
+```js
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+<AutocompleteInput source="author_id" choices={choices} optionText={optionRenderer} />
 ```
 
 You can customize the `filter` function used to filter the results. By default, it's `AutoComplete.fuzzyFilter`, but you can use any of [the functions provided by `AutoComplete`](http://www.material-ui.com/#/components/auto-complete), or a function of your own (`(searchText: string, key: string) => boolean`):
@@ -227,11 +239,46 @@ export const PostEdit = (props) => (
 You can also customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
 
 ```js
-<RadioButtonGroupInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
+const choices = [
     { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
     { _id: 456, full_name: 'Jane Austen', sex: 'F' },
-]} />
+];
+<RadioButtonGroupInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
 ```
+
+`optionText` also accepts a function, so you can shape the option text at will:
+
+```js
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+<RadioButtonGroupInput source="author_id" choices={choices} optionText={optionRenderer} />
+```
+
+`optionText` also accepts a React Element, that will be cloned and receive the related choice as the `record` prop. You can use Field components there.
+
+```js
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
+<RadioButtonGroupInput source="gender" choices={choices} optionText={<FullNameField />}/>
+```
+
+Lastly, use the `options` attribute if you want to override any of Material UI's `<RadioButtonGroup>` attributes:
+
+{% raw %}
+```js
+<RadioButtonGroupInput source="category" options={{
+    labelPosition: 'right'
+}} />
+```
+{% endraw %}
+
+Refer to [Material UI SelectField documentation](http://www.material-ui.com/#/components/radio-button) for more details.
 
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should use the [`<ReferenceInput>`](#referenceinput).
 
@@ -358,10 +405,33 @@ export const PostEdit = (props) => (
 You can also customize the properties to use for the option name and value, thanks to the `optionText` and `optionValue` attributes:
 
 ```js
-<SelectInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
+const choices = [
     { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
     { _id: 456, full_name: 'Jane Austen', sex: 'F' },
-]} />
+];
+<SelectInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
+```
+
+`optionText` also accepts a function, so you can shape the option text at will:
+
+```js
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+<SelectInput source="author_id" choices={choices} optionText={optionRenderer} />
+```
+
+`optionText` also accepts a React Element, that will be cloned and receive the related choice as the `record` prop. You can use Field components there.
+
+```js
+const choices = [
+   { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+   { id: 456, first_name: 'Jane', last_name: 'Austen' },
+];
+const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
+<SelectInput source="gender" choices={choices} optionText={<FullNameField />}/>
 ```
 
 Enabling the `allowEmpty` props adds an empty choice (with `null` value) on top of the options, and makes the value nullable:

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -280,7 +280,19 @@ Lastly, use the `options` attribute if you want to override any of Material UI's
 
 Refer to [Material UI SelectField documentation](http://www.material-ui.com/#/components/radio-button) for more details.
 
-**Tip**: If you want to populate the `choices` attribute with a list of related records, you should use the [`<ReferenceInput>`](#referenceinput).
+**Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<RadioButtonGroupInput>` with [`<ReferenceInput>`](#referenceinput), and leave the `choices` empty:
+
+```js
+import { Edit, RadioButtonGroupInput, ReferenceInput } from 'admin-on-rest/mui'
+
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <ReferenceInput label="Author" source="author_id" reference="authors">
+            <RadioButtonGroupInput optionText="last_name" />
+        </ReferenceInput>
+    </Edit>
+);
+```
 
 ## `<ReferenceInput>`
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -237,7 +237,7 @@ You can also customize the properties to use for the option name and value, than
 
 ## `<ReferenceInput>`
 
-Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `CRUD_GET_MATCHING` REST method), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
+Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `GET_LIST` REST method), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
 
 This means you can use `<ReferenceInput>` with any of [`<SelectInput>`](#selectinput), [`<AutocompleteInput>`](#autocompleteinput), or [`<RadioButtonGroupInput>`](#radiobuttongroupinput), or even with the component of your choice, provided it supports the `choices` attribute.
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -164,7 +164,7 @@ You can also customize the properties to use for the option name and value, than
 
 ## `<ReferenceInput>`
 
-Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `CRUD_GET_MATCHING` REST method), then delegates rendering to a subcomponent, to which it passs the possible choices as the `choices` attribute.
+Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `CRUD_GET_MATCHING` REST method), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
 
 This means you can use `<ReferenceInput>` either with [`<SelectInput>`](#selectinput), or with [`<RadioButtonGroupInput>`](#radiobuttongroupinput), or even with the component of your choice, provided it supports the `choices` attribute.
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -306,12 +306,22 @@ export const CommentEdit = (props) => (
 
 ![ReferenceInput](./img/reference-input.gif)
 
-Set the `allowEmpty` attribute to `true` when the empty value is allowed. This is necessary for instance when unig the `<ReferenceInput>` in [the `Filter` component](./List.html#filters):
+Set the `allowEmpty` prop when the empty value is allowed.
+
+```js
+import { ReferenceInput, SelectInput } from 'admin-on-rest/mui'
+
+<ReferenceInput label="Post" source="post_id" reference="posts" allowEmpty>
+    <SelectInput optionText="title" />
+</ReferenceInput>
+```
+
+**Tip**: `allowEmpty` is set by default for all Input components children of the `<Filter>` component:
 
 ```js
 const CommentFilter = (props) => (
     <Filter {...props}>
-        <ReferenceInput label="Post" source="post_id" reference="posts" allowEmpty>
+        <ReferenceInput label="Post" source="post_id" reference="posts"> // no need for allowEmpty
             <SelectInput optionText="title" />
         </ReferenceInput>
     </Filter>

--- a/docs/RestClients.md
+++ b/docs/RestClients.md
@@ -39,15 +39,14 @@ This REST client fits APIs using simple GET parameters for filters and sorting. 
 
 | REST verb      | API calls
 |----------------|----------------------------------------------------------------
-| `GET_LIST`     | `GET http://my.api.url/posts?sort=['title','ASC']&range=[0, 24]`
-| `GET_MATCHING` | `GET http://my.api.url/posts?filter={title:'bar'}`
+| `GET_LIST`     | `GET http://my.api.url/posts?sort=['title','ASC']&range=[0, 24]&filter={title:'bar'}`
 | `GET_ONE`      | `GET http://my.api.url/posts/123`
 | `GET_MANY`     | `GET http://my.api.url/posts?filter={ids:[123,456,789]}`
 | `UPDATE`       | `PUT http://my.api.url/posts/123`
 | `CREATE`       | `POST http://my.api.url/posts/123`
 | `DELETE`       | `DELETE http://my.api.url/posts/123`
 
-**Note**: The simple REST client expects the API to include a `Content-Range` header in the response to `GET_LIST` and `GET_MATCHING` calls. The value must be the total number of resources in the collection. This allows admin-on-rest to know how many pages of resources there are in total, and build the pagination controls.
+**Note**: The simple REST client expects the API to include a `Content-Range` header in the response to `GET_LIST` calls. The value must be the total number of resources in the collection. This allows admin-on-rest to know how many pages of resources there are in total, and build the pagination controls.
 
 ```
 Content-Range: posts 0-24/319
@@ -84,15 +83,14 @@ This REST client fits APIs powered by [JSON Server](https://github.com/typicode/
 
 | REST verb      | API calls
 |----------------|----------------------------------------------------------------
-| `GET_LIST`     | `GET http://my.api.url/posts?_sort=title&_order=ASC&_start=0&_end=24`
-| `GET_MATCHING` | `GET http://my.api.url/posts?title=bar`
+| `GET_LIST`     | `GET http://my.api.url/posts?_sort=title&_order=ASC&_start=0&_end=24&title=bar`
 | `GET_ONE`      | `GET http://my.api.url/posts/123`
 | `GET_MANY`     | `GET http://my.api.url/posts/123, GET http://my.api.url/posts/456, GET http://my.api.url/posts/789`
 | `UPDATE`       | `PUT http://my.api.url/posts/123`
 | `CREATE`       | `POST http://my.api.url/posts/123`
 | `DELETE`       | `DELETE http://my.api.url/posts/123`
 
-**Note**: The jsonServer REST client expects the API to include a `X-Total-Count` header in the response to `GET_LIST` and `GET_MATCHING` calls. The value must be the total number of resources in the collection. This allows admin-on-rest to know how many pages of resources there are in total, and build the pagination controls.
+**Note**: The jsonServer REST client expects the API to include a `X-Total-Count` header in the response to `GET_LIST` calls. The value must be the total number of resources in the collection. This allows admin-on-rest to know how many pages of resources there are in total, and build the pagination controls.
 
 ```
 X-Total-Count: 319
@@ -187,7 +185,6 @@ Type | Params format
 `DELETE`             | `{ id: {mixed} }`
 `GET_MANY`           | `{ ids: {mixed[]} }`
 `GET_MANY_REFERENCE` | `{ target: {string}, id: {mixed} }`
-`GET_MATCHING`       | `{ filter: {Object} }`
 
 Examples:
 
@@ -202,7 +199,6 @@ restClient(UPDATE, 'posts', { id: 123, { title: "hello, world!" } });
 restClient(DELETE, 'posts', { id: 123 });
 restClient(GET_MANY, 'posts', { ids: [123, 124, 125] });
 restClient(GET_MANY_REFERENCE, 'comments', { target: 'post_id', id: 123 });
-restClient(GET_MATCHING, 'posts', { filter: { title: 'hello' } });
 ```
 
 ### Response Format
@@ -218,7 +214,6 @@ Type | Response format
 `DELETE`             | `{Record}`
 `GET_MANY`           | `{Record[]}`
 `GET_MANY_REFERENCE` | `{Record[]}`
-`GET_MATCHING`       | `{Record[]}`
 
 A `{Record}` is an object literal with at least an `id` property, e.g. `{ id: 123, title: "hello, world" }`.
 
@@ -278,12 +273,6 @@ restClient(GET_MANY_REFERENCE, 'comments', { target: 'post_id', id: 123 });
 // [
 //     { id: 667, title: "I agree", post_id: 123 },
 //     { id: 895, title: "I don't agree", post_id: 123 },
-// ]
-
-restClient(GET_MATCHING, 'posts', { filter: { title: 'hello' } })
-.then(record => console.log(record));
-// [
-//     { id: 123, title: "hello, world" },
 // ]
 ```
 

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -379,7 +379,7 @@ For instance, let's imagine you have to use the my.api.url API, which expects th
 | Create a record     | `POST http://my.api.url/posts/123` |
 | Delete a record     | `DELETE http://my.api.url/posts/123` |
 
-Admin-on-rest defines custom verbs for each of the actions of this list. Just like HTTP verbs (`GET`, `POST`, etc.), REST verbs qualify a request to a REST server. Admin-on-rest verbs are called `GET_LIST`, `GET_MATCHING`, `GET_ONE`, `GET_MANY`, `CREATE`, `UPDATE`, and `DELETE`. The REST client will have to map each of these verbs to one (or many) HTTP request(s).
+Admin-on-rest defines custom verbs for each of the actions of this list. Just like HTTP verbs (`GET`, `POST`, etc.), REST verbs qualify a request to a REST server. Admin-on-rest verbs are called `GET_LIST`, `GET_ONE`, `GET_MANY`, `CREATE`, `UPDATE`, and `DELETE`. The REST client will have to map each of these verbs to one (or many) HTTP request(s).
 
 The code for an API client for my.api.url is as follows:
 
@@ -387,7 +387,6 @@ The code for an API client for my.api.url is as follows:
 // in src/restClient
 import {
     GET_LIST,
-    GET_MATCHING,
     GET_ONE,
     GET_MANY,
     CREATE,
@@ -415,13 +414,6 @@ const convertRESTRequestToHTTP = (type, resource, params) => {
         const query = {
             sort: JSON.stringify([field, order]),
             range: JSON.stringify([(page - 1) * perPage, page * perPage - 1]),
-            filter: JSON.stringify(params.filter),
-        };
-        url = `${API_URL}/${resource}?${queryParameters(query)}`;
-        break;
-    }
-    case GET_MATCHING: {
-        const query = {
             filter: JSON.stringify(params.filter),
         };
         url = `${API_URL}/${resource}?${queryParameters(query)}`;

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -171,6 +171,9 @@
                             </a>
                             <ul class="articles" {% if page.path != 'Inputs.md' %}style="display:none"{% endif %}>
                                 <li class="chapter">
+                                    <a href="#autocompleteinput"><code>&lt;AutocompleteInput&gt;</code></a>
+                                </li>
+                                <li class="chapter">
                                     <a href="#booleaninput-and-nullablebooleaninput"><code>&lt;BooleanInput&gt;</code></a>
                                 </li>
                                 <li class="chapter">

--- a/example/comments.js
+++ b/example/comments.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List, Filter, Edit, Create, Datagrid, DateField, ReferenceField, TextField, EditButton, DisabledInput, DateInput, LongTextInput, SelectInput, ReferenceInput, TextInput } from 'admin-on-rest/mui';
+import { List, Filter, Edit, Create, Datagrid, DateField, ReferenceField, TextField, EditButton, AutocompleteInput, DisabledInput, DateInput, LongTextInput, SelectInput, ReferenceInput, TextInput } from 'admin-on-rest/mui';
 
 export CommentIcon from 'material-ui/svg-icons/communication/chat-bubble';
 import PersonIcon from 'material-ui/svg-icons/social/person';
@@ -82,8 +82,8 @@ export const CommentList = (props) => (
 export const CommentEdit = (props) => (
     <Edit {...props}>
         <DisabledInput source="id" />
-        <ReferenceInput label="Post" source="post_id" reference="posts">
-            <SelectInput optionText="title" />
+        <ReferenceInput label="Post" source="post_id" reference="posts" perPage={5} sort={{ field: 'title', order: 'ASC' }}>
+            <AutocompleteInput optionText="title" />
         </ReferenceInput>
         <TextInput label="Author name" source="author.name" />
         <DateInput label="date" source="created_at" />

--- a/example/comments.js
+++ b/example/comments.js
@@ -13,7 +13,7 @@ import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
 
 const CommentFilter = (props) => (
     <Filter {...props}>
-        <ReferenceInput label="Post" source="post_id" reference="posts" allowEmpty>
+        <ReferenceInput label="Post" source="post_id" reference="posts">
             <SelectInput optionText="title" />
         </ReferenceInput>
     </Filter>

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-runtime": "~6.18.0",
     "inflection": "~1.10.0",
     "lodash.debounce": "~4.0.8",
-    "lodash.defaultsdeep": "^4.6.0",
+    "lodash.defaultsdeep": "~4.6.0",
     "lodash.get": "~4.4.2",
     "material-ui": "~0.16.5",
     "quill": "~1.1.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lodash.debounce": "~4.0.8",
     "lodash.defaultsdeep": "^4.6.0",
     "lodash.get": "~4.4.2",
-    "material-ui": "~0.16.4",
+    "material-ui": "~0.16.5",
     "quill": "~1.1.5",
     "react": "~15.4.0",
     "react-dom": "~15.4.0",

--- a/src/actions/dataActions.js
+++ b/src/actions/dataActions.js
@@ -82,9 +82,9 @@ export const CRUD_GET_MATCHING_LOADING = 'CRUD_GET_MATCHING_LOADING';
 export const CRUD_GET_MATCHING_FAILURE = 'CRUD_GET_MATCHING_FAILURE';
 export const CRUD_GET_MATCHING_SUCCESS = 'CRUD_GET_MATCHING_SUCCESS';
 
-export const crudGetMatching = (reference, relatedTo, filter) => ({
+export const crudGetMatching = (reference, relatedTo, pagination, sort, filter) => ({
     type: CRUD_GET_MATCHING,
-    payload: { filter },
+    payload: { pagination, sort, filter },
     meta: { resource: reference, relatedTo, fetch: GET_MATCHING, cancelPrevious: false },
 });
 

--- a/src/actions/dataActions.js
+++ b/src/actions/dataActions.js
@@ -5,7 +5,6 @@ import {
     UPDATE,
     DELETE,
     GET_MANY,
-    GET_MATCHING,
     GET_MANY_REFERENCE,
 } from '../rest/types';
 
@@ -85,7 +84,7 @@ export const CRUD_GET_MATCHING_SUCCESS = 'CRUD_GET_MATCHING_SUCCESS';
 export const crudGetMatching = (reference, relatedTo, pagination, sort, filter) => ({
     type: CRUD_GET_MATCHING,
     payload: { pagination, sort, filter },
-    meta: { resource: reference, relatedTo, fetch: GET_MATCHING, cancelPrevious: false },
+    meta: { resource: reference, relatedTo, fetch: GET_LIST, cancelPrevious: false },
 });
 
 export const CRUD_GET_MANY_REFERENCE = 'CRUD_GET_MANY_REFERENCE';

--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -10,7 +10,6 @@ import title from '../../util/title';
  * By default, the options are built from:
  *  - the 'id' property as the option value,
  *  - the 'name' property an the option text
- *
  * @example
  * <AutocompleteInput source="gender" choices={[
  *    { id: 'M', name: 'Male' },
@@ -19,14 +18,27 @@ import title from '../../util/title';
  *
  * You can also customize the properties to use for the option name and value,
  * thanks to the `optionText` and `optionValue` props.
- *
  * @example
  * <AutocompleteInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
  *    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
  *    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
  * ]} />
  *
- * The object passed as `options` props is passed to the material-ui <Autocomplete> component
+ * You can customize the `filter` function used to filter the results.
+ * By default, it's `AutoComplete.fuzzyFilter`, but you can use any of
+ * the functions provided by `AutoComplete`, or a function of your own
+ * @see http://www.material-ui.com/#/components/auto-complete
+ * @example
+ * import { Edit, AutocompleteInput } from 'admin-on-rest/mui';
+ * import AutoComplete from 'material-ui/AutoComplete';
+ *
+ * export const PostEdit = (props) => (
+ *     <Edit {...props}>
+ *         <AutocompleteInput source="category" filter={AutoComplete.caseInsensitiveFilter} choices={choices} />
+ *     </Edit>
+ * );
+ *
+ * The object passed as `options` props is passed to the material-ui <AutoComplete> component
  *
  * @example
  * <AutocompleteInput source="author_id" options={{ fullWidth: true }} />
@@ -40,7 +52,7 @@ class AutocompleteInput extends Component {
     }
 
     render() {
-        const { choices, elStyle, input, label, options, optionText, optionValue, setFilter, source } = this.props;
+        const { choices, elStyle, filter, input, label, options, optionText, optionValue, setFilter, source } = this.props;
         const selectedSource = choices.find(choice => choice[optionValue] === input.value);
         const dataSource = choices.map(choice => ({
             value: choice[optionValue],
@@ -51,7 +63,7 @@ class AutocompleteInput extends Component {
                 searchText={selectedSource && selectedSource[optionText]}
                 dataSource={dataSource}
                 floatingLabelText={title(label, source)}
-                filter={AutoComplete.noFilter}
+                filter={filter}
                 onNewRequest={this.onNewRequest}
                 onUpdateInput={setFilter}
                 openOnFocus
@@ -65,6 +77,7 @@ class AutocompleteInput extends Component {
 AutocompleteInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
     elStyle: PropTypes.object,
+    filter: PropTypes.func.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
@@ -77,6 +90,7 @@ AutocompleteInput.propTypes = {
 
 AutocompleteInput.defaultProps = {
     choices: [],
+    filter: AutoComplete.fuzzyFilter,
     options: {},
     optionText: 'name',
     optionValue: 'id',

--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -11,18 +11,29 @@ import title from '../../util/title';
  *  - the 'id' property as the option value,
  *  - the 'name' property an the option text
  * @example
- * <AutocompleteInput source="gender" choices={[
+ * const choices = [
  *    { id: 'M', name: 'Male' },
  *    { id: 'F', name: 'Female' },
- * ]} />
+ * ];
+ * <AutocompleteInput source="gender" choices={choices} />
  *
  * You can also customize the properties to use for the option name and value,
- * thanks to the `optionText` and `optionValue` props.
+ * thanks to the 'optionText' and 'optionValue' attributes.
  * @example
- * <AutocompleteInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
+ * const choices = [
  *    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
  *    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
- * ]} />
+ * ];
+ * <AutocompleteInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
+ *
+ * `optionText` also accepts a function, so you can shape the option text at will:
+ * @example
+ * const choices = [
+ *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+ *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
+ * ];
+ * const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+ * <AutocompleteInput source="author_id" choices={choices} optionText={optionRenderer} />
  *
  * You can customize the `filter` function used to filter the results.
  * By default, it's `AutoComplete.fuzzyFilter`, but you can use any of
@@ -53,14 +64,18 @@ class AutocompleteInput extends Component {
 
     render() {
         const { choices, elStyle, filter, input, label, options, optionText, optionValue, setFilter, source } = this.props;
+
         const selectedSource = choices.find(choice => choice[optionValue] === input.value);
+        const option = typeof optionText === 'function' ?
+            optionText :
+            choice => choice[optionText];
         const dataSource = choices.map(choice => ({
             value: choice[optionValue],
-            text: choice[optionText],
+            text: option(choice),
         }));
         return (
             <AutoComplete
-                searchText={selectedSource && selectedSource[optionText]}
+                searchText={selectedSource && option(selectedSource)}
                 dataSource={dataSource}
                 floatingLabelText={title(label, source)}
                 filter={filter}
@@ -82,7 +97,11 @@ AutocompleteInput.propTypes = {
     input: PropTypes.object,
     label: PropTypes.string,
     options: PropTypes.object,
-    optionText: PropTypes.string.isRequired,
+    optionElement: PropTypes.element,
+    optionText: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+    ]).isRequired,
     optionValue: PropTypes.string.isRequired,
     setFilter: PropTypes.func,
     source: PropTypes.string,

--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -55,7 +55,7 @@ import title from '../../util/title';
  * <AutocompleteInput source="author_id" options={{ fullWidth: true }} />
  */
 class AutocompleteInput extends Component {
-    onNewRequest = (chosenRequest, index) => {
+    handleNewRequest = (chosenRequest, index) => {
         if (index !== -1) {
             const { choices, input, optionValue } = this.props;
             input.onChange(choices[index][optionValue]);
@@ -79,7 +79,7 @@ class AutocompleteInput extends Component {
                 dataSource={dataSource}
                 floatingLabelText={title(label, source)}
                 filter={filter}
-                onNewRequest={this.onNewRequest}
+                onNewRequest={this.handleNewRequest}
                 onUpdateInput={setFilter}
                 openOnFocus
                 style={elStyle}

--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -1,0 +1,86 @@
+import React, { Component, PropTypes } from 'react';
+import AutoComplete from 'material-ui/AutoComplete';
+import title from '../../util/title';
+
+/**
+ * An Input component for an autocomplete field, using an array of objects for the options
+ *
+ * Pass possible options as an array of objects in the 'choices' attribute.
+ *
+ * By default, the options are built from:
+ *  - the 'id' property as the option value,
+ *  - the 'name' property an the option text
+ *
+ * @example
+ * <AutocompleteInput source="gender" choices={[
+ *    { id: 'M', name: 'Male' },
+ *    { id: 'F', name: 'Female' },
+ * ]} />
+ *
+ * You can also customize the properties to use for the option name and value,
+ * thanks to the `optionText` and `optionValue` props.
+ *
+ * @example
+ * <AutocompleteInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
+ *    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
+ *    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
+ * ]} />
+ *
+ * The object passed as `options` props is passed to the material-ui <Autocomplete> component
+ *
+ * @example
+ * <AutocompleteInput source="author_id" options={{ fullWidth: true }} />
+ */
+class AutocompleteInput extends Component {
+    onNewRequest = (chosenRequest, index) => {
+        if (index !== -1) {
+            const { choices, input, optionValue } = this.props;
+            input.onChange(choices[index][optionValue]);
+        }
+    }
+
+    render() {
+        const { choices, elStyle, input, label, options, optionText, optionValue, setFilter, source } = this.props;
+        const selectedSource = choices.find(choice => choice[optionValue] === input.value);
+        const dataSource = choices.map(choice => ({
+            value: choice[optionValue],
+            text: choice[optionText],
+        }));
+        return (
+            <AutoComplete
+                searchText={selectedSource && selectedSource[optionText]}
+                dataSource={dataSource}
+                floatingLabelText={title(label, source)}
+                filter={AutoComplete.noFilter}
+                onNewRequest={this.onNewRequest}
+                onUpdateInput={setFilter}
+                openOnFocus
+                style={elStyle}
+                {...options}
+            />
+        );
+    }
+}
+
+AutocompleteInput.propTypes = {
+    choices: PropTypes.arrayOf(PropTypes.object),
+    elStyle: PropTypes.object,
+    includesLabel: PropTypes.bool.isRequired,
+    input: PropTypes.object,
+    label: PropTypes.string,
+    options: PropTypes.object,
+    optionText: PropTypes.string.isRequired,
+    optionValue: PropTypes.string.isRequired,
+    setFilter: PropTypes.func,
+    source: PropTypes.string,
+};
+
+AutocompleteInput.defaultProps = {
+    choices: [],
+    options: {},
+    optionText: 'name',
+    optionValue: 'id',
+    includesLabel: true,
+};
+
+export default AutocompleteInput;

--- a/src/mui/input/AutocompleteInput.spec.js
+++ b/src/mui/input/AutocompleteInput.spec.js
@@ -27,7 +27,7 @@ describe('<AutocompleteInput />', () => {
         assert.equal(AutoCompleteElement.prop('searchText'), 'foo');
     });
 
-    it('should render pass choices as dataSource', () => {
+    it('should pass choices as dataSource', () => {
         const wrapper = shallow(<AutocompleteInput
             {...defaultProps}
             choices={[

--- a/src/mui/input/AutocompleteInput.spec.js
+++ b/src/mui/input/AutocompleteInput.spec.js
@@ -42,4 +42,46 @@ describe('<AutocompleteInput />', () => {
             { value: 'F', text: 'Female' },
         ]);
     });
+
+    it('should use optionValue as value identifier', () => {
+        const wrapper = shallow(<AutocompleteInput
+            {...defaultProps}
+            optionValue="foobar"
+            choices={[
+                { foobar: 'M', name: 'Male' },
+            ]}
+        />);
+        const AutoCompleteElement = wrapper.find('AutoComplete').first();
+        assert.deepEqual(AutoCompleteElement.prop('dataSource'), [
+            { value: 'M', text: 'Male' },
+        ]);
+    });
+
+    it('should use optionText with a string value as text identifier', () => {
+        const wrapper = shallow(<AutocompleteInput
+            {...defaultProps}
+            optionText="foobar"
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const AutoCompleteElement = wrapper.find('AutoComplete').first();
+        assert.deepEqual(AutoCompleteElement.prop('dataSource'), [
+            { value: 'M', text: 'Male' },
+        ]);
+    });
+
+    it('should use optionText with a function value as text identifier', () => {
+        const wrapper = shallow(<AutocompleteInput
+            {...defaultProps}
+            optionText={choice => choice.foobar}
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const AutoCompleteElement = wrapper.find('AutoComplete').first();
+        assert.deepEqual(AutoCompleteElement.prop('dataSource'), [
+            { value: 'M', text: 'Male' },
+        ]);
+    });
 });

--- a/src/mui/input/AutocompleteInput.spec.js
+++ b/src/mui/input/AutocompleteInput.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import AutocompleteInput from './AutocompleteInput';
+
+describe('<AutocompleteInput />', () => {
+    const defaultProps = {
+        source: 'foo',
+        meta: {},
+        input: {},
+    };
+
+    it('should use a mui AutoComplete', () => {
+        const wrapper = shallow(<AutocompleteInput {...defaultProps} label="hello" />);
+        const AutoCompleteElement = wrapper.find('AutoComplete');
+        assert.equal(AutoCompleteElement.length, 1);
+        assert.equal(AutoCompleteElement.prop('floatingLabelText'), 'hello');
+    });
+
+    it('should use the input parameter value as the initial input searchText', () => {
+        const wrapper = shallow(<AutocompleteInput
+            {...defaultProps}
+            input={{ value: 2 }}
+            choices={[{ id: 2, name: 'foo' }]}
+        />);
+        const AutoCompleteElement = wrapper.find('AutoComplete').first();
+        assert.equal(AutoCompleteElement.prop('searchText'), 'foo');
+    });
+
+    it('should render pass choices as dataSource', () => {
+        const wrapper = shallow(<AutocompleteInput
+            {...defaultProps}
+            choices={[
+                { id: 'M', name: 'Male' },
+                { id: 'F', name: 'Female' },
+            ]}
+            options={{ open: true }}
+        />);
+        const AutoCompleteElement = wrapper.find('AutoComplete').first();
+        assert.deepEqual(AutoCompleteElement.prop('dataSource'), [
+            { value: 'M', text: 'Male' },
+            { value: 'F', text: 'Female' },
+        ]);
+    });
+});

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -10,21 +10,42 @@ import Labeled from './Labeled';
  * By default, the options are built from:
  *  - the 'id' property as the option value,
  *  - the 'name' property an the option text
- *
  * @example
- * <RadioButtonGroupInput source="gender" choices={[
+ * const choices = [
  *    { id: 'M', name: 'Male' },
- *    { id: 'F', label: 'Female' },
- * ]} />
+ *    { id: 'F', name: 'Female' },
+ * ];
+ * <RadioButtonGroupInput source="gender" choices={choices} />
  *
  * You can also customize the properties to use for the option name and value,
  * thanks to the 'optionText' and 'optionValue' attributes.
- *
  * @example
- * <RadioButtonGroupInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
+ * const choices = [
  *    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
  *    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
- * ]} />
+ * ];
+ * <RadioButtonGroupInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
+ *
+ * `optionText` also accepts a function, so you can shape the option text at will:
+ * @example
+ * const choices = [
+ *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+ *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
+ * ];
+ * const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+ * <RadioButtonGroupInput source="author_id" choices={choices} optionText={optionRenderer} />
+ *
+ * `optionText` also accepts a React Element, that will be cloned and receive
+ * the related choice as the `record` prop. You can use Field components there.
+ * @example
+ * const choices = [
+ *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+ *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
+ * ];
+ * const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
+ * <RadioButtonGroupInput source="gender" choices={choices} optionText={<FullNameField />}/>
+ *
+ * The object passed as `options` props is passed to the material-ui <RadioButtonGroup> component
  */
 class RadioButtonGroupInput extends Component {
     handleChange = (event, value) => {
@@ -32,17 +53,23 @@ class RadioButtonGroupInput extends Component {
     }
 
     render() {
-        const { label, source, record, choices, optionText, optionValue, options, elStyle } = this.props;
+        const { label, source, input, choices, optionText, optionValue, options, elStyle } = this.props;
+        const option = React.isValidElement(optionText) ? // eslint-disable-line no-nested-ternary
+            choice => React.cloneElement(optionText, { record: choice }) :
+            (typeof optionText === 'function' ?
+                optionText :
+                choice => choice[optionText]
+            );
         return (
             <Labeled label={label} onChange={this.handleChange} source={source}>
                 <RadioButtonGroup
                     name={source}
-                    defaultSelected={record[source]}
+                    defaultSelected={input.value}
                     style={elStyle}
                     {...options}
                 >
                     {choices.map(choice =>
-                        <RadioButton key={choice[optionText]} label={choice[optionText]} value={choice[optionValue]} />
+                        <RadioButton key={choice[optionValue]} label={option(choice)} value={choice[optionValue]} />
                     )}
                 </RadioButtonGroup>
             </Labeled>
@@ -56,15 +83,17 @@ RadioButtonGroupInput.propTypes = {
     label: PropTypes.string,
     onChange: PropTypes.func,
     options: PropTypes.object,
-    optionText: PropTypes.string.isRequired,
+    optionText: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.element,
+    ]).isRequired,
     optionValue: PropTypes.string.isRequired,
-    record: PropTypes.object,
     source: PropTypes.string,
     style: PropTypes.object,
 };
 
 RadioButtonGroupInput.defaultProps = {
-    record: {},
     options: {},
     optionText: 'name',
     optionValue: 'id',

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -94,6 +94,7 @@ RadioButtonGroupInput.propTypes = {
 };
 
 RadioButtonGroupInput.defaultProps = {
+    choices: [],
     options: {},
     optionText: 'name',
     optionValue: 'id',

--- a/src/mui/input/RadioButtonGroupInput.spec.js
+++ b/src/mui/input/RadioButtonGroupInput.spec.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import RadioButtonGroupInput from './RadioButtonGroupInput';
+
+describe('<RadioButtonGroupInput />', () => {
+    const defaultProps = {
+        source: 'foo',
+        meta: {},
+        input: {},
+    };
+
+    it('should use a mui RadioButtonGroup', () => {
+        const wrapper = shallow(<RadioButtonGroupInput {...defaultProps} label="hello" />);
+        const RadioButtonGroupElement = wrapper.find('RadioButtonGroup');
+        assert.equal(RadioButtonGroupElement.length, 1);
+    });
+
+    it('should use the input parameter value as the initial input value', () => {
+        const wrapper = shallow(<RadioButtonGroupInput {...defaultProps} input={{ value: 2 }} />);
+        const RadioButtonGroupElement = wrapper.find('RadioButtonGroup').first();
+        assert.equal(RadioButtonGroupElement.prop('defaultSelected'), '2');
+    });
+
+    it('should render choices as mui RadioButton components', () => {
+        const wrapper = shallow(<RadioButtonGroupInput
+            {...defaultProps}
+            choices={[
+                { id: 'M', name: 'Male' },
+                { id: 'F', name: 'Female' },
+            ]}
+        />);
+        const RadioButtonElements = wrapper.find('RadioButton');
+        assert.equal(RadioButtonElements.length, 2);
+        const RadioButtonElement1 = RadioButtonElements.first();
+        assert.equal(RadioButtonElement1.prop('value'), 'M');
+        assert.equal(RadioButtonElement1.prop('label'), 'Male');
+        const RadioButtonElement2 = RadioButtonElements.at(1);
+        assert.equal(RadioButtonElement2.prop('value'), 'F');
+        assert.equal(RadioButtonElement2.prop('label'), 'Female');
+    });
+
+    it('should use optionValue as value identifier', () => {
+        const wrapper = shallow(<RadioButtonGroupInput
+            {...defaultProps}
+            optionValue="foobar"
+            choices={[
+                { foobar: 'M', name: 'Male' },
+            ]}
+        />);
+        const RadioButtonElements = wrapper.find('RadioButton');
+        const RadioButtonElement1 = RadioButtonElements.first();
+        assert.equal(RadioButtonElement1.prop('value'), 'M');
+        assert.equal(RadioButtonElement1.prop('label'), 'Male');
+    });
+
+    it('should use optionText with a string value as text identifier', () => {
+        const wrapper = shallow(<RadioButtonGroupInput
+            {...defaultProps}
+            optionText="foobar"
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const RadioButtonElements = wrapper.find('RadioButton');
+        const RadioButtonElement1 = RadioButtonElements.first();
+        assert.equal(RadioButtonElement1.prop('value'), 'M');
+        assert.equal(RadioButtonElement1.prop('label'), 'Male');
+    });
+
+    it('should use optionText with a function value as text identifier', () => {
+        const wrapper = shallow(<RadioButtonGroupInput
+            {...defaultProps}
+            optionText={choice => choice.foobar}
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const RadioButtonElements = wrapper.find('RadioButton');
+        const RadioButtonElement1 = RadioButtonElements.first();
+        assert.equal(RadioButtonElement1.prop('value'), 'M');
+        assert.equal(RadioButtonElement1.prop('label'), 'Male');
+    });
+
+    it('should use optionText with an element value as text identifier', () => {
+        const Foobar = ({ record }) => <span>{record.foobar}</span>;
+        const wrapper = shallow(<RadioButtonGroupInput
+            {...defaultProps}
+            optionText={<Foobar />}
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const RadioButtonElements = wrapper.find('RadioButton');
+        const RadioButtonElement1 = RadioButtonElements.first();
+        assert.equal(RadioButtonElement1.prop('value'), 'M');
+        assert.deepEqual(RadioButtonElement1.prop('label'), <Foobar record={{ id: 'M', foobar: 'Male' }} />);
+    });
+});

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -6,6 +6,7 @@ import { crudGetOne as crudGetOneAction, crudGetMatching as crudGetMatchingActio
 import { getPossibleReferences } from '../../reducer/references/possibleValues';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
+const noFilter = () => true;
 
 /**
  * An Input component for choosing a reference record. Useful for foreign keys.
@@ -55,6 +56,17 @@ const referenceSource = (resource, source) => `${resource}@${source}`;
  *      source="post_id"
  *      reference="posts"
  *      sort={{ field: 'title', order: 'ASC' }}>
+ *     <SelectInput optionText="title" />
+ * </ReferenceInput>
+ *
+ * Also, you can filter the query used to populate the possible values. Use the
+ * `filter` prop for that.
+ *
+ * @example
+ * <ReferenceInput
+ *      source="post_id"
+ *      reference="posts"
+ *      filter={{ is_published: true }}>
  *     <SelectInput optionText="title" />
  * </ReferenceInput>
  *
@@ -136,6 +148,7 @@ export class ReferenceInput extends Component {
             choices: matchingReferences,
             basePath,
             onChange,
+            filter: noFilter, // for AutocompleteInput
             setFilter: this.debouncedSetFilter,
             setPagination: this.setPagination,
             setSort: this.setSort,

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -123,9 +123,9 @@ export class ReferenceInput extends Component {
         }
     }
 
-    fetchReferenceAndOptions({ reference, record, source, resource } = this.props) {
+    fetchReferenceAndOptions({ input, reference, source, resource } = this.props) {
         const { pagination, sort, filter } = this.params;
-        const id = record[source];
+        const id = input.value;
         if (id) {
             this.props.crudGetOne(reference, id, null, false);
         }
@@ -133,7 +133,7 @@ export class ReferenceInput extends Component {
     }
 
     render() {
-        const { input, resource, label, source, record, referenceRecord, allowEmpty, matchingReferences, basePath, onChange, children } = this.props;
+        const { input, resource, label, source, referenceRecord, allowEmpty, matchingReferences, basePath, onChange, children } = this.props;
         if (!referenceRecord && !allowEmpty) {
             return <Labeled label={label} source={source} />;
         }
@@ -144,7 +144,6 @@ export class ReferenceInput extends Component {
             label,
             resource,
             source,
-            record,
             choices: matchingReferences,
             basePath,
             onChange,
@@ -170,7 +169,6 @@ ReferenceInput.propTypes = {
     matchingReferences: PropTypes.array,
     onChange: PropTypes.func,
     perPage: PropTypes.number,
-    record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
     resource: PropTypes.string.isRequired,
@@ -188,12 +186,11 @@ ReferenceInput.defaultProps = {
     matchingReferences: [],
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
-    record: {},
     referenceRecord: null,
 };
 
 function mapStateToProps(state, props) {
-    const referenceId = props.record[props.source];
+    const referenceId = props.input.value;
     return {
         referenceRecord: state.admin[props.reference].data[referenceId],
         matchingReferences: getPossibleReferences(state, referenceSource(props.resource, props.source), props.reference, referenceId),

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -148,14 +148,14 @@ describe('<ReferenceInput />', () => {
         ]);
     });
 
-    it('should call crudGetOne on mount if record is set', () => {
+    it('should call crudGetOne on mount if value is set', () => {
         const crudGetOne = sinon.spy();
         shallow((
             <ReferenceInput
                 {...defaultProps}
                 allowEmpty
                 crudGetOne={crudGetOne}
-                record={{ post_id: 5 }}
+                input={{ value: 5 }}
             >
                 <MyComponent />
             </ReferenceInput>

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -1,0 +1,187 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { ReferenceInput } from './ReferenceInput';
+
+describe('<ReferenceInput />', () => {
+    const defaultProps = {
+        crudGetMatching: () => true,
+        crudGetOne: () => true,
+        includesLabel: true,
+        input: {},
+        reference: 'posts',
+        resource: 'comments',
+        source: 'post_id',
+    };
+    const MyComponent = () => <span id="mycomponent" />;
+
+    it('should not render anything if there is no referenceRecord and allowEmpty is false', () => {
+        const wrapper = shallow((
+            <ReferenceInput {...defaultProps}>
+                <MyComponent />
+            </ReferenceInput>
+        ));
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 0);
+    });
+
+    it('should not render enclosed component if allowEmpty is true', () => {
+        const wrapper = shallow((
+            <ReferenceInput {...defaultProps} allowEmpty>
+                <MyComponent />
+            </ReferenceInput>
+        ));
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
+    });
+
+    it('should call crudGetMatching on mount with default fetch values', () => {
+        const crudGetMatching = sinon.spy();
+        shallow((
+            <ReferenceInput {...defaultProps} allowEmpty crudGetMatching={crudGetMatching}>
+                <MyComponent />
+            </ReferenceInput>
+        ), { lifecycleExperimental: true });
+        assert.deepEqual(crudGetMatching.args[0], [
+            'posts',
+            'comments@post_id',
+            {
+                page: 1,
+                perPage: 25,
+            },
+            {
+                field: 'id',
+                order: 'DESC',
+            },
+            {},
+        ]);
+    });
+
+    it('should allow to customize crudGetMatching arguments with perPage, sort, and filter props', () => {
+        const crudGetMatching = sinon.spy();
+        shallow((
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                crudGetMatching={crudGetMatching}
+                sort={{ field: 'foo', order: 'ASC' }}
+                perPage={5}
+                filter={{ q: 'foo' }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        ), { lifecycleExperimental: true });
+        assert.deepEqual(crudGetMatching.args[0], [
+            'posts',
+            'comments@post_id',
+            {
+                page: 1,
+                perPage: 5,
+            },
+            {
+                field: 'foo',
+                order: 'ASC',
+            },
+            {
+                q: 'foo',
+            },
+        ]);
+    });
+
+    it('should call crudGetMatching when setFilter is called', () => {
+        const crudGetMatching = sinon.spy();
+        const wrapper = shallow((
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                crudGetMatching={crudGetMatching}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        ), { lifecycleExperimental: true });
+        wrapper.instance().setFilter('bar');
+        assert.deepEqual(crudGetMatching.args[1], [
+            'posts',
+            'comments@post_id',
+            {
+                page: 1,
+                perPage: 25,
+            },
+            {
+                field: 'id',
+                order: 'DESC',
+            },
+            {
+                q: 'bar',
+            },
+        ]);
+    });
+
+    it('should use custom filterToQuery function prop', () => {
+        const crudGetMatching = sinon.spy();
+        const wrapper = shallow((
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                crudGetMatching={crudGetMatching}
+                filterToQuery={searchText => ({ foo: searchText })}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        ), { lifecycleExperimental: true });
+        wrapper.instance().setFilter('bar');
+        assert.deepEqual(crudGetMatching.args[1], [
+            'posts',
+            'comments@post_id',
+            {
+                page: 1,
+                perPage: 25,
+            },
+            {
+                field: 'id',
+                order: 'DESC',
+            },
+            {
+                foo: 'bar',
+            },
+        ]);
+    });
+
+    it('should call crudGetOne on mount if record is set', () => {
+        const crudGetOne = sinon.spy();
+        shallow((
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                crudGetOne={crudGetOne}
+                record={{ post_id: 5 }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        ), { lifecycleExperimental: true });
+        assert.deepEqual(crudGetOne.args[0], [
+            'posts',
+            5,
+            null,
+            false,
+        ]);
+    });
+
+    it('should pass onChange down to child component', () => {
+        const onChange = sinon.spy();
+        const wrapper = shallow((
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                onChange={onChange}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        ));
+        wrapper.find('MyComponent').simulate('change', 'foo');
+        assert.deepEqual(onChange.args[0], [
+            'foo',
+        ]);
+    });
+});

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -49,7 +49,7 @@ import MenuItem from 'material-ui/MenuItem';
  * The object passed as `options` props is passed to the material-ui <SelectField> component
  */
 class SelectInput extends Component {
-    onChange = (event, index, value) => this.props.input.onChange(value);
+    handleChange = (event, index, value) => this.props.input.onChange(value);
 
     render() {
         const { allowEmpty, input, label, choices, optionText, optionValue, options, source, elStyle } = this.props;
@@ -64,7 +64,7 @@ class SelectInput extends Component {
                 {...input}
                 menuStyle={{ maxHeight: '41px', overflowY: 'hidden' }}
                 floatingLabelText={title(label, source)}
-                onChange={this.onChange}
+                onChange={this.handleChange}
                 autoWidth
                 style={elStyle}
                 {...options}

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -11,28 +11,54 @@ import MenuItem from 'material-ui/MenuItem';
  * By default, the options are built from:
  *  - the 'id' property as the option value,
  *  - the 'name' property an the option text
- *
  * @example
- * <SelectInput source="gender" choices={[
+ * const choices = [
  *    { id: 'M', name: 'Male' },
  *    { id: 'F', name: 'Female' },
- * ]} />
+ * ];
+ * <SelectInput source="gender" choices={choices} />
  *
  * You can also customize the properties to use for the option name and value,
  * thanks to the 'optionText' and 'optionValue' attributes.
- *
  * @example
- * <SelectInput label="Author" source="author_id" optionText="full_name" optionValue="_id" choices={[
+ * const choices = [
  *    { _id: 123, full_name: 'Leo Tolstoi', sex: 'M' },
  *    { _id: 456, full_name: 'Jane Austen', sex: 'F' },
- * ]} />
+ * ];
+ * <SelectInput source="author_id" choices={choices} optionText="full_name" optionValue="_id" />
+ *
+ * `optionText` also accepts a function, so you can shape the option text at will:
+ * @example
+ * const choices = [
+ *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+ *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
+ * ];
+ * const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
+ * <SelectInput source="author_id" choices={choices} optionText={optionRenderer} />
+ *
+ * `optionText` also accepts a React Element, that will be cloned and receive
+ * the related choice as the `record` prop. You can use Field components there.
+ * @example
+ * const choices = [
+ *    { id: 123, first_name: 'Leo', last_name: 'Tolstoi' },
+ *    { id: 456, first_name: 'Jane', last_name: 'Austen' },
+ * ];
+ * const FullNameField = ({ record }) => <span>{record.first_name} {record.last_name}</span>;
+ * <SelectInput source="gender" choices={choices} optionText={<FullNameField />}/>
+ *
+ * The object passed as `options` props is passed to the material-ui <SelectField> component
  */
 class SelectInput extends Component {
     onChange = (event, index, value) => this.props.input.onChange(value);
 
     render() {
         const { allowEmpty, input, label, choices, optionText, optionValue, options, source, elStyle } = this.props;
-
+        const option = React.isValidElement(optionText) ? // eslint-disable-line no-nested-ternary
+            choice => React.cloneElement(optionText, { record: choice }) :
+            (typeof optionText === 'function' ?
+                optionText :
+                choice => choice[optionText]
+            );
         return (
             <SelectField
                 {...input}
@@ -47,7 +73,7 @@ class SelectInput extends Component {
                     <MenuItem value={null} primaryText="" />
                 }
                 {choices.map(choice =>
-                    <MenuItem key={choice[optionValue]} primaryText={choice[optionText]} value={choice[optionValue]} />
+                    <MenuItem key={choice[optionValue]} primaryText={option(choice)} value={choice[optionValue]} />
                 )}
             </SelectField>
         );
@@ -62,7 +88,11 @@ SelectInput.propTypes = {
     input: PropTypes.object,
     label: PropTypes.string,
     options: PropTypes.object,
-    optionText: PropTypes.string.isRequired,
+    optionText: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.element,
+    ]).isRequired,
     optionValue: PropTypes.string.isRequired,
     source: PropTypes.string,
 };

--- a/src/mui/input/SelectInput.spec.js
+++ b/src/mui/input/SelectInput.spec.js
@@ -56,4 +56,61 @@ describe('<SelectInput />', () => {
         assert.equal(MenuItemElement1.prop('value'), null);
         assert.equal(MenuItemElement1.prop('primaryText'), '');
     });
+
+    it('should use optionValue as value identifier', () => {
+        const wrapper = shallow(<SelectInput
+            {...defaultProps}
+            optionValue="foobar"
+            choices={[
+                { foobar: 'M', name: 'Male' },
+            ]}
+        />);
+        const MenuItemElements = wrapper.find('MenuItem');
+        const MenuItemElement1 = MenuItemElements.first();
+        assert.equal(MenuItemElement1.prop('value'), 'M');
+        assert.equal(MenuItemElement1.prop('primaryText'), 'Male');
+    });
+
+    it('should use optionText with a string value as text identifier', () => {
+        const wrapper = shallow(<SelectInput
+            {...defaultProps}
+            optionText="foobar"
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const MenuItemElements = wrapper.find('MenuItem');
+        const MenuItemElement1 = MenuItemElements.first();
+        assert.equal(MenuItemElement1.prop('value'), 'M');
+        assert.equal(MenuItemElement1.prop('primaryText'), 'Male');
+    });
+
+    it('should use optionText with a function value as text identifier', () => {
+        const wrapper = shallow(<SelectInput
+            {...defaultProps}
+            optionText={choice => choice.foobar}
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const MenuItemElements = wrapper.find('MenuItem');
+        const MenuItemElement1 = MenuItemElements.first();
+        assert.equal(MenuItemElement1.prop('value'), 'M');
+        assert.equal(MenuItemElement1.prop('primaryText'), 'Male');
+    });
+
+    it('should use optionText with an element value as text identifier', () => {
+        const Foobar = ({ record }) => <span>{record.foobar}</span>;
+        const wrapper = shallow(<SelectInput
+            {...defaultProps}
+            optionText={<Foobar />}
+            choices={[
+                { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const MenuItemElements = wrapper.find('MenuItem');
+        const MenuItemElement1 = MenuItemElements.first();
+        assert.equal(MenuItemElement1.prop('value'), 'M');
+        assert.deepEqual(MenuItemElement1.prop('primaryText'), <Foobar record={{ id: 'M', foobar: 'Male' }} />);
+    });
 });

--- a/src/mui/input/index.js
+++ b/src/mui/input/index.js
@@ -1,3 +1,4 @@
+export AutocompleteInput from './AutocompleteInput';
 export BooleanInput from './BooleanInput';
 export DateInput from './DateInput';
 export DisabledInput from './DisabledInput';

--- a/src/mui/list/FilterForm.js
+++ b/src/mui/list/FilterForm.js
@@ -32,6 +32,7 @@ export class FilterForm extends Component {
                         }
                         <div style={{ display: 'inline-block' }}>
                             <Field
+                                allowEmpty
                                 {...filterElement.props}
                                 name={filterElement.props.source}
                                 component={filterElement.type}

--- a/src/reducer/references/possibleValues.js
+++ b/src/reducer/references/possibleValues.js
@@ -7,7 +7,7 @@ export default (previousState = initialState, { type, payload, meta }) => {
     case CRUD_GET_MATCHING_SUCCESS:
         return {
             ...previousState,
-            [meta.relatedTo]: payload.map(record => record.id),
+            [meta.relatedTo]: payload.data.map(record => record.id),
         };
     default:
         return previousState;

--- a/src/reducer/resource/data.js
+++ b/src/reducer/resource/data.js
@@ -77,9 +77,9 @@ export default (resource) => (previousState = initialState, { type, payload, met
     }
     switch (type) {
     case CRUD_GET_LIST_SUCCESS:
+    case CRUD_GET_MATCHING_SUCCESS:
         return addRecords(payload.data, previousState);
     case CRUD_GET_MANY_SUCCESS:
-    case CRUD_GET_MATCHING_SUCCESS:
     case CRUD_GET_MANY_REFERENCE_SUCCESS:
         return addRecords(payload, previousState);
     case CRUD_UPDATE: // replace record in edit form with edited one to avoid displaying previous record version

--- a/src/rest/jsonServer.js
+++ b/src/rest/jsonServer.js
@@ -1,7 +1,6 @@
 import { queryParameters, fetchJson } from '../util/fetch';
 import {
     GET_LIST,
-    GET_MATCHING,
     GET_ONE,
     GET_MANY,
     GET_MANY_REFERENCE,
@@ -16,7 +15,6 @@ import {
  * @see https://github.com/typicode/json-server
  * @example
  * GET_LIST     => GET http://my.api.url/posts?_sort=title&_order=ASC&_start=0&_end=24
- * GET_MATCHING => GET http://my.api.url/posts?title=bar
  * GET_ONE      => GET http://my.api.url/posts/123
  * GET_MANY     => GET http://my.api.url/posts/123, GET http://my.api.url/posts/456, GET http://my.api.url/posts/789
  * UPDATE       => PUT http://my.api.url/posts/123
@@ -34,8 +32,7 @@ export default (apiUrl, httpClient = fetchJson) => {
         let url = '';
         const options = {};
         switch (type) {
-        case GET_LIST:
-        case GET_MATCHING: {
+        case GET_LIST: {
             const { page, perPage } = params.pagination;
             const { field, order } = params.sort;
             const query = {

--- a/src/rest/jsonServer.js
+++ b/src/rest/jsonServer.js
@@ -34,7 +34,8 @@ export default (apiUrl, httpClient = fetchJson) => {
         let url = '';
         const options = {};
         switch (type) {
-        case GET_LIST: {
+        case GET_LIST:
+        case GET_MATCHING: {
             const { page, perPage } = params.pagination;
             const { field, order } = params.sort;
             const query = {
@@ -45,10 +46,6 @@ export default (apiUrl, httpClient = fetchJson) => {
                 _end: page * perPage,
             };
             url = `${apiUrl}/${resource}?${queryParameters(query)}`;
-            break;
-        }
-        case GET_MATCHING: {
-            url = `${apiUrl}/${resource}?${queryParameters(params.filter)}`;
             break;
         }
         case GET_ONE:

--- a/src/rest/simple.js
+++ b/src/rest/simple.js
@@ -1,7 +1,6 @@
 import { queryParameters, fetchJson } from '../util/fetch';
 import {
     GET_LIST,
-    GET_MATCHING,
     GET_ONE,
     GET_MANY,
     GET_MANY_REFERENCE,
@@ -17,7 +16,6 @@ import {
  * @see https://github.com/marmelab/FakeRest
  * @example
  * GET_LIST     => GET http://my.api.url/posts?sort=['title','ASC']&range=[0, 24]
- * GET_MATCHING => GET http://my.api.url/posts?filter={title:'bar'}
  * GET_ONE      => GET http://my.api.url/posts/123
  * GET_MANY     => GET http://my.api.url/posts?filter={ids:[123,456,789]}
  * UPDATE       => PUT http://my.api.url/posts/123
@@ -35,8 +33,7 @@ export default (apiUrl, httpClient = fetchJson) => {
         let url = '';
         const options = {};
         switch (type) {
-        case GET_LIST:
-        case GET_MATCHING: {
+        case GET_LIST: {
             const { page, perPage } = params.pagination;
             const { field, order } = params.sort;
             const query = {

--- a/src/rest/simple.js
+++ b/src/rest/simple.js
@@ -35,19 +35,13 @@ export default (apiUrl, httpClient = fetchJson) => {
         let url = '';
         const options = {};
         switch (type) {
-        case GET_LIST: {
+        case GET_LIST:
+        case GET_MATCHING: {
             const { page, perPage } = params.pagination;
             const { field, order } = params.sort;
             const query = {
                 sort: JSON.stringify([field, order]),
                 range: JSON.stringify([(page - 1) * perPage, (page * perPage) - 1]),
-                filter: JSON.stringify(params.filter),
-            };
-            url = `${apiUrl}/${resource}?${queryParameters(query)}`;
-            break;
-        }
-        case GET_MATCHING: {
-            const query = {
                 filter: JSON.stringify(params.filter),
             };
             url = `${apiUrl}/${resource}?${queryParameters(query)}`;

--- a/src/rest/types.js
+++ b/src/rest/types.js
@@ -1,5 +1,4 @@
 export const GET_LIST = 'GET_LIST';
-export const GET_MATCHING = 'GET_MATCHING';
 export const GET_ONE = 'GET_ONE';
 export const GET_MANY = 'GET_MANY';
 export const GET_MANY_REFERENCE = 'GET_MANY_REFERENCE';


### PR DESCRIPTION
- [x] Add `<AutocompleteInput>` field (Closes #70)
- [x] Use it in the blog example
- [x] [BC Break] Add a limit to the fetching of `<ReferenceInput>` (set to 25 by default)
- [x] Add a `perPage` prop to `<ReferenceInput>` to allow fetching more or less options
- [x] Add a `sort` prop to `<ReferenceInput>` to allow sorting of options
- [x] Add doc
- [x] Add tests
- [x] [BC Break] Remove `GET_MATCHING` REST verb (and merge with `GET_LIST`)
- [x] `optionText` accepts a function in `<SelectInput>`, `<RadioButtonGroupInput>`, and `<AutocompleteInput>`
- [x] `optionText` accepts an element in `<SelectInput>`, and `<RadioButtonGroupInput>`
- [x] Fix bad setup of `ReferenceInput` value in filters
- [x] Set `allowEmpty` to true by default in `Filter` form (was breaking `<ReferenceInput>` in filters by default)