### PR TITLE
[RFR] Use Json REST client in example

### DIFF
--- a/docs/RestClients.md
+++ b/docs/RestClients.md
@@ -163,6 +163,11 @@ const httpClient = (url, options) => {
 
 Now all the requests to the REST API will contain the `Authorization: SRTRDFVESGNJYTUKTYTHRG` header.
 
+### Third-Party Clients
+
+You can find REST clients for admin-on-rest in third-party repositories.
+
+* [marmelab/aor-json-rest-client](https://github.com/marmelab/aor-json-rest-client) provides a local REST client based on a JavaScript object. It doesn't even use HTTP. Use it for testing purposes.
 
 ## Writing your own REST client
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -80,6 +80,9 @@
                                     <a href="#adding-custom-headers">Adding Custom Headers</a>
                                 </li>
                                 <li class="chapter">
+                                    <a href="#third-party-clients">Third-Party Clients</a>
+                                </li>
+                                <li class="chapter">
                                     <a href="#writing-your-own-rest-client">Writing your own REST client</a>
                                 </li>
                             </ul>

--- a/example/app.js
+++ b/example/app.js
@@ -2,22 +2,16 @@ import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 
-import FakeRest from 'fakerest';
-import fetchMock from 'fetch-mock';
-import data from './data';
-
-import { simpleRestClient, Admin, Resource } from 'admin-on-rest';
+import { Admin, Resource } from 'admin-on-rest';
+import jsonRestClient from 'aor-json-rest-client';
 import { Delete } from 'admin-on-rest/mui';
 
 import { PostList, PostCreate, PostEdit, PostShow, PostIcon } from './posts';
 import { CommentList, CommentEdit, CommentCreate, CommentIcon } from './comments';
 
-const restServer = new FakeRest.FetchServer('http://localhost:3000');
-restServer.init(data);
-restServer.toggleLogging(); // logging is off by default, enable it
-fetchMock.mock('^http://localhost:3000', restServer.getHandler());
+import data from './data';
 
-const restClient = simpleRestClient('http://localhost:3000');
+const restClient = jsonRestClient(data, true);
 const delayedRestClient = (type, resource, params) => new Promise(resolve => setTimeout(() => resolve(restClient(type, resource, params)), 1000));
 
 render(

--- a/example/package.json
+++ b/example/package.json
@@ -8,13 +8,11 @@
   },
   "author": "",
   "license": "MIT",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
+    "aor-json-rest-client": "~1.3.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-polyfill": "^6.9.1",
-    "babel-preset-react": "^6.11.1",
-    "fakerest": "^1.2.1",
-    "fetch-mock": "^4.6.0"
+    "babel-preset-react": "^6.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "eslint-plugin-jsx-a11y": "~2.2.3",
     "eslint-plugin-react": "~6.7.1",
     "extract-text-webpack-plugin": "~1.0.1",
-    "fakerest": "~1.2.1",
-    "fetch-mock": "~5.5.0",
     "full-icu": "~1.0.3",
     "ignore-styles": "~5.0.1",
     "mocha": "~3.2.0",


### PR DESCRIPTION
To facilitate tests, use [marmelab/aor-json-rest-client](https://github.com/marmelab/aor-json-rest-client) instead of `simpleRestClient` + `fakerest` +  `fetch-mock`.