### PR TITLE
[RFR] Add the ability to add custom routes

### DIFF
--- a/docs/AdminResource.md
+++ b/docs/AdminResource.md
@@ -37,6 +37,7 @@ Here are all the props accepted by the component:
 * [`appLayout`](#applayout)
 * [`customReducers`](#customreducers)
 * [`customSagas`](#customsagas)
+* [`customRoutes`](#customroutes)
 * [`authClient`](#authclient)
 * [`loginPage`](#loginpage)
 * [`logoutButton`](#logoutbutton)
@@ -285,6 +286,49 @@ const App = () => (
 
 export default App;
 ```
+
+### `customRoutes`
+
+To register your own routes, create a function returning a [react-router](https://github.com/ReactTraining/react-router) `<Route>` component:
+
+```js
+// in src/customRoutes.js
+import React from 'react';
+import { Route } from 'react-router';
+import Foo from './Foo';
+import Bar from './Bar';
+
+export default () => (
+    <Route>
+        <Route path="/foo" component={Foo} />
+        <Route path="/bar" component={Bar} />
+    </Route>
+);
+```
+
+Then, pass this function as `customRoutes` prop to the `<Admin>` component:
+
+```js
+// in src/App.js
+import React from 'react';
+import { Admin } from 'admin-on-rest';
+
+import customRoutes from './customRoutes';
+
+const App = () => (
+    <Admin customRoutes={customRoutes} restClient={jsonServerRestClient('http://jsonplaceholder.typicode.com')}>
+        ...
+    </Admin>
+);
+
+export default App;
+```
+
+Now, when a user browses to `/foo` or `/bar`, the components you defined will appear in the main part of the screen.
+
+**Tip**: It's up to you to create a [custom menu](#applayout) entry, or custom buttons, to lead to your custom pages.
+
+**Tip**: Your custom pages take precedence over admin-on-rest's own routes. That means that `customRoutes` lets you override any route you want!
 
 ### `authClient`
 

--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -5,9 +5,11 @@ title: "Including the Admin in Another App"
 
 # Including admin-on-rest on another React app
 
-The `<Admin>` tag is a great shortcut got be up and running with admin-on-rest in minutes. However, in many cases, you will want to embed the admin in another application, or customize the admin deeply (custom menus, custom actions, custom reducers). Fortunately, you can do all the work that `<Admin>` does on any React application.
+The `<Admin>` tag is a great shortcut got be up and running with admin-on-rest in minutes. However, in many cases, you will want to embed the admin in another application, or customize the admin deeply. Fortunately, you can do all the work that `<Admin>` does on any React application.
 
 Beware that you need to know about [redux](http://redux.js.org/), [react-router](https://github.com/reactjs/react-router), and [redux-saga](https://github.com/yelouafi/redux-saga) to go further.
+
+**Tip**: Before going for the Custom App route, explore all the options of [the `<Admin>` component](./AdminResource.html##the-admin-component). They allow you to add custom routes, custom reducers, custom sagas, and customize the layout.
 
 ## Basic Admin App
 

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -24,6 +24,7 @@ const Admin = ({
     children,
     customReducers = {},
     customSagas = [],
+    customRoutes,
     dashboard,
     locale = DEFAULT_LOCALE,
     messages = {},
@@ -78,6 +79,7 @@ const Admin = ({
                     {dashboard ? undefined : <Redirect from="/" to={`/${firstResource}`} />}
                     <Route path="/login" component={LoginPage} />
                     <Route path="/" component={Layout} resources={resources}>
+                        {customRoutes && customRoutes()}
                         {dashboard && <IndexRoute component={dashboard} onEnter={onEnter()} />}
                         {resources.map(resource =>
                             <CrudRoute
@@ -107,6 +109,7 @@ Admin.propTypes = {
     children: PropTypes.node,
     customSagas: PropTypes.array,
     customReducers: PropTypes.object,
+    customRoutes: PropTypes.func,
     dashboard: componentPropType,
     loginPage: componentPropType,
     logoutButton: componentPropType,


### PR DESCRIPTION
Closes #283

To register your own routes, create a function returning a [react-router](https://github.com/ReactTraining/react-router) `<Route>` component:

```js
// in src/customRoutes.js
import React from 'react';
import { Route } from 'react-router';
import Foo from './Foo';
import Bar from './Bar';

export default () => (
    <Route>
        <Route path="/foo" component={Foo} />
        <Route path="/bar" component={Bar} />
    </Route>
);
```

Then, pass this function as `customRoutes` prop to the `<Admin>` component:

```js
// in src/App.js
import React from 'react';
import { Admin } from 'admin-on-rest';

import customRoutes from './customRoutes';

const App = () => (
    <Admin customRoutes={customRoutes} restClient={jsonServerRestClient('http://jsonplaceholder.typicode.com')}>
        ...
    </Admin>
);

export default App;
```

Now, when a user browses to `/foo` or `/bar`, the components you defined will appear in the main part of the screen.