### PR TITLE
[RFR] [BC Break] Rename input props includesLabel and includesField to add-

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -573,7 +573,7 @@ const LatLngInput = () => (
     <span>
         <Field name="lat" component="input" type="number" placeholder="latitude" />
         &nbsp;
-        <Field name="lng" component="input" tyle="number" placeholder="longitude" />
+        <Field name="lng" component="input" type="number" placeholder="longitude" />
     </span>
 );
 export default LatLngInput;
@@ -581,12 +581,39 @@ export default LatLngInput;
 // in ItemEdit.js
 const ItemEdit = (props) => (
     <Edit {...props}>
-        <LatLngInput label="Position" />
+        <LatLngInput />
     </Edit>
 );
 ```
 
 `LatLngInput` takes no props, because the `<Field>` component can access the current record via its context. The `name` prop serves as a selector for the record property to edit. All `Field` props except `name` and `component` are passed to the child component/element (an `<input>` in that example). Executing this component will render roughly the following code:
+
+```html
+<span>
+    <input type="number" placeholder="longitude" value={record.lat} />
+    <input type="number" placeholder="longitude" value={record.lng} />
+</span>
+```
+
+This component lacks a label. Admin-on-rest provides the `<Labeled>` component for that:
+
+```js
+// in LatLongInput.js
+import { Field } from 'redux-form';
+import { Labeled } from 'admin-on-rest/lib/mui';
+const LatLngInput = () => (
+    <Labeled label="position">
+        <span>
+            <Field name="lat" component="input" type="number" placeholder="latitude" />
+            &nbsp;
+            <Field name="lng" component="input" type="number" placeholder="longitude" />
+        </span>
+    </Labelled>
+);
+export default LatLngInput;
+```
+
+Now the component will render with a label:
 
 ```html
 <label>Position</label>
@@ -596,24 +623,44 @@ const ItemEdit = (props) => (
 </span>
 ```
 
-**Tip**: Although the `LatLngInput` component doesn't specify a `label` prop, admin-on-rest uses it to create a label on top of the input. If your component already includes a label, you can disable this behavior by setting `includesLabel: true` in the default props:
+Adding a label to an input component is such a common operation that admin-on-rest has the ability to do it automatically: just set the `addLabel` prop, and specify the label in the `label` prop:
 
 ```js
 // in LatLongInput.js
 import { Field } from 'redux-form';
 const LatLngInput = () => (
-    <div>
-        <div>Position</div>
+    <span>
         <Field name="lat" component="input" type="number" placeholder="latitude" />
         &nbsp;
-        <Field name="lng" component="input" tyle="number" placeholder="longitude" />
-    </div>
+        <Field name="lng" component="input" type="number" placeholder="longitude" />
+    </span>
+);
+export default LatLngInput;
+// in ItemEdit.js
+const ItemEdit = (props) => (
+    <Edit {...props}>
+        <LatLngInput addLabel label="Position" />
+    </Edit>
+);
+```
+
+**Tip**: To avoid repeating them each time you use the component, you should define `label` and `addLabel` as `defaultProps`:
+
+```js
+// in LatLongInput.js
+import { Field } from 'redux-form';
+const LatLngInput = () => (
+    <span>
+        <Field name="lat" component="input" type="number" placeholder="latitude" />
+        &nbsp;
+        <Field name="lng" component="input" type="number" placeholder="longitude" />
+    </span>
 );
 LatLngInput.defaultProps = {
-    includesLabel: true,
-};
+    addLabel: true,
+    label: 'Position',
+}
 export default LatLngInput;
