### PR TITLE
[RFR] Remove translate warnings when using empty label on buttons

### DIFF
--- a/src/mui/button/CreateButton.js
+++ b/src/mui/button/CreateButton.js
@@ -7,7 +7,7 @@ import Translate from '../../i18n/Translate';
 
 const CreateButton = ({ basePath = '', translate, label = 'aor.action.create' }) => <FlatButton
     primary
-    label={translate(label)}
+    label={label && translate(label)}
     icon={<ContentAdd />}
     containerElement={<Link to={`${basePath}/create`} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/DeleteButton.js
+++ b/src/mui/button/DeleteButton.js
@@ -7,7 +7,7 @@ import Translate from '../../i18n/Translate';
 
 const DeleteButton = ({ basePath = '', label = 'aor.action.delete', record = {}, translate }) => <FlatButton
     secondary
-    label={translate(label)}
+    label={label && translate(label)}
     icon={<ActionDelete />}
     containerElement={<Link to={`${linkToRecord(basePath, record.id)}/delete`} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/EditButton.js
+++ b/src/mui/button/EditButton.js
@@ -8,7 +8,7 @@ import Translate from '../../i18n/Translate';
 
 const EditButton = ({ basePath = '', label = 'aor.action.edit', record = {}, translate }) => <FlatButton
     primary
-    label={translate(label)}
+    label={label && translate(label)}
     icon={<ContentCreate />}
     containerElement={<Link to={linkToRecord(basePath, record.id)} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/ListButton.js
+++ b/src/mui/button/ListButton.js
@@ -6,7 +6,7 @@ import Translate from '../../i18n/Translate';
 
 const ListButton = ({ basePath = '', label = 'aor.action.list', translate }) => <FlatButton
     primary
-    label={translate(label)}
+    label={label && translate(label)}
     icon={<ActionList />}
     containerElement={<Link to={basePath} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/RefreshButton.js
+++ b/src/mui/button/RefreshButton.js
@@ -5,7 +5,7 @@ import Translate from '../../i18n/Translate';
 
 const RefreshButton = ({ label = 'aor.action.refresh', translate, refresh }) => <FlatButton
     primary
-    label={translate(label)}
+    label={label && translate(label)}
     onClick={refresh}
     icon={<NavigationRefresh />}
 />;

--- a/src/mui/button/SaveButton.js
+++ b/src/mui/button/SaveButton.js
@@ -18,7 +18,7 @@ class SaveButton extends Component {
         const { saving, label = 'aor.action.save', translate } = this.props;
         return <RaisedButton
             type="submit"
-            label={translate(label)}
+            label={label && translate(label)}
             icon={saving ? <CircularProgress size={25} thickness={2} /> : <ContentSave />}
             onClick={this.handleClick}
             primary={!saving}

--- a/src/mui/button/ShowButton.js
+++ b/src/mui/button/ShowButton.js
@@ -7,7 +7,7 @@ import Translate from '../../i18n/Translate';
 
 const ShowButton = ({ basePath = '', label = 'aor.action.show', record = {}, translate }) => <FlatButton
     primary
-    label={translate(label)}
+    label={label && translate(label)}
     icon={<ImageEye />}
     containerElement={<Link to={`${linkToRecord(basePath, record.id)}/show`} />}
     style={{ overflow: 'inherit' }}


### PR DESCRIPTION
Apparently, the empty string is a valid key for polyglot.js, so it complains that there is no translation. If you want my opinion, it's a polyglot bug, but the maintainers disagree:

https://github.com/airbnb/polyglot.js/pull/85

So we're relmoving the warnings from the admin-on-rest side.