### PR TITLE
[RFR] Fix pagination error in console

### DIFF
--- a/src/mui/list/Pagination.js
+++ b/src/mui/list/Pagination.js
@@ -10,6 +10,7 @@ export class Pagination extends Component {
     range() {
         const input = [];
         const { page, perPage, total } = this.props;
+        if (isNaN(page)) return input;
         const nbPages = Math.ceil(total / perPage) || 1;
 
         // display page links around the current page


### PR DESCRIPTION
Depending on a race condition, the pagination sometimes temporarily receives NaN as
page number. In that case, it shouldn't try to render a page button with
NaN as a label.