### PR TITLE
[RFR] Fix default list state

### DIFF
--- a/src/reducer/resource/list/params.js
+++ b/src/reducer/resource/list/params.js
@@ -1,14 +1,14 @@
 import { CRUD_CHANGE_LIST_PARAMS } from '../../../actions/listActions';
 
 const defaultState = {
-    sort: null,
-    order: null,
+    sort: 'id',
+    order: 'DESC',
     page: 1,
-    perPage: null,
+    perPage: 10,
     filter: {},
 };
 
-export default (resource) => (previousState = defaultState, { type, payload, meta }) => {
+export default resource => (previousState = defaultState, { type, payload, meta }) => {
     if (!meta || meta.resource !== resource) {
         return previousState;
     }

--- a/src/reducer/resource/list/params.spec.js
+++ b/src/reducer/resource/list/params.spec.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import reducer from './params';
+
+describe('List Params Reducer', () => {
+    it('should contains correct default state', () => {
+        const defaultState = reducer('foo')(undefined, {});
+        assert.deepEqual(defaultState, {
+            filter: {},
+            order: 'DESC',
+            page: 1,
+            perPage: 10,
+            sort: 'id',
+        });
+    });
+});


### PR DESCRIPTION
It especially fixes a weird behavior:

* Go on page 2 of posts list,
* Refresh your browser,
* Click on "Posts" menu item,
* List is not refreshed.