### PR TITLE
[RFR] Fix default list state

### DIFF
--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -59,6 +59,9 @@ export class List extends Component {
 
     componentDidMount() {
         this.updateData();
+        if (Object.keys(this.props.query).length > 0) {
+             this.props.changeListParams(this.props.resource, this.props.query);
+        }
     }
 
     componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
It fixes a weird behavior:

* Go on page 2 of posts list,
* Refresh your browser,
* Click on "Posts" menu item,
* List is not refreshed.

Supersedes #264 