### PR TITLE
[RFR] Fix form validation from input prop in TabbedForm component

### DIFF
--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -3,9 +3,37 @@ import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
-import { validateForm } from '../../util/validate';
+import { getFieldConstraints } from '../../util/validate';
 import { SaveButton } from '../button';
 import getDefaultValues from '../form/getDefaultValues';
+
+/**
+ * Validator function for redux-form
+ */
+export const validateForm = (values, { children, validation }) => {
+    const errors = typeof validation === 'function' ? validation(values) : {};
+
+    // warn user we expect an object here, in case of validation just returned an error message
+    if (errors === null || typeof errors !== 'object') {
+        throw new Error('Validation function given to form components should return an object.');
+    }
+
+    // digging first in `<FormTab>`, then in all children
+    const fieldConstraints = Children.toArray(children)
+        .map(child => child.props.children)
+        .map(getFieldConstraints)
+        .reduce((prev, next) => ({ ...prev, ...next }), {});
+    Object.keys(fieldConstraints).forEach(fieldName => {
+        const error = fieldConstraints[fieldName](values[fieldName], values);
+        if (error.length > 0) {
+            if (!errors[fieldName]) {
+                errors[fieldName] = [];
+            }
+            errors[fieldName] = [...errors[fieldName], ...error];
+        }
+    });
+    return errors;
+};
 
 export class TabbedForm extends Component {
     constructor(props) {

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -61,7 +61,7 @@ export const getConstraintsFunctionFromFunctionOrObject = (constraints) => {
  *    }
  * }
  */
-const getFieldConstraints = children => React.Children.toArray(children)
+export const getFieldConstraints = children => React.Children.toArray(children)
     .map(({ props: { source: fieldName, validation } }) => ({ fieldName, validation }))
     .filter(({ validation }) => !!validation)
     .reduce((constraints, { fieldName, validation }) => {

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -70,12 +70,12 @@ export const getFieldConstraints = children => React.Children.toArray(children)
     }, {});
 
 export const getErrorsForForm = (validation, values) => {
-    const errorsForForm = typeof validation === 'function' ? validation(values) : {};
+    const errors = typeof validation === 'function' ? validation(values) : {};
     // warn user we expect an object here, in case of validation just returned an error message
-    if (errorsForForm === null || typeof errorsForForm !== 'object') {
+    if (errors === null || typeof errors !== 'object') {
         throw new Error('Validation function given to form components should return an object.');
     }
-    return errorsForForm;
+    return errors;
 };
 
 export const getErrorsForFieldConstraints = (fieldConstraints, values) => {

--- a/src/util/validate.js
+++ b/src/util/validate.js
@@ -69,19 +69,18 @@ export const getFieldConstraints = children => React.Children.toArray(children)
         return constraints;
     }, {});
 
-/**
- * Validator function for redux-form
- */
-export const validateForm = (values, { children, validation }) => {
-    const errors = typeof validation === 'function' ? validation(values) : {};
-
+export const getErrorsForForm = (validation, values) => {
+    const errorsForForm = typeof validation === 'function' ? validation(values) : {};
     // warn user we expect an object here, in case of validation just returned an error message
-    if (errors === null || typeof errors !== 'object') {
+    if (errorsForForm === null || typeof errorsForForm !== 'object') {
         throw new Error('Validation function given to form components should return an object.');
     }
+    return errorsForForm;
+};
 
-    const fieldConstraints = getFieldConstraints(children);
-    Object.keys(fieldConstraints).forEach(fieldName => {
+export const getErrorsForFieldConstraints = (fieldConstraints, values) => {
+    const errors = {};
+    Object.keys(fieldConstraints).forEach((fieldName) => {
         const error = fieldConstraints[fieldName](values[fieldName], values);
         if (error.length > 0) {
             if (!errors[fieldName]) {
@@ -92,3 +91,11 @@ export const validateForm = (values, { children, validation }) => {
     });
     return errors;
 };
+
+/**
+ * Validator function for redux-form
+ */
+export const validateForm = (values, { children, validation }) => ({
+    ...getErrorsForForm(validation, values),
+    ...getErrorsForFieldConstraints(getFieldConstraints(children), values),
+});

--- a/src/util/validate.spec.js
+++ b/src/util/validate.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import assert from 'assert';
-import { coreConstraints, getConstraintsFunctionFromFunctionOrObject, validateForm } from './validate';
+import { coreConstraints, getErrorsForForm, getErrorsForFieldConstraints, getConstraintsFunctionFromFunctionOrObject, validateForm } from './validate';
 import TextInput from '../mui/input/TextInput';
 
 describe('Validator', () => {
@@ -211,6 +211,44 @@ describe('Validator', () => {
 
             const valueError = validateForm({ rate: 6 }, props);
             assert.deepEqual(valueError, { rate: 'Maximum value: 5' });
+        });
+    });
+
+    describe('getErrorsForForm', () => {
+        const values = { foo: 1, bar: 2, hello: 'world' };
+
+        it('should return an empty object when no validation function is passed', () => {
+            assert.deepEqual({}, getErrorsForForm(null, values));
+        });
+
+        it('should return an empty object when all values are correct', () => {
+            const validate = v => v.foo !== 1 ? { foo: ['error'] } : {}; // eslint-disable-line no-confusing-arrow
+            assert.deepEqual({}, getErrorsForForm(validate, values));
+        });
+
+        it('should return an error object for incorrect values', () => {
+            const validate = v => v.foo !== 2 ? { foo: ['error'] } : {}; // eslint-disable-line no-confusing-arrow
+            assert.deepEqual({ foo: ['error'] }, getErrorsForForm(validate, values));
+        });
+
+    });
+
+    describe('getErrorsForFieldConstraints', () => {
+        const values = { foo: 1, bar: 2, hello: 'world' };
+
+        it('should return an empty object when all values are correct', () => {
+            const constraints = {
+                foo: _ => [],
+            };
+            assert.deepEqual({}, getErrorsForFieldConstraints(constraints, values));
+        });
+
+        it('should return an error object for incorrect values', () => {
+            const constraints = {
+                foo: _ => [],
+                bar: _ => ['error'],
+            };
+            assert.deepEqual({ bar: ['error'] }, getErrorsForFieldConstraints(constraints, values));
         });
     });
 


### PR DESCRIPTION
`<TabbedForm>` used the same technique as `<SimpleForm>` to merge `validation` props from `<Input>` fields: iterating over the children. But it doesn't work for `<TabbedForm>`, since its children are `<FormTab>` components, not `<Input>` components. So validation was broken in `<TabbedForm>`.

This PR fixes it.