### PR TITLE
Fix validation on some inputs

### DIFF
--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -65,7 +65,7 @@ class AutocompleteInput extends Component {
     }
 
     render() {
-        const { choices, elStyle, filter, input, label, options, optionText, optionValue, setFilter, source } = this.props;
+        const { choices, elStyle, filter, input, label, options, optionText, optionValue, setFilter, source, meta: { touched, error } } = this.props;
 
         const selectedSource = choices.find(choice => choice[optionValue] === input.value);
         const option = typeof optionText === 'function' ?
@@ -85,6 +85,7 @@ class AutocompleteInput extends Component {
                 onUpdateInput={setFilter}
                 openOnFocus
                 style={elStyle}
+                errorText={touched && error}
                 {...options}
             />
         );
@@ -98,6 +99,7 @@ AutocompleteInput.propTypes = {
     filter: PropTypes.func.isRequired,
     input: PropTypes.object,
     label: PropTypes.string,
+    meta: PropTypes.object,
     options: PropTypes.object,
     optionElement: PropTypes.element,
     optionText: PropTypes.oneOfType([

--- a/src/mui/input/AutocompleteInput.spec.js
+++ b/src/mui/input/AutocompleteInput.spec.js
@@ -84,4 +84,24 @@ describe('<AutocompleteInput />', () => {
             { value: 'M', text: 'Male' },
         ]);
     });
+
+    describe('error message', () => {
+        it('should not be displayed if field is pristine', () => {
+            const wrapper = shallow(<AutocompleteInput {...defaultProps} meta={{ touched: false }} />);
+            const AutoCompleteElement = wrapper.find('AutoComplete');
+            assert.equal(AutoCompleteElement.prop('errorText'), false);
+        });
+
+        it('should not be displayed if field has been touched but is valid', () => {
+            const wrapper = shallow(<AutocompleteInput {...defaultProps} meta={{ touched: true, error: false }} />);
+            const AutoCompleteElement = wrapper.find('AutoComplete');
+            assert.equal(AutoCompleteElement.prop('errorText'), false);
+        });
+
+        it('should be displayed if field has been touched and is invalid', () => {
+            const wrapper = shallow(<AutocompleteInput {...defaultProps} meta={{ touched: true, error: 'Required field.' }} />);
+            const AutoCompleteElement = wrapper.find('AutoComplete');
+            assert.equal(AutoCompleteElement.prop('errorText'), 'Required field.');
+        });
+    });
 });

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -137,7 +137,7 @@ export class ReferenceInput extends Component {
     }
 
     render() {
-        const { input, resource, label, source, referenceRecord, allowEmpty, matchingReferences, basePath, onChange, children } = this.props;
+        const { input, resource, label, source, referenceRecord, allowEmpty, matchingReferences, basePath, onChange, children, meta } = this.props;
         if (!referenceRecord && !allowEmpty) {
             return <Labeled label={label} source={source} />;
         }
@@ -147,6 +147,7 @@ export class ReferenceInput extends Component {
             input,
             label,
             resource,
+            meta,
             source,
             choices: matchingReferences,
             basePath,
@@ -171,6 +172,7 @@ ReferenceInput.propTypes = {
     input: PropTypes.object.isRequired,
     label: PropTypes.string,
     matchingReferences: PropTypes.array,
+    meta: PropTypes.object,
     onChange: PropTypes.func,
     perPage: PropTypes.number,
     reference: PropTypes.string.isRequired,

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -3,6 +3,7 @@ import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { ReferenceInput } from './ReferenceInput';
+import { SelectInput } from './SelectInput';
 
 describe('<ReferenceInput />', () => {
     const defaultProps = {
@@ -182,5 +183,20 @@ describe('<ReferenceInput />', () => {
         assert.deepEqual(onChange.args[0], [
             'foo',
         ]);
+    });
+
+    it('should pass meta down to child component', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                meta={{ touched: false }}
+            >
+                <MyComponent />
+            </ReferenceInput>,
+        );
+
+        const myComponent = wrapper.find('MyComponent');
+        assert.notEqual(myComponent.prop('meta', undefined));
     });
 });

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -52,7 +52,7 @@ class SelectInput extends Component {
     handleChange = (event, index, value) => this.props.input.onChange(value);
 
     render() {
-        const { allowEmpty, input, label, choices, optionText, optionValue, options, source, elStyle } = this.props;
+        const { allowEmpty, input, label, choices, optionText, optionValue, options, source, elStyle, meta: { touched, error } } = this.props;
         const option = React.isValidElement(optionText) ? // eslint-disable-line no-nested-ternary
             choice => React.cloneElement(optionText, { record: choice }) :
             (typeof optionText === 'function' ?
@@ -67,6 +67,7 @@ class SelectInput extends Component {
                 onChange={this.handleChange}
                 autoWidth
                 style={elStyle}
+                errorText={touched && error}
                 {...options}
             >
                 {allowEmpty &&
@@ -87,6 +88,7 @@ SelectInput.propTypes = {
     elStyle: PropTypes.object,
     input: PropTypes.object,
     label: PropTypes.string,
+    meta: PropTypes.object,
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,

--- a/src/mui/input/SelectInput.spec.js
+++ b/src/mui/input/SelectInput.spec.js
@@ -113,4 +113,24 @@ describe('<SelectInput />', () => {
         assert.equal(MenuItemElement1.prop('value'), 'M');
         assert.deepEqual(MenuItemElement1.prop('primaryText'), <Foobar record={{ id: 'M', foobar: 'Male' }} />);
     });
+
+    describe('error message', () => {
+        it('should not be displayed if field is pristine', () => {
+            const wrapper = shallow(<SelectInput {...defaultProps} meta={{ touched: false }} />);
+            const SelectFieldElement = wrapper.find('SelectField');
+            assert.equal(SelectFieldElement.prop('errorText'), false);
+        });
+
+        it('should not be displayed if field has been touched but is valid', () => {
+            const wrapper = shallow(<SelectInput {...defaultProps} meta={{ touched: true, error: false }} />);
+            const SelectFieldElement = wrapper.find('SelectField');
+            assert.equal(SelectFieldElement.prop('errorText'), false);
+        });
+
+        it('should be displayed if field has been touched and is invalid', () => {
+            const wrapper = shallow(<SelectInput {...defaultProps} meta={{ touched: true, error: 'Required field.' }} />);
+            const SelectFieldElement = wrapper.find('SelectField');
+            assert.equal(SelectFieldElement.prop('errorText'), 'Required field.');
+        });
+    });
 });


### PR DESCRIPTION
Hi,

### issue 
marmelab/admin-on-rest#253

- AutocompleteInput: still some validation issues, but it needs refactoring
- ReferenceInput
- SelectInput


### ~notes~ (reverted)
~[Line 65 of SelectInput.js](https://github.com/marmelab/admin-on-rest/pull/289/files?diff=split#diff-5470e5c0cbc29b42c57d5cdfd5170621L65)~

![selection_050](https://cloud.githubusercontent.com/assets/18367406/22652733/e0971d54-ec87-11e6-963c-098bfcc3d31e.png)
![selection_049](https://cloud.githubusercontent.com/assets/18367406/22652734/e09aa898-ec87-11e6-8fb9-9e218be26e20.png)
