### PR TITLE
[RFR] Avoid useless rerenders in Layout and Datagrid

### DIFF
--- a/example/posts.js
+++ b/example/posts.js
@@ -35,11 +35,12 @@ const PostFilter = (props) => (
     </Filter>
 );
 
-export const PostList = (props) => (
+const titleFieldStyle = { maxWidth: '20em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' };
+export const PostList = props => (
     <List {...props} filters={<PostFilter />} sort={{ field: 'published_at', order: 'DESC' }}>
         <Datagrid>
             <TextField source="id" />
-            <TextField source="title" style={{ maxWidth: '20em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}/>
+            <TextField source="title" style={titleFieldStyle} />
             <DateField source="published_at" style={{ fontStyle: 'italic' }} />
             <BooleanField label="Commentable" source="commentable" />
             <NumberField source="views" />

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-router": "~2.8.1",
     "react-router-redux": "~4.0.6",
     "react-tap-event-plugin": "~2.0.0",
-    "recompose": "^0.21.2",
+    "recompose": "~0.21.2",
     "redux": "~3.6.0",
     "redux-form": "~6.2.0",
     "redux-saga": "~0.14.2"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-router": "~2.8.1",
     "react-router-redux": "~4.0.6",
     "react-tap-event-plugin": "~2.0.0",
+    "recompose": "^0.21.2",
     "redux": "~3.6.0",
     "redux-form": "~6.2.0",
     "redux-saga": "~0.14.2"

--- a/src/mui/button/EditButton.js
+++ b/src/mui/button/EditButton.js
@@ -1,8 +1,9 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
+import shouldUpdate from 'recompose/shouldUpdate';
 import FlatButton from 'material-ui/FlatButton';
 import ContentCreate from 'material-ui/svg-icons/content/create';
-import linkToRecord from '../../util/linkToRecord'
+import linkToRecord from '../../util/linkToRecord';
 
 const EditButton = ({ basePath = '', label = 'Edit', record = {} }) => <FlatButton
     primary
@@ -18,4 +19,7 @@ EditButton.propTypes = {
     record: PropTypes.object,
 };
 
-export default EditButton;
+export default shouldUpdate((props, nextProps) =>
+    props.record.id !== nextProps.record.id
+    || props.basePath !== nextProps.basePath
+)(EditButton);

--- a/src/mui/detail/Show.spec.js
+++ b/src/mui/detail/Show.spec.js
@@ -34,7 +34,7 @@ describe('<Show />', () => {
                 <TextField source="bar" />
             </SimpleShowLayout>
         </Show>);
-        const inputs = wrapper.find('TextField');
+        const inputs = wrapper.find('pure(TextField)');
         assert.deepEqual(inputs.map(i => i.prop('source')), ['foo', 'bar']);
     });
 });

--- a/src/mui/field/BooleanField.js
+++ b/src/mui/field/BooleanField.js
@@ -1,10 +1,11 @@
 import React, { PropTypes } from 'react';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
 
 import FalseIcon from 'material-ui/svg-icons/content/clear';
 import TrueIcon from 'material-ui/svg-icons/action/done';
 
-const BooleanField = ({ source, record = {}, elStyle }) => {
+export const BooleanField = ({ source, record = {}, elStyle }) => {
     if (get(record, source) === false) {
         return <FalseIcon style={elStyle} />;
     }
@@ -24,7 +25,9 @@ BooleanField.propTypes = {
     source: PropTypes.string.isRequired,
 };
 
-BooleanField.defaultProps = {
+const PureBooleanField = pure(BooleanField);
+
+PureBooleanField.defaultProps = {
     addLabel: true,
     elStyle: {
         display: 'block',
@@ -32,4 +35,4 @@ BooleanField.defaultProps = {
     },
 };
 
-export default BooleanField;
+export default PureBooleanField;

--- a/src/mui/field/BooleanField.spec.js
+++ b/src/mui/field/BooleanField.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
-import BooleanField from './BooleanField';
+import { BooleanField } from './BooleanField';
 
 describe('<BooleanField />', () => {
     it('should display tick if value is true', () => assert.ok(

--- a/src/mui/field/ChipField.js
+++ b/src/mui/field/ChipField.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
-import Chip from 'material-ui/Chip';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
+import Chip from 'material-ui/Chip';
 
 const ChipField = ({ source, record = {}, elStyle = { margin: 4 } }) =>
     <Chip style={elStyle}>{get(record, source)}</Chip>;
@@ -13,8 +14,10 @@ ChipField.propTypes = {
     record: PropTypes.object,
 };
 
-ChipField.defaultProps = {
+const PureChipField = pure(ChipField);
+
+PureChipField.defaultProps = {
     addLabel: true,
 };
 
-export default ChipField;
+export default PureChipField;

--- a/src/mui/field/DateField.js
+++ b/src/mui/field/DateField.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
 
 const toLocaleStringSupportsLocales = (() => {
     // from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
@@ -36,7 +37,7 @@ const toLocaleStringSupportsLocales = (() => {
  * <span>mercredi 7 novembre 2012</span>
  */
 
-const DateField = ({ elStyle, locales, options, record, showTime = false, source }) => {
+export const DateField = ({ elStyle, locales, options, record, showTime = false, source }) => {
     if (!record) return null;
     const value = get(record, source);
     if (value == null) return null;
@@ -62,8 +63,10 @@ DateField.propTypes = {
     source: PropTypes.string.isRequired,
 };
 
-DateField.defaultProps = {
+const PureDateField = pure(DateField);
+
+PureDateField.defaultProps = {
     addLabel: true,
 };
 
-export default DateField;
+export default PureDateField;

--- a/src/mui/field/DateField.spec.js
+++ b/src/mui/field/DateField.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
-import DateField from './DateField';
+import { DateField } from './DateField';
 
 describe('<DateField />', () => {
     it('should return null when the record is not set', () => assert.equal(

--- a/src/mui/field/EmailField.js
+++ b/src/mui/field/EmailField.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
 
 const EmailField = ({ source, record = {}, elStyle }) =>
     <a style={elStyle} href={`mailto:${get(record, source)}`}>{get(record, source)}</a>;
@@ -12,8 +13,10 @@ EmailField.propTypes = {
     source: PropTypes.string.isRequired,
 };
 
-EmailField.defaultProps = {
+const PureEmailField = pure(EmailField);
+
+PureEmailField.defaultProps = {
     addLabel: true,
 };
 
-export default EmailField;
+export default PureEmailField;

--- a/src/mui/field/FunctionField.js
+++ b/src/mui/field/FunctionField.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import pure from 'recompose/pure';
 
 /**
  * @example
@@ -17,8 +18,10 @@ FunctionField.propTypes = {
     source: PropTypes.string,
 };
 
-FunctionField.defaultProps = {
+const PureFunctionField = pure(FunctionField);
+
+PureFunctionField.defaultProps = {
     addLabel: true,
 };
 
-export default FunctionField;
+export default PureFunctionField;

--- a/src/mui/field/NumberField.js
+++ b/src/mui/field/NumberField.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
 
 const hasNumberFormat = !!(typeof Intl === 'object' && Intl && typeof Intl.NumberFormat === 'function');
 
@@ -31,7 +32,7 @@ const hasNumberFormat = !!(typeof Intl === 'object' && Intl && typeof Intl.Numbe
  * // renders the record { id: 1234, price: 25.99 } as
  * <span>25,99 $US</span>
  */
-const NumberField = ({ record, source, locales, options, elStyle }) => {
+export const NumberField = ({ record, source, locales, options, elStyle }) => {
     if (!record) return null;
     const value = get(record, source);
     if (value == null) return null;
@@ -52,10 +53,12 @@ NumberField.propTypes = {
     source: PropTypes.string.isRequired,
 };
 
-NumberField.defaultProps = {
+const PureNumberField = pure(NumberField);
+
+PureNumberField.defaultProps = {
     addLabel: true,
     style: { textAlign: 'right' },
     headerStyle: { textAlign: 'right' },
 };
 
-export default NumberField;
+export default PureNumberField;

--- a/src/mui/field/NumberField.spec.js
+++ b/src/mui/field/NumberField.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
-import NumberField from './NumberField';
+import { NumberField } from './NumberField';
 
 describe('<NumberField />', () => {
     it('should return null when the record is not set', () => assert.equal(

--- a/src/mui/field/RichTextField.js
+++ b/src/mui/field/RichTextField.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
 
 export const removeTags = input => input.replace(/<[^>]+>/gm, '');
 
@@ -21,9 +22,11 @@ RichTextField.propTypes = {
     stripTags: PropTypes.bool,
 };
 
-RichTextField.defaultProps = {
+const PureRichTextField = pure(RichTextField);
+
+PureRichTextField.defaultProps = {
     addLabel: true,
     stripTags: false,
 };
 
-export default RichTextField;
+export default PureRichTextField;

--- a/src/mui/field/TextField.js
+++ b/src/mui/field/TextField.js
@@ -1,8 +1,10 @@
 import React, { PropTypes } from 'react';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
 
-const TextField = ({ source, record = {}, elStyle }) =>
-    <span style={elStyle}>{get(record, source)}</span>;
+const TextField = ({ source, record = {}, elStyle }) => {
+    return <span style={elStyle}>{get(record, source)}</span>;
+}
 
 TextField.propTypes = {
     addLabel: PropTypes.bool,
@@ -12,8 +14,10 @@ TextField.propTypes = {
     source: PropTypes.string.isRequired,
 };
 
-TextField.defaultProps = {
+const PureTextField = pure(TextField);
+
+PureTextField.defaultProps = {
     addLabel: true,
 };
 
-export default TextField;
+export default PureTextField;

--- a/src/mui/field/UrlField.js
+++ b/src/mui/field/UrlField.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import get from 'lodash.get';
+import pure from 'recompose/pure';
 
 const UrlField = ({ source, record = {}, elStyle }) => (
     <a href={get(record, source)} style={elStyle}>
@@ -15,8 +16,10 @@ UrlField.propTypes = {
     source: PropTypes.string.isRequired,
 };
 
-UrlField.defaultProps = {
+const PureUrlField = pure(UrlField);
+
+PureUrlField.defaultProps = {
     addLabel: true,
 };
 
-export default UrlField;
+export default PureUrlField;

--- a/src/mui/layout/AppBar.js
+++ b/src/mui/layout/AppBar.js
@@ -1,0 +1,18 @@
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+import pure from 'recompose/pure';
+import MuiAppBar from 'material-ui/AppBar';
+import CircularProgress from 'material-ui/CircularProgress';
+
+const AppBar = ({ title, isLoading }) => {
+    const Title = <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
+    const RightElement = isLoading ? <CircularProgress color="#fff" size={30} thickness={2} style={{ margin: 8 }} /> : <span />;
+    return <MuiAppBar title={Title} iconElementRight={RightElement} />;
+};
+
+AppBar.propTypes = {
+    isLoading: PropTypes.bool.isRequired,
+    title: PropTypes.string.isRequired,
+};
+
+export default pure(AppBar);

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -1,10 +1,8 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
-import AppBar from 'material-ui/AppBar';
-import CircularProgress from 'material-ui/CircularProgress';
+import AppBar from './AppBar';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import Notification from './Notification';
 import Menu from './Menu';
@@ -12,14 +10,12 @@ import Menu from './Menu';
 injectTapEventPlugin();
 
 const Layout = ({ isLoading, children, route, title, theme }) => {
-    const Title = <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
-    const RightElement = isLoading ? <CircularProgress color="#fff" size={30} thickness={2} style={{ margin: 8 }} /> : <span />;
     const muiTheme = getMuiTheme(theme);
 
     return (
         <MuiThemeProvider muiTheme={muiTheme}>
             <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-                <AppBar title={Title} iconElementRight={RightElement} />
+                <AppBar title={title} isLoading={isLoading} />
                 <div className="body" style={{ display: 'flex', flex: '1', backgroundColor: '#edecec' }}>
                     <div style={{ flex: 1 }}>{children}</div>
                     <Menu resources={route.resources} />

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -3,6 +3,7 @@ import inflection from 'inflection';
 import Paper from 'material-ui/Paper';
 import { List, ListItem } from 'material-ui/List';
 import { Link } from 'react-router';
+import pure from 'recompose/pure';
 
 const Menu = ({ resources }) => (
     <Paper style={{ flex: '0 0 15em', order: -1 }}>
@@ -26,4 +27,4 @@ Menu.propTypes = {
     resources: PropTypes.array.isRequired,
 };
 
-export default Menu;
+export default pure(Menu);

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -86,6 +86,7 @@ class Datagrid extends Component {
                         {React.Children.map(children, (field, index) => (
                             <DatagridHeaderCell
                                 key={field.props.source || index}
+                                cacheKey={index}
                                 field={field}
                                 defaultStyle={index === 0 ? styles.header['th:first-child'] : styles.header.th}
                                 currentSort={currentSort}

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import DatagridCell from './DatagridCell';
 import DatagridHeaderCell from './DatagridHeaderCell';
+import DatagridBody from './DatagridBody';
 
 const defaultStyles = {
     table: {
@@ -78,7 +79,7 @@ class Datagrid extends Component {
     }
 
     render() {
-        const { resource, children, ids, data, currentSort, basePath, styles = defaultStyles, rowStyle } = this.props;
+        const { resource, children, ids, isLoading, data, currentSort, basePath, styles = defaultStyles, rowStyle } = this.props;
         return (
             <table style={styles.table}>
                 <thead>
@@ -86,29 +87,18 @@ class Datagrid extends Component {
                         {React.Children.map(children, (field, index) => (
                             <DatagridHeaderCell
                                 key={field.props.source || index}
-                                cacheKey={index}
                                 field={field}
                                 defaultStyle={index === 0 ? styles.header['th:first-child'] : styles.header.th}
                                 currentSort={currentSort}
+                                isSorting={field.props.source === currentSort.field}
                                 updateSort={this.updateSort}
                             />
                         ))}
                     </tr>
                 </thead>
-                <tbody style={styles.tbody}>
-                    {ids.map((id, rowIndex) => (
-                        <tr style={rowStyle ? rowStyle(data[id], rowIndex) : styles.tr} key={id}>
-                            {React.Children.map(children, (field, index) => (
-                                <DatagridCell
-                                    key={`${id}-${field.props.source || index}`}
-                                    record={data[id]}
-                                    defaultStyle={index === 0 ? styles.cell['td:first-child'] : styles.cell.td}
-                                    {...{ field, basePath, resource }}
-                                />
-                            ))}
-                        </tr>
-                    ))}
-                </tbody>
+                <DatagridBody resource={resource} ids={ids} data={data} basePath={basePath} styles={styles} rowStyle={rowStyle} isLoading={isLoading}>
+                    {children}
+                </DatagridBody>
             </table>
         );
     }
@@ -116,6 +106,7 @@ class Datagrid extends Component {
 
 Datagrid.propTypes = {
     ids: PropTypes.arrayOf(PropTypes.any).isRequired,
+    isLoading: PropTypes.bool,
     resource: PropTypes.string,
     data: PropTypes.object.isRequired,
     currentSort: PropTypes.shape({

--- a/src/mui/list/DatagridBody.js
+++ b/src/mui/list/DatagridBody.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react';
+import shouldUpdate from 'recompose/shouldUpdate';
+import DatagridCell from './DatagridCell';
+
+const DatagridBody = ({ resource, children, ids, data, basePath, styles, rowStyle }) => (
+    <tbody style={styles.tbody}>
+        {ids.map((id, rowIndex) => (
+            <tr style={rowStyle ? rowStyle(data[id], rowIndex) : styles.tr} key={id}>
+                {React.Children.map(children, (field, index) => (
+                    <DatagridCell
+                        key={`${id}-${field.props.source || index}`}
+                        record={data[id]}
+                        defaultStyle={index === 0 ? styles.cell['td:first-child'] : styles.cell.td}
+                        {...{ field, basePath, resource }}
+                    />
+                ))}
+            </tr>
+        ))}
+    </tbody>
+);
+
+DatagridBody.propTypes = {
+    ids: PropTypes.arrayOf(PropTypes.any).isRequired,
+    isLoading: PropTypes.bool,
+    resource: PropTypes.string,
+    data: PropTypes.object.isRequired,
+    basePath: PropTypes.string,
+    styles: PropTypes.object,
+    rowStyle: PropTypes.func,
+};
+
+DatagridBody.defaultProps = {
+    data: {},
+    ids: [],
+};
+
+export default shouldUpdate((props, nextProps) => nextProps.isLoading === false)(DatagridBody);

--- a/src/mui/list/DatagridCell.js
+++ b/src/mui/list/DatagridCell.js
@@ -6,7 +6,7 @@ const DatagridCell = ({ field, record, basePath, resource, defaultStyle }) => {
     const style = defaultsDeep({}, field.props.style, field.type.defaultProps ? field.type.defaultProps.style : {}, defaultStyle);
     return (
         <TableRowColumn style={style}>
-            <field.type {...field.props} {...{ record, basePath, resource }} />
+            {React.cloneElement(field, { record, basePath, resource })}
         </TableRowColumn>
     );
 };

--- a/src/mui/list/DatagridHeaderCell.js
+++ b/src/mui/list/DatagridHeaderCell.js
@@ -56,11 +56,11 @@ DatagridHeaderCell.propTypes = {
         sort: PropTypes.string,
         order: PropTypes.string,
     }),
+    isSorting: PropTypes.bool,
     updateSort: PropTypes.func.isRequired,
 };
 
 export default shouldUpdate((props, nextProps) =>
-    props.currentSort.field !== nextProps.currentSort.field
-    || props.currentSort.order !== nextProps.currentSort.order
-    || props.cacheKey !== nextProps.cacheKey
+    props.isSorting !== nextProps.isSorting
+    || (nextProps.isSorting && props.currentSort.order !== nextProps.currentSort.order)
 )(DatagridHeaderCell);

--- a/src/mui/list/DatagridHeaderCell.js
+++ b/src/mui/list/DatagridHeaderCell.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import defaultsDeep from 'lodash.defaultsdeep';
+import shouldUpdate from 'recompose/shouldUpdate';
 import { TableHeaderColumn } from 'material-ui/Table';
 import FlatButton from 'material-ui/FlatButton';
 import ContentSort from 'material-ui/svg-icons/content/sort';
@@ -58,4 +59,8 @@ DatagridHeaderCell.propTypes = {
     updateSort: PropTypes.func.isRequired,
 };
 
-export default DatagridHeaderCell;
+export default shouldUpdate((props, nextProps) =>
+    props.currentSort.field !== nextProps.currentSort.field
+    || props.currentSort.order !== nextProps.currentSort.order
+    || props.cacheKey !== nextProps.cacheKey
+)(DatagridHeaderCell);

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -185,6 +185,7 @@ export class List extends Component {
                     data,
                     currentSort: { field: query.sort, order: query.order },
                     basePath,
+                    isLoading,
                     setSort: this.setSort,
                 })}
                 {pagination && React.cloneElement(pagination, {

--- a/src/mui/list/Pagination.js
+++ b/src/mui/list/Pagination.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import pure from 'recompose/pure';
 import FlatButton from 'material-ui/FlatButton';
 import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
@@ -114,4 +115,4 @@ Pagination.propTypes = {
     setPage: PropTypes.func,
 };
 
-export default Pagination;
+export default pure(Pagination);


### PR DESCRIPTION
First step towards performance improvements

Measurements show a great improvement when updating the list (change sort, add filter change page): 630ms => 154ms.

The datagrid body no longer rerenders *before* fetching data. We still rerender the list heading (to update the sort icon before fetching), but only for columns that need it.

before:

![image](https://cloud.githubusercontent.com/assets/99944/22211016/05687e90-e18c-11e6-9398-edfca5d84c4b.png)


after:

![image](https://cloud.githubusercontent.com/assets/99944/22213187/801797fa-e193-11e6-8eb0-03fa8b128023.png)



