### PR TITLE
[RFR] Add peerDependencies for react-dropzone

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,9 @@
     "redux-form": "~6.2.0",
     "redux-saga": "~0.14.2",
     "reselect": "~2.5.4"
+  },
+  "peerDependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-stage-0": "^6.22.0"
   }
 }


### PR DESCRIPTION
After updating aor to 0.8, I had this error on our project :
```
Module build failed: ReferenceError: Unknown plugin "add-module-exports" specified in
"/app/node_modules/react-dropzone/.babelrc" at 0, attempted to resolve relative to
"/app/node_modules/react-dropzone"
```
 Installing `babel-plugin-add-module-exports` and `babel-preset-stage-0` has resolved the problem.