-
 // in ItemEdit.js
 const ItemEdit = (props) => (
     <Edit {...props}>
@@ -647,9 +694,6 @@ const LatLngInput = () => (
         <Field name="lng" component={NumberInput} label="longitude" />
     </span>
 );
-LatLngInput.defaultProps = {
-    includesLabel: true,
-};
 export default LatLngInput;
 
 // in ItemEdit.js
@@ -661,7 +705,7 @@ const ItemEdit = (props) => (
 );
 ```
 
-`<NumberInput>` receives the props passed to the `<Field>` componeny - `label` in the example. Since the `lat` and `lng` inputs are labeled, no need to label the `<LanLngInput>` component - that's with the `includesLabel` default prop is set to `true`.
+`<NumberInput>` receives the props passed to the `<Field>` component - `label` in the example. `<NumberInput>` is already labelled, so there is no need to also label the `<LanLngInput>` component - that's why `addLabel` isn't set as default prop this time.
 
 **Tip**: If you need to pass a material ui component to `Field`, use a [field renderer function](http://redux-form.com/6.4.3/examples/material-ui/) to map the props:
 
@@ -687,7 +731,7 @@ const LatLngInput = () => (
 
 For more details on how to use redux-form's `<Field>` component, please refer to [the redux-form doc](http://redux-form.com/6.4.3/docs/api/Field.md/).
 
-**Tip**: If you only need one `<Field>` component in a custom input, you can let admin-on-rest do the `<Field>` decoration for you by setting the `includesField` default prop to `false`:
+**Tip**: If you only need one `<Field>` component in a custom input, you can let admin-on-rest do the `<Field>` decoration for you by setting the `addField` default prop to `true`:
 
 ```js
 // in PersonEdit.js
@@ -712,8 +756,7 @@ const SexInput = ({ input, meta: { touched, error } }) => (
     </SelectField>
 );
 SexInput.defaultProps = {
-    includesField: false, // require a <Field> decoration
-    includesLabel: true,
+    addField: true, // require a <Field> decoration
 }
 export default SexInput;
 
@@ -733,12 +776,9 @@ const renderSexInput = ({ input, meta: { touched, error } }) => (
     </SelectField>
 );
 const SexInput = ({ source }) => <Field name={source} component={renderSexInput} />
-SexInput.defaultProps = {
-    includesLabel: true,
-}
 export default SexInput;
 ```
 
-Most admin-on-rest input components use `includeField: false` in default props.
+Most admin-on-rest input components use `addField: true` in default props.
 
 **Tip**: `<Field>` injects two props to its child component: `input` and `meta`. To learn more about these props, please refer to [the `<Field>` component documentation](http://redux-form.com/6.4.3/docs/api/Field.md/#props) in the redux-form website.

--- a/src/mui/detail/RecordForm.js
+++ b/src/mui/detail/RecordForm.js
@@ -57,15 +57,17 @@ export const RecordForm = ({ children, handleSubmit, record, resource, basePath 
             <div style={{ padding: '0 1em 1em 1em' }}>
                 {React.Children.map(children, input => (
                     <div key={input.props.source} style={input.props.style}>
-                        { input.props.includesField === false ?
-                            (input.props.includesLabel ?
-                                <Field {...commonProps} {...input.props} name={input.props.source} component={input.type} /> :
-                                <Field {...commonProps} {...input.props} name={input.props.source} component={Labeled} label={input.props.label}>{ input }</Field>
+                        { input.props.addField ?
+                            (input.props.addLabel ?
+                                <Field {...commonProps} {...input.props} name={input.props.source} component={Labeled} label={input.props.label}>{ input }</Field> :
+                                <Field {...commonProps} {...input.props} name={input.props.source} component={input.type} />
                             ) :
-                            (input.props.includesLabel ?
-                                React.cloneElement(input, commonProps) :
-                                <Labeled {...commonProps} label={input.props.label} source={input.props.source}>{input}</Labeled>
-
+                            (input.props.addLabel ?
+                                <Labeled {...commonProps} label={input.props.label} source={input.props.source}>{input}</Labeled> :
+                                (typeof input.type === 'string' ?
+                                    input :
+                                    React.cloneElement(input, commonProps)
+                                )
                             )
                         }
                     </div>

--- a/src/mui/detail/RecordForm.spec.js
+++ b/src/mui/detail/RecordForm.spec.js
@@ -91,10 +91,10 @@ describe('<RecordForm />', () => {
         assert.equal(button.length, 1);
     });
 
-    it('should render <Labeled /> component if input does not include label', () => {
+    it('should render <Labeled /> component if input sets addLabel', () => {
         const wrapper = shallow(
             <RecordForm>
-                <TextInput source="name" label="Name" includesLabel={false} />
+                <TextInput source="name" label="Name" addLabel />
             </RecordForm>
         );
 

--- a/src/mui/detail/Show.js
+++ b/src/mui/detail/Show.js
@@ -44,6 +44,7 @@ export class Show extends Component {
     render() {
         const { title, children, id, data, isLoading, resource, hasDelete, hasEdit } = this.props;
         const basePath = this.getBasePath();
+        const commonProps = { record: data, basePath, resource };
 
         return (
             <Card style={{ margin: '2em', opacity: isLoading ? 0.8 : 1 }}>
@@ -57,9 +58,13 @@ export class Show extends Component {
                     <div style={{ padding: '0 1em 1em 1em' }}>
                         {React.Children.map(children, field => (
                             <div key={field.props.source} style={field.props.style}>
-                                <Labeled label={field.props.label} source={field.props.source} disabled={false} record={data} basePath={basePath} resource={resource} >
-                                    <field.type {...field.props} />
-                                </Labeled>
+                                {field.props.addLabel ?
+                                    <Labeled {...commonProps} label={field.props.label} source={field.props.source} disabled={false}>{field}</Labeled> :
+                                    (typeof field.type === 'string' ?
+                                        field :
+                                        React.cloneElement(field, commonProps)
+                                    )
+                                }
                             </div>
                         ))}
                     </div>

--- a/src/mui/field/BooleanField.js
+++ b/src/mui/field/BooleanField.js
@@ -17,6 +17,7 @@ const BooleanField = ({ source, record = {}, elStyle }) => {
 };
 
 BooleanField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     record: PropTypes.object,
@@ -24,6 +25,7 @@ BooleanField.propTypes = {
 };
 
 BooleanField.defaultProps = {
+    addLabel: true,
     elStyle: {
         display: 'block',
         margin: 'auto',

--- a/src/mui/field/ChipField.js
+++ b/src/mui/field/ChipField.js
@@ -6,10 +6,15 @@ const ChipField = ({ source, record = {}, elStyle = { margin: 4 } }) =>
     <Chip style={elStyle}>{get(record, source)}</Chip>;
 
 ChipField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     source: PropTypes.string.isRequired,
     record: PropTypes.object,
+};
+
+ChipField.defaultProps = {
+    addLabel: true,
 };
 
 export default ChipField;

--- a/src/mui/field/DateField.js
+++ b/src/mui/field/DateField.js
@@ -49,6 +49,7 @@ const DateField = ({ elStyle, locales, options, record, showTime = false, source
 };
 
 DateField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     locales: PropTypes.oneOfType([
@@ -59,6 +60,10 @@ DateField.propTypes = {
     record: PropTypes.object,
     showTime: PropTypes.bool,
     source: PropTypes.string.isRequired,
+};
+
+DateField.defaultProps = {
+    addLabel: true,
 };
 
 export default DateField;

--- a/src/mui/field/EmailField.js
+++ b/src/mui/field/EmailField.js
@@ -5,10 +5,15 @@ const EmailField = ({ source, record = {}, elStyle }) =>
     <a style={elStyle} href={`mailto:${get(record, source)}`}>{get(record, source)}</a>;
 
 EmailField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     record: PropTypes.object,
     source: PropTypes.string.isRequired,
+};
+
+EmailField.defaultProps = {
+    addLabel: true,
 };
 
 export default EmailField;

--- a/src/mui/field/FunctionField.js
+++ b/src/mui/field/FunctionField.js
@@ -9,11 +9,16 @@ const FunctionField = ({ record = {}, source, render, elStyle }) => record ?
     null;
 
 FunctionField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     render: PropTypes.func.isRequired,
     record: PropTypes.object,
     source: PropTypes.string,
+};
+
+FunctionField.defaultProps = {
+    addLabel: true,
 };
 
 export default FunctionField;

--- a/src/mui/field/NumberField.js
+++ b/src/mui/field/NumberField.js
@@ -40,6 +40,7 @@ const NumberField = ({ record, source, locales, options, elStyle }) => {
 };
 
 NumberField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     locales: PropTypes.oneOfType([
@@ -52,6 +53,7 @@ NumberField.propTypes = {
 };
 
 NumberField.defaultProps = {
+    addLabel: true,
     style: { textAlign: 'right' },
     headerStyle: { textAlign: 'right' },
 };

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -46,6 +46,7 @@ export class ReferenceField extends Component {
 }
 
 ReferenceField.propTypes = {
+    addLabel: PropTypes.bool,
     allowEmpty: PropTypes.bool.isRequired,
     basePath: PropTypes.string.isRequired,
     children: PropTypes.element.isRequired,
@@ -59,6 +60,7 @@ ReferenceField.propTypes = {
 };
 
 ReferenceField.defaultProps = {
+    addLabel: true,
     referenceRecord: null,
     record: {},
     allowEmpty: false,

--- a/src/mui/field/ReferenceManyField.js
+++ b/src/mui/field/ReferenceManyField.js
@@ -59,10 +59,10 @@ export class ReferenceManyField extends Component {
 }
 
 ReferenceManyField.propTypes = {
+    addLabel: PropTypes.bool,
     basePath: PropTypes.string.isRequired,
     children: PropTypes.element.isRequired,
     crudGetManyReference: PropTypes.func.isRequired,
-    includesLabel: PropTypes.bool,
     label: PropTypes.string,
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
@@ -84,7 +84,7 @@ const ConnectedReferenceManyField = connect(mapStateToProps, {
 })(ReferenceManyField);
 
 ConnectedReferenceManyField.defaultProps = {
-    includesLabel: false,
+    addLabel: true,
     source: '',
 };
 

--- a/src/mui/field/RichTextField.js
+++ b/src/mui/field/RichTextField.js
@@ -12,16 +12,18 @@ const RichTextField = ({ source, record = {}, stripTags, elStyle }) => {
     return <div style={elStyle} dangerouslySetInnerHTML={{ __html: value }}></div>;
 };
 
-RichTextField.defaultProps = {
-    stripTags: false,
-};
-
 RichTextField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     record: PropTypes.object,
     source: PropTypes.string.isRequired,
     stripTags: PropTypes.bool,
+};
+
+RichTextField.defaultProps = {
+    addLabel: true,
+    stripTags: false,
 };
 
 export default RichTextField;

--- a/src/mui/field/TextField.js
+++ b/src/mui/field/TextField.js
@@ -5,10 +5,15 @@ const TextField = ({ source, record = {}, elStyle }) =>
     <span style={elStyle}>{get(record, source)}</span>;
 
 TextField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     record: PropTypes.object,
     source: PropTypes.string.isRequired,
+};
+
+TextField.defaultProps = {
+    addLabel: true,
 };
 
 export default TextField;

--- a/src/mui/field/UrlField.js
+++ b/src/mui/field/UrlField.js
@@ -8,10 +8,15 @@ const UrlField = ({ source, record = {}, elStyle }) => (
 );
 
 UrlField.propTypes = {
+    addLabel: PropTypes.bool,
     elStyle: PropTypes.object,
     label: PropTypes.string,
     record: PropTypes.object,
     source: PropTypes.string.isRequired,
+};
+
+UrlField.defaultProps = {
+    addLabel: true,
 };
 
 export default UrlField;

--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -90,11 +90,10 @@ class AutocompleteInput extends Component {
 }
 
 AutocompleteInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     choices: PropTypes.arrayOf(PropTypes.object),
     elStyle: PropTypes.object,
     filter: PropTypes.func.isRequired,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     options: PropTypes.object,
@@ -109,10 +108,9 @@ AutocompleteInput.propTypes = {
 };
 
 AutocompleteInput.defaultProps = {
+    addField: true,
     choices: [],
     filter: AutoComplete.fuzzyFilter,
-    includesField: false,
-    includesLabel: true,
     options: {},
     optionText: 'name',
     optionValue: 'id',

--- a/src/mui/input/BooleanInput.js
+++ b/src/mui/input/BooleanInput.js
@@ -28,17 +28,15 @@ const BooleanInput = ({ input, label, source, elStyle }) => (
 );
 
 BooleanInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     elStyle: PropTypes.object,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     source: PropTypes.string,
 };
 
 BooleanInput.defaultProps = {
-    includesField: false,
-    includesLabel: true,
+    addField: true,
 };
 
 export default BooleanInput;

--- a/src/mui/input/DateInput.js
+++ b/src/mui/input/DateInput.js
@@ -37,9 +37,8 @@ class DateInput extends Component {
 }
 
 DateInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     elStyle: PropTypes.object,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
@@ -48,8 +47,7 @@ DateInput.propTypes = {
 };
 
 DateInput.defaultProps = {
-    includesField: false,
-    includesLabel: true,
+    addField: true,
     options: {},
 };
 

--- a/src/mui/input/DisabledInput.js
+++ b/src/mui/input/DisabledInput.js
@@ -10,14 +10,9 @@ const DisabledInput = ({ label, record, source }) => <TextField
 />;
 
 DisabledInput.propTypes = {
-    includesLabel: PropTypes.bool,
     label: PropTypes.string,
     record: PropTypes.object,
     source: PropTypes.string,
-};
-
-DisabledInput.defaultProps = {
-    includesLabel: true,
 };
 
 export default DisabledInput;

--- a/src/mui/input/Labeled.js
+++ b/src/mui/input/Labeled.js
@@ -1,10 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Children, Component, PropTypes } from 'react';
 import TextField from 'material-ui/TextField';
 import title from '../../util/title';
 
 const defaultLabelStyle = {
     paddingTop: '2em',
-    height: 'auto'
+    height: 'auto',
 };
 
 /**
@@ -12,6 +12,10 @@ const defaultLabelStyle = {
  *
  * Useful to use a Field in the Edit or Create components.
  * The child component will receive the current record.
+ *
+ * This component name doesn't have a typo. We had to choose between
+ * the American English "Labeled", and the British English "Labelled".
+ * We flipped a coin.
  *
  * @example
  * <Labeled label="Comments">
@@ -22,7 +26,7 @@ class Labeled extends Component {
     render() {
         const { input, label, resource, record, onChange, basePath, children, source, disabled = true, labelStyle = defaultLabelStyle } = this.props;
         if (!label && !source) {
-            throw new Error(`Cannot create label for component <${children && children.type && children.type.name}>: You must set either the label or source props. You can also disable automated label insertion by setting 'includesLabel: true' in the component default props`);
+            throw new Error(`Cannot create label for component <${children && children.type && children.type.name}>: You must set either the label or source props. You can also disable automated label insertion by setting 'addLabel: false' in the component default props`);
         }
         return (
             <TextField
@@ -33,7 +37,10 @@ class Labeled extends Component {
                 underlineShow={false}
                 style={labelStyle}
             >
-                {children && React.cloneElement(children, { input, record, resource, onChange, basePath })}
+                {children && typeof children.type !== 'string' ?
+                    React.cloneElement(children, { input, record, resource, onChange, basePath }) :
+                    children
+                }
             </TextField>
         );
     }
@@ -50,10 +57,6 @@ Labeled.propTypes = {
     resource: PropTypes.string,
     source: PropTypes.string,
     labelStyle: PropTypes.object,
-};
-
-Labeled.defaultProps = {
-    includesLabel: true,
 };
 
 export default Labeled;

--- a/src/mui/input/LongTextInput.js
+++ b/src/mui/input/LongTextInput.js
@@ -15,9 +15,8 @@ const LongTextInput = ({ input, label, meta: { touched, error }, options, source
 );
 
 LongTextInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     elStyle: PropTypes.object,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
@@ -28,8 +27,7 @@ LongTextInput.propTypes = {
 };
 
 LongTextInput.defaultProps = {
-    includesField: false,
-    includesLabel: true,
+    addField: true,
     options: {},
 };
 

--- a/src/mui/input/NullableBooleanInput.js
+++ b/src/mui/input/NullableBooleanInput.js
@@ -17,9 +17,8 @@ const NullableBooleanInput = ({ input, meta: { touched, error }, label, source, 
 );
 
 NullableBooleanInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     elStyle: PropTypes.object,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
@@ -27,8 +26,7 @@ NullableBooleanInput.propTypes = {
 };
 
 NullableBooleanInput.defaultProps = {
-    includesField: false,
-    includesLabel: true,
+    addField: true,
 };
 
 export default NullableBooleanInput;

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -42,9 +42,8 @@ class NumberInput extends Component {
 }
 
 NumberInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     elStyle: PropTypes.object,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
@@ -57,8 +56,7 @@ NumberInput.propTypes = {
 };
 
 NumberInput.defaultProps = {
-    includesField: false,
-    includesLabel: true,
+    addField: true,
     options: {},
     step: 'any',
 };

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -78,9 +78,8 @@ class RadioButtonGroupInput extends Component {
 }
 
 RadioButtonGroupInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     choices: PropTypes.arrayOf(PropTypes.object),
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     label: PropTypes.string,
     onChange: PropTypes.func,
     options: PropTypes.object,
@@ -95,9 +94,8 @@ RadioButtonGroupInput.propTypes = {
 };
 
 RadioButtonGroupInput.defaultProps = {
+    addField: true,
     choices: [],
-    includesField: false,
-    includesLabel: true,
     options: {},
     optionText: 'name',
     optionValue: 'id',

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -156,6 +156,7 @@ export class ReferenceInput extends Component {
 }
 
 ReferenceInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     allowEmpty: PropTypes.bool.isRequired,
     basePath: PropTypes.string,
     children: PropTypes.element.isRequired,
@@ -163,8 +164,6 @@ ReferenceInput.propTypes = {
     crudGetOne: PropTypes.func.isRequired,
     filter: PropTypes.object,
     filterToQuery: PropTypes.func.isRequired,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object.isRequired,
     label: PropTypes.string,
     matchingReferences: PropTypes.array,
@@ -204,8 +203,7 @@ const ConnectedReferenceInput = connect(mapStateToProps, {
 })(ReferenceInput);
 
 ConnectedReferenceInput.defaultProps = {
-    includesField: false,
-    includesLabel: true,
+    addField: true,
 };
 
 export default ConnectedReferenceInput;

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -8,7 +8,6 @@ describe('<ReferenceInput />', () => {
     const defaultProps = {
         crudGetMatching: () => true,
         crudGetOne: () => true,
-        includesLabel: true,
         input: {},
         reference: 'posts',
         resource: 'comments',

--- a/src/mui/input/RichTextInput.js
+++ b/src/mui/input/RichTextInput.js
@@ -43,8 +43,8 @@ class RichTextInput extends Component {
 }
 
 RichTextInput.propTypes = {
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
+    addField: PropTypes.bool.isRequired,
+    addLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     options: PropTypes.object,
@@ -56,8 +56,8 @@ RichTextInput.propTypes = {
 };
 
 RichTextInput.defaultProps = {
-    includesField: false,
-    includesLabel: false,
+    addField: true,
+    addLabel: true,
     options: {},
     record: {},
     toolbar: true,

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -81,11 +81,10 @@ class SelectInput extends Component {
 }
 
 SelectInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     allowEmpty: PropTypes.bool.isRequired,
     choices: PropTypes.arrayOf(PropTypes.object),
     elStyle: PropTypes.object,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     options: PropTypes.object,
@@ -99,13 +98,12 @@ SelectInput.propTypes = {
 };
 
 SelectInput.defaultProps = {
+    addField: true,
     allowEmpty: false,
     choices: [],
     options: {},
     optionText: 'name',
     optionValue: 'id',
-    includesField: false,
-    includesLabel: true,
 };
 
 export default SelectInput;

--- a/src/mui/input/TextInput.js
+++ b/src/mui/input/TextInput.js
@@ -29,9 +29,8 @@ const TextInput = ({ input, label, meta: { touched, error }, options, type, sour
 );
 
 TextInput.propTypes = {
+    addField: PropTypes.bool.isRequired,
     elStyle: PropTypes.object,
-    includesField: PropTypes.bool.isRequired,
-    includesLabel: PropTypes.bool.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
     meta: PropTypes.object,
@@ -44,8 +43,7 @@ TextInput.propTypes = {
 };
 
 TextInput.defaultProps = {
-    includesField: false,
-    includesLabel: true,
+    addField: true,
     options: {},
     type: 'text',
 };


### PR DESCRIPTION
## Revert the `includesLabel` logic

Until now, a label was added by default to all Input component unless the component opted out with `includesLabel: true`. That lead to WTF moments, as when defining a custom input as follows:

```js
// in SexInput.js
import SelectField from 'material-ui/SelectField';
import MenuItem from 'material-ui/MenuItem';
const SexInput = ({ input, meta: { touched, error } }) => (
    <SelectField
        floatingLabelText="Sex"
        errorText={touched && error}
        {...input}
    >
        <MenuItem value="M" primaryText="Male" />
        <MenuItem value="F" primaryText="Female" />
    </SelectField>
);
SexInput.defaultProps = {
   includesField: false, // require a <Field> decoration
};
export default SexInput;
```

This perfectly looking code would produce a runtime error:

> Cannot create label for component SexInput: You must set either the label or source props. You can also disable automated label insertion by setting 'addLabel: false' in the component default props

The developer would think: "Wat?", then dive in the documentation, and remember about automatic label decoration. Only by adding `includesLabel: true` to the default props could he remove the error.

Following the *Principle of Least WTF*™, custom components shouldn't be decorated by a label by default. So I reverted the logic, and now you need to explicitly ask for a label if you want to, using `addLabel: true` (rather than `includesLabel: false`, which is a hard to understand double negation).

Since most admin-on-rest components already have a label, we don't even have to set the `addLabel` prop since it should be `false` in that case.

## Revert the `includesField` logic

Having `addLabel` and `includesField` as props isn't consistent. Besides, following #206, Field decoration is optional, so the two props have the same meaning. So I renamed `includesField: false` to `addField: true`. Now the following code works fine:

```js
// in SexInput.js
import SelectField from 'material-ui/SelectField';
import MenuItem from 'material-ui/MenuItem';
const SexInput = ({ input, meta: { touched, error } }) => (
    <SelectField
        floatingLabelText="Sex"
        errorText={touched && error}
        {...input}
    >
        <MenuItem value="M" primaryText="Male" />
        <MenuItem value="F" primaryText="Female" />
    </SelectField>
);
SexInput.defaultProps = {
   addField: true, // require a <Field> decoration
};
export default SexInput;
```

The documentation has been updated accordingly.