### PR TITLE
Translation function Backward compatibility fix for 0.8.0.

### DIFF
--- a/src/mui/button/CreateButton.js
+++ b/src/mui/button/CreateButton.js
@@ -5,9 +5,9 @@ import FlatButton from 'material-ui/FlatButton';
 import ContentAdd from 'material-ui/svg-icons/content/add';
 import translate from '../../i18n/translate';
 
-const CreateButton = ({ basePath = '', translate, label = 'aor.action.create' }) => <FlatButton
+const CreateButton = ({ basePath = '', translate, label }) => <FlatButton
     primary
-    label={label && translate(label)}
+    label={label || translate('aor.action.create')}
     icon={<ContentAdd />}
     containerElement={<Link to={`${basePath}/create`} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/DeleteButton.js
+++ b/src/mui/button/DeleteButton.js
@@ -5,9 +5,9 @@ import ActionDelete from 'material-ui/svg-icons/action/delete';
 import linkToRecord from '../../util/linkToRecord';
 import translate from '../../i18n/translate';
 
-const DeleteButton = ({ basePath = '', label = 'aor.action.delete', record = {}, translate }) => <FlatButton
+const DeleteButton = ({ basePath = '', label , record = {}, translate }) => <FlatButton
     secondary
-    label={label && translate(label)}
+    label={label || translate('aor.action.delete')}
     icon={<ActionDelete />}
     containerElement={<Link to={`${linkToRecord(basePath, record.id)}/delete`} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/EditButton.js
+++ b/src/mui/button/EditButton.js
@@ -6,9 +6,9 @@ import ContentCreate from 'material-ui/svg-icons/content/create';
 import linkToRecord from '../../util/linkToRecord';
 import translate from '../../i18n/translate';
 
-const EditButton = ({ basePath = '', label = 'aor.action.edit', record = {}, translate }) => <FlatButton
+const EditButton = ({ basePath = '', label, record = {}, translate }) => <FlatButton
     primary
-    label={label && translate(label)}
+    label={label || translate('aor.action.edit')}
     icon={<ContentCreate />}
     containerElement={<Link to={linkToRecord(basePath, record.id)} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/ListButton.js
+++ b/src/mui/button/ListButton.js
@@ -4,9 +4,9 @@ import FlatButton from 'material-ui/FlatButton';
 import ActionList from 'material-ui/svg-icons/action/list';
 import translate from '../../i18n/translate';
 
-const ListButton = ({ basePath = '', label = 'aor.action.list', translate }) => <FlatButton
+const ListButton = ({ basePath = '', label, translate }) => <FlatButton
     primary
-    label={label && translate(label)}
+    label={label || translate('aor.action.list')}
     icon={<ActionList />}
     containerElement={<Link to={basePath} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/button/RefreshButton.js
+++ b/src/mui/button/RefreshButton.js
@@ -3,9 +3,9 @@ import FlatButton from 'material-ui/FlatButton';
 import NavigationRefresh from 'material-ui/svg-icons/navigation/refresh';
 import translate from '../../i18n/translate';
 
-const RefreshButton = ({ label = 'aor.action.refresh', translate, refresh }) => <FlatButton
+const RefreshButton = ({ label, translate, refresh }) => <FlatButton
     primary
-    label={label && translate(label)}
+    label={label || translate('aor.action.refresh')}
     onClick={refresh}
     icon={<NavigationRefresh />}
 />;

--- a/src/mui/button/SaveButton.js
+++ b/src/mui/button/SaveButton.js
@@ -15,10 +15,10 @@ class SaveButton extends Component {
     }
 
     render() {
-        const { saving, label = 'aor.action.save', translate } = this.props;
+        const { saving, label, translate } = this.props;
         return <RaisedButton
             type="submit"
-            label={label && translate(label)}
+            label={label || translate('aor.action.save')}
             icon={saving ? <CircularProgress size={25} thickness={2} /> : <ContentSave />}
             onClick={this.handleClick}
             primary={!saving}

--- a/src/mui/button/ShowButton.js
+++ b/src/mui/button/ShowButton.js
@@ -5,9 +5,9 @@ import ImageEye from 'material-ui/svg-icons/image/remove-red-eye';
 import linkToRecord from '../../util/linkToRecord';
 import translate from '../../i18n/translate';
 
-const ShowButton = ({ basePath = '', label = 'aor.action.show', record = {}, translate }) => <FlatButton
+const ShowButton = ({ basePath = '', label, record = {}, translate }) => <FlatButton
     primary
-    label={label && translate(label)}
+    label={label || translate('aor.action.show')}
     icon={<ImageEye />}
     containerElement={<Link to={`${linkToRecord(basePath, record.id)}/show`} />}
     style={{ overflow: 'inherit' }}

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -32,7 +32,7 @@ const Menu = ({ resources, translate, logout }) => (
                     <ListItem
                         key={resource.name}
                         containerElement={<Link to={`/${resource.name}`} />}
-                        primaryText={translatedResourceName(resource, translate)}
+                        primaryText={resource.options.label || translatedResourceName(resource, translate)}
                         leftIcon={<resource.icon />}
                     />,
                 )

--- a/src/mui/layout/Title.js
+++ b/src/mui/layout/Title.js
@@ -6,7 +6,7 @@ const Title = ({ defaultTitle, record, title, translate }) => {
         return <span>{defaultTitle}</span>;
     }
     if (typeof title === 'string') {
-        return <span>{translate(title, { _: defaultTitle })}</span>;
+        return <span>{title}</span>;
     }
     return React.cloneElement(title, { record });
 };

--- a/src/util/FieldTitle.js
+++ b/src/util/FieldTitle.js
@@ -7,8 +7,8 @@ import translate from '../i18n/translate';
 
 const FieldTitle = ({ resource, source, label, translate }) => (
     <span>
-        {typeof label !== 'undefined' ?
-            translate(label, { _: label })
+        {typeof label === 'string' ?
+            label
             :
             (typeof source !== 'undefined' ?
                 translate(`resources.${resource}.fields.${source}`, { _: inflection.humanize(source) })


### PR DESCRIPTION
This pull request fixes following use cases after update to 0.8.0:

1. Setting `options.label` for `<Resource/>`
2. Setting string type `title` for `<List/>`, `<Show/>`, `<Edit/>`, `<Create/>`
3. Setting custom `label` for InputFields.
