### PR TITLE
[RFR] Handle sidebar toggle

### DIFF
--- a/src/mui/layout/AppBar.js
+++ b/src/mui/layout/AppBar.js
@@ -4,15 +4,16 @@ import pure from 'recompose/pure';
 import MuiAppBar from 'material-ui/AppBar';
 import CircularProgress from 'material-ui/CircularProgress';
 
-const AppBar = ({ title, isLoading }) => {
+const AppBar = ({ title, isLoading, onLeftIconButtonTouchTap }) => {
     const Title = <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
     const RightElement = isLoading ? <CircularProgress color="#fff" size={30} thickness={2} style={{ margin: 8 }} /> : <span />;
-    return <MuiAppBar title={Title} iconElementRight={RightElement} />;
+    return <MuiAppBar title={Title} iconElementRight={RightElement} onLeftIconButtonTouchTap={onLeftIconButtonTouchTap} />;
 };
 
 AppBar.propTypes = {
     isLoading: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired,
+    onLeftIconButtonTouchTap: PropTypes.func.isRequired,
 };
 
 export default pure(AppBar);

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -11,21 +11,58 @@ import defaultTheme from '../defaultTheme';
 
 injectTapEventPlugin();
 
-const Layout = ({ isLoading, children, route, title, theme, logout }) => {
-    const muiTheme = getMuiTheme(theme);
-    const prefix = autoprefixer(muiTheme);
-    return (
-        <MuiThemeProvider muiTheme={muiTheme}>
-            <div style={prefix({ display: 'flex', flexDirection: 'column', minHeight: '100vh' })}>
-                <AppBar title={title} isLoading={isLoading} />
-                <div className="body" style={prefix({ display: 'flex', flex: '1', backgroundColor: '#edecec' })}>
-                    <div style={prefix({ flex: 1 })}>{children}</div>
-                    <Menu resources={route.resources} logout={logout} />
+const styles = {
+    main: {
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100vh',
+    },
+    body: {
+        backgroundColor: '#edecec',
+        display: 'flex',
+        flex: 1,
+        overflow: 'hidden',
+    },
+    content: {
+        flex: 1,
+    },
+};
+
+const prefixedStyles = {};
+
+class Layout extends Component {
+    state = {
+        sidebarOpen: true,
+    };
+
+    toggleSidebar = () => {
+        this.setState({ sidebarOpen: !this.state.sidebarOpen });
+    }
+
+    render() {
+        const { isLoading, children, route, title, theme, logout } = this.props;
+        const { sidebarOpen } = this.state;
+        const muiTheme = getMuiTheme(theme);
+        if (!prefixedStyles.main) {
+            // do this once because user agent never changes
+            const prefix = autoprefixer(muiTheme);
+            prefixedStyles.main = prefix(styles.main);
+            prefixedStyles.body = prefix(styles.body);
+            prefixedStyles.content = prefix(styles.content);
+        }
+        return (
+            <MuiThemeProvider muiTheme={muiTheme}>
+                <div style={prefixedStyles.main}>
+                    <AppBar title={title} isLoading={isLoading} onLeftIconButtonTouchTap={this.toggleSidebar} />
+                    <div className="body" style={prefixedStyles.body}>
+                        <Menu resources={route.resources} logout={logout} open={sidebarOpen} />
+                        <div style={prefixedStyles.content}>{children}</div>
+                    </div>
+                    <Notification />
                 </div>
-                <Notification />
-            </div>
-        </MuiThemeProvider>
-    );
+            </MuiThemeProvider>
+        );
+    }
 };
 
 Layout.propTypes = {

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -55,8 +55,8 @@ class Layout extends Component {
                 <div style={prefixedStyles.main}>
                     <AppBar title={title} isLoading={isLoading} onLeftIconButtonTouchTap={this.toggleSidebar} />
                     <div className="body" style={prefixedStyles.body}>
-                        <Menu resources={route.resources} logout={logout} open={sidebarOpen} />
                         <div style={prefixedStyles.content}>{children}</div>
+                        <Menu resources={route.resources} logout={logout} open={sidebarOpen} />
                     </div>
                     <Notification />
                 </div>

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -9,16 +9,16 @@ import translate from '../../i18n/translate';
 
 const styles = {
     open: {
-        flex: '0 0 15em',
+        flex: '0 0 16em',
         order: -1,
         transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
         marginLeft: 0,
     },
     closed: {
-        flex: '0 0 15em',
+        flex: '0 0 16em',
         order: -1,
         transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
-        marginLeft: '-15em',
+        marginLeft: '-16em',
     },
 };
 

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -4,14 +4,20 @@ import Paper from 'material-ui/Paper';
 import { List, ListItem } from 'material-ui/List';
 import { Link } from 'react-router';
 import pure from 'recompose/pure';
+import compose from 'recompose/compose';
 import translate from '../../i18n/translate';
 
-const style = {
-    flex: '0 0 15em',
-    order: -1,
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
+const styles = {
+    open: {
+        flex: '0 0 15em',
+        transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
+        marginLeft: 0,
+    },
+    closed: {
+        flex: '0 0 15em',
+        transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
+        marginLeft: '-15em',
+    },
 };
 
 const translatedResourceName = (resource, translate) =>
@@ -22,8 +28,8 @@ const translatedResourceName = (resource, translate) =>
             inflection.humanize(inflection.pluralize(resource.name)),
     });
 
-const Menu = ({ resources, translate, logout }) => (
-    <Paper style={style}>
+const Menu = ({ resources, translate, logout, open }) => (
+    <Paper style={open ? styles.open : styles.closed}>
         <List>
             {resources
                 .filter(r => r.list)
@@ -47,4 +53,9 @@ Menu.propTypes = {
     logout: PropTypes.element,
 };
 
-export default translate(pure(Menu));
+const enhanced = compose(
+    pure,
+    translate,
+);
+
+export default enhanced(Menu);

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -10,11 +10,13 @@ import translate from '../../i18n/translate';
 const styles = {
     open: {
         flex: '0 0 15em',
+        order: -1,
         transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
         marginLeft: 0,
     },
     closed: {
         flex: '0 0 15em',
+        order: -1,
         transition: 'margin 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms',
         marginLeft: '-15em',
     },


### PR DESCRIPTION
- [x] Allow to show sidebar using hamburger
- [ ] ~~Show sidebar or not depending on the screen width~~
- [ ] ~~Allow to hide sidebar on large screens using hamburger~~
- [ ] ~~Allo to hide sidebar on small screens by clickaway~~
- [ ] ~~on small screens, hide sidebar after menu click~~

Not dealing with the small screen use case as in #322. This would require switching to a `<Drawer>` component for the menu in small screens, which is possible, but demands more work. Besides, admin-on-rest isn't fitted for small screens, yet (see #282).

Closes #258