### PR TITLE
[RFR] Make custom input components easier

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -687,7 +687,7 @@ const LatLngInput = () => (
 
 For more details on how to use redux-form's `<Field>` component, please refer to [the redux-form doc](http://redux-form.com/6.4.3/docs/api/Field.md/).
 
-**Tip**: If you only need one `<Field>` component in a custom input, you can let admin-on-rest do the `<Field>` decoration for you by setting the `requiresField: true` default prop:
+**Tip**: If you only need one `<Field>` component in a custom input, you can let admin-on-rest do the `<Field>` decoration for you by setting the `includesField` default prop to `false`:
 
 ```js
 // in PersonEdit.js
@@ -712,8 +712,8 @@ const SexInput = ({ input, meta: { touched, error } }) => (
     </SelectField>
 );
 SexInput.defaultProps = {
+    includesField: false, // require a <Field> decoration
     includesLabel: true,
-    requiresField: true, // require a <Field> decoration
 }
 export default SexInput;
 
@@ -739,6 +739,6 @@ SexInput.defaultProps = {
 export default SexInput;
 ```
 
-Most admin-on-rest input components use `requiresField: true` in default props.
+Most admin-on-rest input components use `includeField: false` in default props.
 
 **Tip**: `<Field>` injects two props to its child component: `input` and `meta`. To learn more about these props, please refer to [the `<Field>` component documentation](http://redux-form.com/6.4.3/docs/api/Field.md/#props) in the redux-form website.

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -208,7 +208,7 @@ import { DisabledInput } from 'admin-on-rest/lib/mui';
 
 ```js
 // in src/posts.js
-import { Edit, DisabledInput, LongTextInput, TextField, TextInput } from 'admin-on-rest/lib/mui';
+import { Edit, LongTextInput, TextField } from 'admin-on-rest/lib/mui';
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -222,7 +222,7 @@ export const PostEdit = (props) => (
 
 ```js
 // in src/posts.js
-import { Edit, DisabledInput, LongTextInput, TextInput } from 'admin-on-rest/lib/mui';
+import { Edit, LongTextInput } from 'admin-on-rest/lib/mui';
 const titleStyle = { textOverflow: 'ellipsis', overflow: 'hidden', maxWidth: '20em' };
 const Title = ({ record }) => <span style={titleStyle}>{record.title}</span>;
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -60,7 +60,7 @@ Then you can display a text input to edit the author first name as follows:
 To let users choose a value in a list using a dropdown with autocompletion, use `<AutocompleteInput>`. It renders using [Material ui's `<AutoComplete>` component](http://www.material-ui.com/#/components/auto-complete) and a `fuzzySearch` filter. Set the `choices` attribute to determine the options list (with `id`, `name` tuples).
 
 ```js
-import { Edit, AutocompleteInput } from 'admin-on-rest/mui';
+import { Edit, AutocompleteInput } from 'admin-on-rest/lib/mui';
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -97,7 +97,7 @@ const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
 You can customize the `filter` function used to filter the results. By default, it's `AutoComplete.fuzzyFilter`, but you can use any of [the functions provided by `AutoComplete`](http://www.material-ui.com/#/components/auto-complete), or a function of your own (`(searchText: string, key: string) => boolean`):
 
 ```js
-import { Edit, AutocompleteInput } from 'admin-on-rest/mui';
+import { Edit, AutocompleteInput } from 'admin-on-rest/lib/mui';
 import AutoComplete from 'material-ui/AutoComplete';
 
 export const PostEdit = (props) => (
@@ -123,7 +123,7 @@ Refer to [Material UI Autocomplete documentation](http://www.material-ui.com/#/c
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<AutocompleteInput>` with [`<ReferenceInput>`](#referenceinput), and leave the `choices` empty:
 
 ```js
-import { Edit, AutocompleteInput, ReferenceInput } from 'admin-on-rest/mui'
+import { Edit, AutocompleteInput, ReferenceInput } from 'admin-on-rest/lib/mui'
 
 export const CommentEdit = (props) => (
     <Edit {...props}>
@@ -143,7 +143,7 @@ export const CommentEdit = (props) => (
 `<BooleanInput />` is a toggle button allowing you to attribute a `true` or `false` value to a record field.
 
 ``` js
-import { BooleanInput } from 'admin-on-rest/mui';
+import { BooleanInput } from 'admin-on-rest/lib/mui';
 
 <BooleanInput label="Allow comments?" source="commentable" />
 ```
@@ -155,7 +155,7 @@ This input does not handle `null` values. You would need the `<NullableBooleanIn
 `<NullableBooleanInput />` renders as a dropdown list, allowing to choose between true, false, and null values.
 
 ``` js
-import { NullableBooleanInput } from 'admin-on-rest/mui';
+import { NullableBooleanInput } from 'admin-on-rest/lib/mui';
 
 <NullableBooleanInput label="Allow comments?" source="commentable" />
 ```
@@ -167,7 +167,7 @@ import { NullableBooleanInput } from 'admin-on-rest/mui';
 Ideal for editing dates, `<DateInput>` renders a beautiful [Date Picker](http://www.material-ui.com/#/components/date-picker) with full localization support.
 
 ``` js
-import { DateInput } from 'admin-on-rest/mui';
+import { DateInput } from 'admin-on-rest/lib/mui';
 
 <DateInput source="published_at" />
 ```
@@ -197,19 +197,49 @@ Refer to [Material UI Datepicker documentation](http://www.material-ui.com/#/com
 When you want to display a record property in an `<Edit>` form without letting users update it (such as for auto-incremented primary keys), use the `<DisabledInput>`:
 
 ``` js
-import { DisabledInput } from 'admin-on-rest/mui';
+import { DisabledInput } from 'admin-on-rest/lib/mui';
 
 <DisabledInput source="id" />
 ```
 
 ![DisabledInput](./img/disabled-input.png)
 
+**Tip**: To add non-editable fields to the `<Edit>` view, you can also use one of admin-on-rest `Field` components:
+
+```js
+// in src/posts.js
+import { Edit, DisabledInput, LongTextInput, TextField, TextInput } from 'admin-on-rest/lib/mui';
+
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <TextField source="title" /> {/* NOT EDITABLE */}
+        <LongTextInput source="body" />
+    </Edit>
+);
+```
+
+**Tip**: You can even use a component of your own, provided it accepts `record` and `label` props:
+
+```js
+// in src/posts.js
+import { Edit, DisabledInput, LongTextInput, TextInput } from 'admin-on-rest/lib/mui';
+const titleStyle = { textOverflow: 'ellipsis', overflow: 'hidden', maxWidth: '20em' };
+const Title = ({ record }) => <span style={titleStyle}>{record.title}</span>;
+
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <Title label="Title" />
+        <LongTextInput source="body" />
+    </Edit>
+);
+```
+
 ## `<LongTextInput>`
 
 `<LongTextInput>` is the best choice for multiline text values. It renders as an auto expandable textarea.
 
 ``` js
-import { LongTextInput } from 'admin-on-rest/mui';
+import { LongTextInput } from 'admin-on-rest/lib/mui';
 
 <LongTextInput source="teaser" />
 ```
@@ -221,7 +251,7 @@ import { LongTextInput } from 'admin-on-rest/mui';
 `<NumberInput>` translates to a HTMl `<input type="number">`. It is necessary for numeric values because of a [known React bug](https://github.com/facebook/react/issues/1425), which prevents using the more generic [`<TextInput>`](#textinput) in that case.
 
 ``` js
-import { NumberInput } from 'admin-on-rest/mui';
+import { NumberInput } from 'admin-on-rest/lib/mui';
 
 <NumberInput source="nb_views" />
 ```
@@ -237,7 +267,7 @@ You can customize the `step` props (which defaults to "any"):
 If you want to let the user choose a value among a list of possible values by showing them all (instead of hiding them behind a dropdown list, as in [`<SelectInput>`](#selectinput)), `<RadioButtonGroupInput>` is the right component. Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
 ```js
-import { Edit, RadioButtonGroupInput } from 'admin-on-rest/mui';
+import { Edit, RadioButtonGroupInput } from 'admin-on-rest/lib/mui';
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -299,7 +329,7 @@ Refer to [Material UI SelectField documentation](http://www.material-ui.com/#/co
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<RadioButtonGroupInput>` with [`<ReferenceInput>`](#referenceinput), and leave the `choices` empty:
 
 ```js
-import { Edit, RadioButtonGroupInput, ReferenceInput } from 'admin-on-rest/mui'
+import { Edit, RadioButtonGroupInput, ReferenceInput } from 'admin-on-rest/lib/mui'
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -319,7 +349,7 @@ This means you can use `<ReferenceInput>` with any of [`<SelectInput>`](#selecti
 The component expects a `source` and a `reference` attributes. For instance, to make the `post_id` for a `comment` editable:
 
 ```js
-import { ReferenceInput, SelectInput } from 'admin-on-rest/mui'
+import { ReferenceInput, SelectInput } from 'admin-on-rest/lib/mui'
 
 export const CommentEdit = (props) => (
     <Edit {...props}>
@@ -337,7 +367,7 @@ export const CommentEdit = (props) => (
 Set the `allowEmpty` prop when the empty value is allowed.
 
 ```js
-import { ReferenceInput, SelectInput } from 'admin-on-rest/mui'
+import { ReferenceInput, SelectInput } from 'admin-on-rest/lib/mui'
 
 <ReferenceInput label="Post" source="post_id" reference="posts" allowEmpty>
     <SelectInput optionText="title" />
@@ -407,7 +437,7 @@ The enclosed component may further filter results (that's the case, for instance
 is powered by [Quill](https://quilljs.com/).
 
 ``` js
-import { RichTextInput } from 'admin-on-rest/mui';
+import { RichTextInput } from 'admin-on-rest/lib/mui';
 
 <RichTextInput source="body" />
 ```
@@ -425,7 +455,7 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 To let users choose a value in a list using a dropdown, use `<SelectInput>`. It renders using [Material ui's `<SelectField>`](http://www.material-ui.com/#/components/select-field). Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
 ```js
-import { Edit, SelectInput } from 'admin-on-rest/mui';
+import { Edit, SelectInput } from 'admin-on-rest/lib/mui';
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -497,7 +527,7 @@ Refer to [Material UI SelectField documentation](http://www.material-ui.com/#/co
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<SelectInput>` with [`<ReferenceInput>`](#referenceinput), and leave the `choices` empty:
 
 ```js
-import { Edit, SelectInput, ReferenceInput } from 'admin-on-rest/mui'
+import { Edit, SelectInput, ReferenceInput } from 'admin-on-rest/lib/mui'
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -515,7 +545,7 @@ If, instead of showing choices as a dropdown list, you prefer to display them as
 `<TextInput>` is the most common input. It is used for texts, emails, URL or passwords. In translates to an HTML `<input>` tag.
 
 ``` js
-import { TextInput } from 'admin-on-rest/mui';
+import { TextInput } from 'admin-on-rest/lib/mui';
 
 <TextInput source="title" />
 ```
@@ -532,33 +562,183 @@ You can choose a specific input type using the `type` attribute, for instance `t
 
 ## Writing Your Own Input Component
 
-If you need a more specific input type, you can also write it yourself. In addition to `source` and `label` attributes, it must accept an `input` attribute to integrate with admin-on-rest forms (powered by redux-form). Admin-on-rest will inject the `input` attribute at runtime, and it will contain a `value` (computed from the current record and source), and an `onChange` function (to manage the input).
+If you need a more specific input type, you can also write it yourself. You'll have to rely on redux-form's [`<Field>`](http://redux-form.com/6.4.3/docs/api/Field.md/) component, so as to handle the value update cycle.
 
-For instance, here is an simplified version of admin-on-rest's `<TextInput>` component:
+For instance, let's write a component to edit the latitude and longitude of the current record:
 
 ```js
-import React, { PropTypes } from 'react';
-
-const TextInput = ({ source, label, input }) => (
+// in LatLongInput.js
+import { Field } from 'redux-form';
+const LatLngInput = () => (
     <span>
-        <label for={source}>{label}</label>
-        <input name={source} value={input.value} onChange={input.onChange} type="text" />
+        <Field name="lat" component="input" type="number" placeholder="latitude" />
+        &nbsp;
+        <Field name="lng" component="input" tyle="number" placeholder="longitude" />
     </span>
 );
+export default LatLngInput;
 
-TextInput.propTypes = {
-    includesLabel: PropTypes.bool.isRequired,
-    input: PropTypes.object,
-    label: PropTypes.string,
-    onChange: PropTypes.func,
-    source: PropTypes.string.isRequired,
-};
-
-TextInput.defaultProps = {
-    includesLabel: true,
-};
-
-export default TextInput;
+// in ItemEdit.js
+const ItemEdit = (props) => (
+    <Edit {...props}>
+        <LatLngInput label="Position" />
+    </Edit>
+);
 ```
 
-**Tip**: Admin-on-rest inspects the `includesLabel` attribute to determine whether to render an additional label on top of the input component or not. If `includesLabel` is false, admin-on-rest considers the components doesn't have its own label, and adds another one.
+`LatLngInput` takes no props, because the `<Field>` component can access the current record via its context. The `name` prop serves as a selector for the record property to edit. All `Field` props except `name` and `component` are passed to the child component/element (an `<input>` in that example). Executing this component will render roughly the following code:
+
+```html
+<label>Position</label>
+<span>
+    <input type="number" placeholder="longitude" value={record.lat} />
+    <input type="number" placeholder="longitude" value={record.lng} />
+</span>
+```
+
+**Tip**: Although the `LatLngInput` component doesn't specify a `label` prop, admin-on-rest uses it to create a label on top of the input. If your component already includes a label, you can disable this behavior by setting `includesLabel: true` in the default props:
+
+```js
+// in LatLongInput.js
+import { Field } from 'redux-form';
+const LatLngInput = () => (
+    <div>
+        <div>Position</div>
+        <Field name="lat" component="input" type="number" placeholder="latitude" />
+        &nbsp;
+        <Field name="lng" component="input" tyle="number" placeholder="longitude" />
+    </div>
+);
+LatLngInput.defaultProps = {
+    includesLabel: true,
+};
+export default LatLngInput;
+
+// in ItemEdit.js
+const ItemEdit = (props) => (
+    <Edit {...props}>
+        <LatLngInput />
+    </Edit>
+);
+```
+
+**Tip**: The `<Field>` component supports dot notation in the `name` prop, to edit nested props:
+
+```js
+const LatLongInput = () => (
+    <span>
+        <Field name="position.lat" component="input" type="number" placeholder="latitude" />
+        &nbsp;
+        <Field name="position.lng" component="input" tyle="number" placeholder="longitude" />
+    </span>
+);
+```
+
+Instead of HTML `input` elements, you can use admin-on-rest components in `<Field>`. For instance, `<NumberInput>`:
+
+```js
+// in LatLongInput.js
+import { Field } from 'redux-form';
+import { NumberInput } from 'admin-on-rest/lib/mui';
+const LatLngInput = () => (
+    <span>
+        <Field name="lat" component={NumberInput} label="latitude" />
+        &nbsp;
+        <Field name="lng" component={NumberInput} label="longitude" />
+    </span>
+);
+LatLngInput.defaultProps = {
+    includesLabel: true,
+};
+export default LatLngInput;
+
+// in ItemEdit.js
+const ItemEdit = (props) => (
+    <Edit {...props}>
+        <DisabledInput source="id" />
+        <LatLngInput />
+    </Edit>
+);
+```
+
+`<NumberInput>` receives the props passed to the `<Field>` componeny - `label` in the example. Since the `lat` and `lng` inputs are labeled, no need to label the `<LanLngInput>` component - that's with the `includesLabel` default prop is set to `true`.
+
+**Tip**: If you need to pass a material ui component to `Field`, use a [field renderer function](http://redux-form.com/6.4.3/examples/material-ui/) to map the props:
+
+```js
+import TextField from 'material-ui/TextField';
+const renderTextField = ({ input, label, meta: { touched, error }, ...custom }) => (
+    <TextField
+        hintText={label}
+        floatingLabelText={label}
+        errorText={touched && error}
+        {...input}
+        {...custom}
+    />
+);
+const LatLngInput = () => (
+    <span>
+        <Field name="lat" component={renderTextField} label="latitude" />
+        &nbsp;
+        <Field name="lng" component={renderTextField} label="longitude" />
+    </span>
+);
+```
+
+For more details on how to use redux-form's `<Field>` component, please refer to [the redux-form doc](http://redux-form.com/6.4.3/docs/api/Field.md/).
+
+**Tip**: If you only need one `<Field>` component in a custom input, you can let admin-on-rest do the `<Field>` decoration for you by setting the `requiresField: true` default prop:
+
+```js
+// in PersonEdit.js
+import SexInput from './SexInput.js';
+const PersonEdit = (props) => (
+    <Edit {...props}>
+        <SexInput source="sex" />
+    </Edit>
+);
+
+// in SexInput.js
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+const SexInput = ({ input, meta: { touched, error } }) => (
+    <SelectField
+        floatingLabelText="Sex"
+        errorText={touched && error}
+        {...input}
+    >
+        <MenuItem value="M" primaryText="Male" />
+        <MenuItem value="F" primaryText="Female" />
+    </SelectField>
+);
+SexInput.defaultProps = {
+    includesLabel: true,
+    requiresField: true, // require a <Field> decoration
+}
+export default SexInput;
+
+// equivalent of
+
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+import { Field } from 'redux-form';
+const renderSexInput = ({ input, meta: { touched, error } }) => (
+    <SelectField
+        floatingLabelText="Sex"
+        errorText={touched && error}
+        {...input}
+    >
+        <MenuItem value="M" primaryText="Male" />
+        <MenuItem value="F" primaryText="Female" />
+    </SelectField>
+);
+const SexInput = ({ source }) => <Field name={source} component={renderSexInput} />
+SexInput.defaultProps = {
+    includesLabel: true,
+}
+export default SexInput;
+```
+
+Most admin-on-rest input components use `requiresField: true` in default props.
+
+**Tip**: `<Field>` injects two props to its child component: `input` and `meta`. To learn more about these props, please refer to [the `<Field>` component documentation](http://redux-form.com/6.4.3/docs/api/Field.md/#props) in the redux-form website.

--- a/src/mui/detail/RecordForm.js
+++ b/src/mui/detail/RecordForm.js
@@ -55,7 +55,7 @@ export const RecordForm = ({ children, handleSubmit, record, resource, basePath 
         <div style={{ padding: '0 1em 1em 1em' }}>
             {React.Children.map(children, input => (
                 <div key={input.props.source} style={input.props.style}>
-                    { input.props.requiresField ?
+                    { input.props.includesField === false ?
                         (input.props.includesLabel ?
                             <Field
                                 {...input.props}

--- a/src/mui/detail/RecordForm.js
+++ b/src/mui/detail/RecordForm.js
@@ -55,25 +55,32 @@ export const RecordForm = ({ children, handleSubmit, record, resource, basePath 
         <div style={{ padding: '0 1em 1em 1em' }}>
             {React.Children.map(children, input => (
                 <div key={input.props.source} style={input.props.style}>
-                    { input.props.includesLabel ?
-                        <Field
-                            {...input.props}
-                            name={input.props.source}
-                            component={input.type}
-                            resource={resource}
-                            record={record}
-                            basePath={basePath}
-                        />
-                        :
-                        <Field
-                            {...input.props}
-                            name={input.props.source}
-                            component={Labeled}
-                            label={input.props.label}
-                            resource={resource}
-                            record={record}
-                            basePath={basePath}
-                        >{ input }</Field>
+                    { input.props.requiresField ?
+                        (input.props.includesLabel ?
+                            <Field
+                                {...input.props}
+                                name={input.props.source}
+                                component={input.type}
+                                resource={resource}
+                                record={record}
+                                basePath={basePath}
+                            />
+                            :
+                            <Field
+                                {...input.props}
+                                name={input.props.source}
+                                component={Labeled}
+                                label={input.props.label}
+                                resource={resource}
+                                record={record}
+                                basePath={basePath}
+                            >{ input }</Field>
+                        ) :
+                        (input.props.includesLabel ?
+                            React.cloneElement(input, { resource, record, basePath }) :
+                            <Labeled label={input.props.label} source={input.props.source} resource={resource} record={record} basePath={basePath}>{input}</Labeled>
+
+                        )
                     }
                 </div>
             ))}

--- a/src/mui/detail/RecordForm.js
+++ b/src/mui/detail/RecordForm.js
@@ -50,48 +50,35 @@ export const validateForm = (values, { children, validation }) => {
     return errors;
 };
 
-export const RecordForm = ({ children, handleSubmit, record, resource, basePath }) => (
-    <form onSubmit={handleSubmit}>
-        <div style={{ padding: '0 1em 1em 1em' }}>
-            {React.Children.map(children, input => (
-                <div key={input.props.source} style={input.props.style}>
-                    { input.props.includesField === false ?
-                        (input.props.includesLabel ?
-                            <Field
-                                {...input.props}
-                                name={input.props.source}
-                                component={input.type}
-                                resource={resource}
-                                record={record}
-                                basePath={basePath}
-                            />
-                            :
-                            <Field
-                                {...input.props}
-                                name={input.props.source}
-                                component={Labeled}
-                                label={input.props.label}
-                                resource={resource}
-                                record={record}
-                                basePath={basePath}
-                            >{ input }</Field>
-                        ) :
-                        (input.props.includesLabel ?
-                            React.cloneElement(input, { resource, record, basePath }) :
-                            <Labeled label={input.props.label} source={input.props.source} resource={resource} record={record} basePath={basePath}>{input}</Labeled>
+export const RecordForm = ({ children, handleSubmit, record, resource, basePath }) => {
+    const commonProps = { resource, record, basePath };
+    return (
+        <form onSubmit={handleSubmit}>
+            <div style={{ padding: '0 1em 1em 1em' }}>
+                {React.Children.map(children, input => (
+                    <div key={input.props.source} style={input.props.style}>
+                        { input.props.includesField === false ?
+                            (input.props.includesLabel ?
+                                <Field {...commonProps} {...input.props} name={input.props.source} component={input.type} /> :
+                                <Field {...commonProps} {...input.props} name={input.props.source} component={Labeled} label={input.props.label}>{ input }</Field>
+                            ) :
+                            (input.props.includesLabel ?
+                                React.cloneElement(input, commonProps) :
+                                <Labeled {...commonProps} label={input.props.label} source={input.props.source}>{input}</Labeled>
 
-                        )
-                    }
-                </div>
-            ))}
-        </div>
-        <Toolbar>
-            <ToolbarGroup>
-                <SaveButton />
-            </ToolbarGroup>
-        </Toolbar>
-    </form>
-);
+                            )
+                        }
+                    </div>
+                ))}
+            </div>
+            <Toolbar>
+                <ToolbarGroup>
+                    <SaveButton />
+                </ToolbarGroup>
+            </Toolbar>
+        </form>
+    );
+};
 
 RecordForm.propTypes = {
     children: PropTypes.node,

--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -93,6 +93,7 @@ AutocompleteInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
     elStyle: PropTypes.object,
     filter: PropTypes.func.isRequired,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
@@ -103,7 +104,6 @@ AutocompleteInput.propTypes = {
         PropTypes.func,
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
-    requiresField: PropTypes.bool.isRequired,
     setFilter: PropTypes.func,
     source: PropTypes.string,
 };
@@ -111,11 +111,11 @@ AutocompleteInput.propTypes = {
 AutocompleteInput.defaultProps = {
     choices: [],
     filter: AutoComplete.fuzzyFilter,
+    includesField: false,
+    includesLabel: true,
     options: {},
     optionText: 'name',
     optionValue: 'id',
-    includesLabel: true,
-    requiresField: true,
 };
 
 export default AutocompleteInput;

--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -103,6 +103,7 @@ AutocompleteInput.propTypes = {
         PropTypes.func,
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
     setFilter: PropTypes.func,
     source: PropTypes.string,
 };
@@ -114,6 +115,7 @@ AutocompleteInput.defaultProps = {
     optionText: 'name',
     optionValue: 'id',
     includesLabel: true,
+    requiresField: true,
 };
 
 export default AutocompleteInput;

--- a/src/mui/input/BooleanInput.js
+++ b/src/mui/input/BooleanInput.js
@@ -29,16 +29,16 @@ const BooleanInput = ({ input, label, source, elStyle }) => (
 
 BooleanInput.propTypes = {
     elStyle: PropTypes.object,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
 };
 
 BooleanInput.defaultProps = {
+    includesField: false,
     includesLabel: true,
-    requiresField: true,
 };
 
 export default BooleanInput;

--- a/src/mui/input/BooleanInput.js
+++ b/src/mui/input/BooleanInput.js
@@ -32,11 +32,13 @@ BooleanInput.propTypes = {
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
-    source: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
+    source: PropTypes.string,
 };
 
 BooleanInput.defaultProps = {
     includesLabel: true,
+    requiresField: true,
 };
 
 export default BooleanInput;

--- a/src/mui/input/DateInput.js
+++ b/src/mui/input/DateInput.js
@@ -38,19 +38,19 @@ class DateInput extends Component {
 
 DateInput.propTypes = {
     elStyle: PropTypes.object,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
     options: PropTypes.object,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
 };
 
 DateInput.defaultProps = {
+    includesField: false,
     includesLabel: true,
     options: {},
-    requiresField: true,
 };
 
 export default DateInput;

--- a/src/mui/input/DateInput.js
+++ b/src/mui/input/DateInput.js
@@ -43,12 +43,14 @@ DateInput.propTypes = {
     label: PropTypes.string,
     meta: PropTypes.object,
     options: PropTypes.object,
-    source: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
+    source: PropTypes.string,
 };
 
 DateInput.defaultProps = {
     includesLabel: true,
     options: {},
+    requiresField: true,
 };
 
 export default DateInput;

--- a/src/mui/input/DisabledInput.js
+++ b/src/mui/input/DisabledInput.js
@@ -1,18 +1,19 @@
 import React, { PropTypes } from 'react';
 import TextField from 'material-ui/TextField';
+import get from 'lodash.get';
 import title from '../../util/title';
 
-const DisabledInput = ({ input, label, source }) => <TextField
-    value={input.value}
+const DisabledInput = ({ label, record, source }) => <TextField
+    value={get(record, source)}
     floatingLabelText={title(label, source)}
     disabled
 />;
 
 DisabledInput.propTypes = {
     includesLabel: PropTypes.bool,
-    input: PropTypes.object,
     label: PropTypes.string,
-    source: PropTypes.string.isRequired,
+    record: PropTypes.object,
+    source: PropTypes.string,
 };
 
 DisabledInput.defaultProps = {

--- a/src/mui/input/Labeled.js
+++ b/src/mui/input/Labeled.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import TextField from 'material-ui/TextField';
 import title from '../../util/title';
 
@@ -18,18 +18,26 @@ const defaultLabelStyle = {
  *     <FooComponent source="title" />
  * </Labeled>
  */
-const Labeled = ({ input, label, resource, record, onChange, basePath, children, source, disabled = true, labelStyle = defaultLabelStyle }) => (
-    <TextField
-        floatingLabelText={title(label, source)}
-        floatingLabelFixed
-        fullWidth
-        disabled={disabled}
-        underlineShow={false}
-        style={labelStyle}
-    >
-        {children && React.cloneElement(children, { input, record, resource, onChange, basePath })}
-    </TextField>
-);
+class Labeled extends Component {
+    render() {
+        const { input, label, resource, record, onChange, basePath, children, source, disabled = true, labelStyle = defaultLabelStyle } = this.props;
+        if (!label && !source) {
+            throw new Error(`Cannot create label for component <${children && children.type && children.type.name}>: You must set either the label or source props. You can also disable automated label insertion by setting 'includesLabel: true' in the component default props`);
+        }
+        return (
+            <TextField
+                floatingLabelText={title(label, source)}
+                floatingLabelFixed
+                fullWidth
+                disabled={disabled}
+                underlineShow={false}
+                style={labelStyle}
+            >
+                {children && React.cloneElement(children, { input, record, resource, onChange, basePath })}
+            </TextField>
+        );
+    }
+}
 
 Labeled.propTypes = {
     basePath: PropTypes.string,
@@ -40,8 +48,12 @@ Labeled.propTypes = {
     onChange: PropTypes.func,
     record: PropTypes.object,
     resource: PropTypes.string,
-    source: PropTypes.string.isRequired,
+    source: PropTypes.string,
     labelStyle: PropTypes.object,
+};
+
+Labeled.defaultProps = {
+    includesLabel: true,
 };
 
 export default Labeled;

--- a/src/mui/input/LongTextInput.js
+++ b/src/mui/input/LongTextInput.js
@@ -16,21 +16,21 @@ const LongTextInput = ({ input, label, meta: { touched, error }, options, source
 
 LongTextInput.propTypes = {
     elStyle: PropTypes.object,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
     name: PropTypes.string,
     options: PropTypes.object,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
     validation: PropTypes.object,
 };
 
 LongTextInput.defaultProps = {
+    includesField: false,
     includesLabel: true,
     options: {},
-    requiresField: true,
 };
 
 export default LongTextInput;

--- a/src/mui/input/LongTextInput.js
+++ b/src/mui/input/LongTextInput.js
@@ -22,13 +22,15 @@ LongTextInput.propTypes = {
     meta: PropTypes.object,
     name: PropTypes.string,
     options: PropTypes.object,
-    source: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
+    source: PropTypes.string,
     validation: PropTypes.object,
 };
 
 LongTextInput.defaultProps = {
     includesLabel: true,
     options: {},
+    requiresField: true,
 };
 
 export default LongTextInput;

--- a/src/mui/input/NullableBooleanInput.js
+++ b/src/mui/input/NullableBooleanInput.js
@@ -18,17 +18,17 @@ const NullableBooleanInput = ({ input, meta: { touched, error }, label, source, 
 
 NullableBooleanInput.propTypes = {
     elStyle: PropTypes.object,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
 };
 
 NullableBooleanInput.defaultProps = {
+    includesField: false,
     includesLabel: true,
-    requiresField: true,
 };
 
 export default NullableBooleanInput;

--- a/src/mui/input/NullableBooleanInput.js
+++ b/src/mui/input/NullableBooleanInput.js
@@ -22,11 +22,13 @@ NullableBooleanInput.propTypes = {
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
-    source: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
+    source: PropTypes.string,
 };
 
 NullableBooleanInput.defaultProps = {
     includesLabel: true,
+    requiresField: true,
 };
 
 export default NullableBooleanInput;

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -43,6 +43,7 @@ class NumberInput extends Component {
 
 NumberInput.propTypes = {
     elStyle: PropTypes.object,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
@@ -50,16 +51,15 @@ NumberInput.propTypes = {
     name: PropTypes.string,
     onChange: PropTypes.func,
     options: PropTypes.object,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
     step: PropTypes.string.isRequired,
     validation: PropTypes.object,
 };
 
 NumberInput.defaultProps = {
+    includesField: false,
     includesLabel: true,
     options: {},
-    requiresField: true,
     step: 'any',
 };
 

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -50,7 +50,8 @@ NumberInput.propTypes = {
     name: PropTypes.string,
     onChange: PropTypes.func,
     options: PropTypes.object,
-    source: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
+    source: PropTypes.string,
     step: PropTypes.string.isRequired,
     validation: PropTypes.object,
 };
@@ -58,6 +59,7 @@ NumberInput.propTypes = {
 NumberInput.defaultProps = {
     includesLabel: true,
     options: {},
+    requiresField: true,
     step: 'any',
 };
 

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -89,16 +89,18 @@ RadioButtonGroupInput.propTypes = {
         PropTypes.element,
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
     style: PropTypes.object,
 };
 
 RadioButtonGroupInput.defaultProps = {
     choices: [],
+    includesLabel: true,
     options: {},
     optionText: 'name',
     optionValue: 'id',
-    includesLabel: true,
+    requiresField: true,
 };
 
 export default RadioButtonGroupInput;

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -79,6 +79,7 @@ class RadioButtonGroupInput extends Component {
 
 RadioButtonGroupInput.propTypes = {
     choices: PropTypes.arrayOf(PropTypes.object),
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     label: PropTypes.string,
     onChange: PropTypes.func,
@@ -89,18 +90,17 @@ RadioButtonGroupInput.propTypes = {
         PropTypes.element,
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
     style: PropTypes.object,
 };
 
 RadioButtonGroupInput.defaultProps = {
     choices: [],
+    includesField: false,
     includesLabel: true,
     options: {},
     optionText: 'name',
     optionValue: 'id',
-    requiresField: true,
 };
 
 export default RadioButtonGroupInput;

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -163,6 +163,7 @@ ReferenceInput.propTypes = {
     crudGetOne: PropTypes.func.isRequired,
     filter: PropTypes.object,
     filterToQuery: PropTypes.func.isRequired,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object.isRequired,
     label: PropTypes.string,
@@ -171,7 +172,6 @@ ReferenceInput.propTypes = {
     perPage: PropTypes.number,
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
-    requiresField: PropTypes.bool.isRequired,
     resource: PropTypes.string.isRequired,
     sort: PropTypes.shape({
         field: PropTypes.string,
@@ -204,8 +204,8 @@ const ConnectedReferenceInput = connect(mapStateToProps, {
 })(ReferenceInput);
 
 ConnectedReferenceInput.defaultProps = {
+    includesField: false,
     includesLabel: true,
-    requiresField: true,
 };
 
 export default ConnectedReferenceInput;

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -171,12 +171,13 @@ ReferenceInput.propTypes = {
     perPage: PropTypes.number,
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
+    requiresField: PropTypes.bool.isRequired,
     resource: PropTypes.string.isRequired,
     sort: PropTypes.shape({
         field: PropTypes.string,
         order: PropTypes.oneOf(['ASC', 'DESC']),
     }),
-    source: PropTypes.string.isRequired,
+    source: PropTypes.string,
 };
 
 ReferenceInput.defaultProps = {
@@ -204,6 +205,7 @@ const ConnectedReferenceInput = connect(mapStateToProps, {
 
 ConnectedReferenceInput.defaultProps = {
     includesLabel: true,
+    requiresField: true,
 };
 
 export default ConnectedReferenceInput;

--- a/src/mui/input/RichTextInput.js
+++ b/src/mui/input/RichTextInput.js
@@ -43,11 +43,11 @@ class RichTextInput extends Component {
 }
 
 RichTextInput.propTypes = {
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     options: PropTypes.object,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
     toolbar: PropTypes.oneOfType([
         PropTypes.array,
@@ -56,10 +56,10 @@ RichTextInput.propTypes = {
 };
 
 RichTextInput.defaultProps = {
+    includesField: false,
     includesLabel: false,
     options: {},
     record: {},
-    requiresField: true,
     toolbar: true,
 };
 

--- a/src/mui/input/RichTextInput.js
+++ b/src/mui/input/RichTextInput.js
@@ -43,10 +43,12 @@ class RichTextInput extends Component {
 }
 
 RichTextInput.propTypes = {
+    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     options: PropTypes.object,
-    includesLabel: PropTypes.bool.isRequired,
+    requiresField: PropTypes.bool.isRequired,
+    source: PropTypes.string,
     toolbar: PropTypes.oneOfType([
         PropTypes.array,
         PropTypes.bool,
@@ -54,9 +56,10 @@ RichTextInput.propTypes = {
 };
 
 RichTextInput.defaultProps = {
-    record: {},
-    options: {},
     includesLabel: false,
+    options: {},
+    record: {},
+    requiresField: true,
     toolbar: true,
 };
 

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -84,6 +84,7 @@ SelectInput.propTypes = {
     allowEmpty: PropTypes.bool.isRequired,
     choices: PropTypes.arrayOf(PropTypes.object),
     elStyle: PropTypes.object,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
@@ -94,7 +95,6 @@ SelectInput.propTypes = {
         PropTypes.element,
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
 };
 
@@ -104,7 +104,7 @@ SelectInput.defaultProps = {
     options: {},
     optionText: 'name',
     optionValue: 'id',
-    requiresField: true,
+    includesField: false,
     includesLabel: true,
 };
 

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -94,6 +94,7 @@ SelectInput.propTypes = {
         PropTypes.element,
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
 };
 
@@ -103,6 +104,7 @@ SelectInput.defaultProps = {
     options: {},
     optionText: 'name',
     optionValue: 'id',
+    requiresField: true,
     includesLabel: true,
 };
 

--- a/src/mui/input/TextInput.js
+++ b/src/mui/input/TextInput.js
@@ -37,7 +37,8 @@ TextInput.propTypes = {
     name: PropTypes.string,
     onChange: PropTypes.func,
     options: PropTypes.object,
-    source: PropTypes.string.isRequired,
+    requiresField: PropTypes.bool.isRequired,
+    source: PropTypes.string,
     type: PropTypes.string,
     validation: PropTypes.object,
 };
@@ -45,6 +46,7 @@ TextInput.propTypes = {
 TextInput.defaultProps = {
     includesLabel: true,
     options: {},
+    requiresField: true,
     type: 'text',
 };
 

--- a/src/mui/input/TextInput.js
+++ b/src/mui/input/TextInput.js
@@ -30,6 +30,7 @@ const TextInput = ({ input, label, meta: { touched, error }, options, type, sour
 
 TextInput.propTypes = {
     elStyle: PropTypes.object,
+    includesField: PropTypes.bool.isRequired,
     includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
@@ -37,16 +38,15 @@ TextInput.propTypes = {
     name: PropTypes.string,
     onChange: PropTypes.func,
     options: PropTypes.object,
-    requiresField: PropTypes.bool.isRequired,
     source: PropTypes.string,
     type: PropTypes.string,
     validation: PropTypes.object,
 };
 
 TextInput.defaultProps = {
+    includesField: false,
     includesLabel: true,
     options: {},
-    requiresField: true,
     type: 'text',
 };
 


### PR DESCRIPTION
By making the decoration by redux-form `<Field>` component optional, it becomes much easier to create custom (and composite) input components. 

- [x] [BC Break] Custom input elements are not decorated by `<Field>` by default
- [x] Add support for `includesField` prop to automate decoration by `<Field>`
- [x] Set `includesField: false` in all existing input components
- [x] Allow usage of field components in `<Edit>` and `<Create>` views
- [x] Add doc

Tests are hard - due to redux-form usage of `context` and all.

```js
// in LatLongInput.js
import { Field } from 'redux-form';
import { NumberInput } from 'admin-on-rest/lib/mui';
const LatLngInput = () => (
    <span>
        <Field name="lat" component={NumberInput} label="latitude" />
        &nbsp;
        <Field name="lng" component={NumberInput} label="longitude" />
    </span>
);
LatLngInput.defaultProps = {
    includesLabel: true,
};
export default LatLngInput;

// in ItemEdit.js
const ItemEdit = (props) => (
    <Edit {...props}>
        <DisabledInput source="id" />
        <LatLngInput />
    </Edit>
);
```