### PR TITLE
[RFR] Fix Refresh button doesn't refresh reference fields

### DIFF
--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -29,6 +29,10 @@ export class Edit extends Component {
     componentWillReceiveProps(nextProps) {
         if (this.props.data !== nextProps.data) {
             this.setState({ record: nextProps.data }); // FIXME: erases user entry when fetch response arrives late
+            if (this.fullRefresh) {
+                this.fullRefresh = false;
+                this.setState({ key: this.state.key + 1 });
+            }
         }
         if (this.props.id !== nextProps.id) {
             this.updateData(nextProps.resource, nextProps.id);
@@ -58,7 +62,8 @@ export class Edit extends Component {
 
     refresh = (event) => {
         event.stopPropagation();
-        this.setState({ key: this.state.key + 1 }, () => this.updateData());
+        this.fullRefresh = true;
+        this.updateData();
     }
 
     handleSubmit(record) {

--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -15,7 +15,10 @@ const arrayizeChildren = children => (Array.isArray(children) ? children : [chil
 export class Edit extends Component {
     constructor(props) {
         super(props);
-        this.state = { record: props.data };
+        this.state = {
+            key: 0,
+            record: props.data,
+        };
         this.handleSubmit = this.handleSubmit.bind(this);
     }
 
@@ -55,7 +58,7 @@ export class Edit extends Component {
 
     refresh = (event) => {
         event.stopPropagation();
-        this.updateData();
+        this.setState({ key: this.state.key + 1 }, () => this.updateData());
     }
 
     handleSubmit(record) {
@@ -64,10 +67,11 @@ export class Edit extends Component {
 
     render() {
         const { actions = <DefaultActions />, children, data, hasDelete, hasShow, id, isLoading, resource, title } = this.props;
+        const { key } = this.state;
         const basePath = this.getBasePath();
 
         return (
-            <Card style={{ margin: '2em', opacity: isLoading ? 0.8 : 1 }}>
+            <Card style={{ margin: '2em', opacity: isLoading ? 0.8 : 1 }} key={key}>
                 {actions && React.cloneElement(actions, {
                     basePath,
                     data,

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -72,6 +72,10 @@ export class List extends Component {
          || nextProps.query.filter !== this.props.query.filter) {
             this.updateData(Object.keys(nextProps.query).length > 0 ? nextProps.query : nextProps.params);
         }
+        if (nextProps.data !== this.props.data && this.fullRefresh) {
+            this.fullRefresh = false;
+            this.setState({ key: this.state.key + 1 });
+        }
         if (Object.keys(nextProps.filters).length === 0 && Object.keys(this.props.filters).length === 0) {
             return;
         }
@@ -104,7 +108,8 @@ export class List extends Component {
 
     refresh = (event) => {
         event.stopPropagation();
-        this.setState({ key: this.state.key + 1 }, () => this.updateData());
+        this.fullRefresh = true;
+        this.updateData();
     }
 
     /**

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -54,7 +54,7 @@ export class List extends Component {
     constructor(props) {
         super(props);
         this.debouncedSetFilters = debounce(this.setFilters.bind(this), 500);
-        this.state = {};
+        this.state = { key: 0 };
     }
 
     componentDidMount() {
@@ -104,7 +104,7 @@ export class List extends Component {
 
     refresh = (event) => {
         event.stopPropagation();
-        this.updateData();
+        this.setState({ key: this.state.key + 1 }, () => this.updateData());
     }
 
     /**
@@ -153,11 +153,12 @@ export class List extends Component {
 
     render() {
         const { filter, pagination = <DefaultPagination />, actions = <DefaultActions />, resource, hasCreate, title, data, ids, total, children, isLoading } = this.props;
+        const { key } = this.state;
         const query = this.getQuery();
         const filterValues = query.filter;
         const basePath = this.getBasePath();
         return (
-            <Card style={{ margin: '2em', opacity: isLoading ? 0.8 : 1 }}>
+            <Card style={{ margin: '2em', opacity: isLoading ? 0.8 : 1 }} key={key}>
                 {actions && React.cloneElement(actions, {
                     resource,
                     filter,


### PR DESCRIPTION
To force fetching again data in inner components (e.g. in `<ReferenceField>`), we change the value of the `key` prop on reload.

(`forceUpdate()` should also work, but a) [it's discouraged](http://stackoverflow.com/a/35004739/1333479), and b) it doesn't work for some reason)

- [x] Proof of concept
- [x] Backport to master
- [x] Test more

Note: This doesn't work on the blog example (i.e. no refreshing of the referenne fields) because `aor-json-rest-client` returns always the same record and therefore passes the strict equality check. I'll fix that in the related repository.

Fixes #279 
