### PR TITLE
[RFR] Use mui <Table> element for datagrid

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -232,6 +232,10 @@ Here are all the props accepted by the component:
 
 * [`styles`](#custom-grid-style)
 * [`rowStyle`](#row-style-function)
+* [`options`](#options)
+* [`headerOptions`](#options)
+* [`bodyOptions`](#options)
+* [`rowOptions`](#options)
 
 It renders as many columns as it receives `<Field>` children.
 
@@ -322,6 +326,36 @@ export const PostList = (props) => (
     </List>
 );
 ```
+
+### `options`, `headerOptions`, `bodyOptions`, and `rowOptions`
+
+Admin-on-rest relies on [material-ui's `<Table>` component](http://www.material-ui.com/#/components/table) for rendering the datagrid. The `options`, `headerOptions`, `bodyOptions`, and `rowOptions` props allow your to override the props of `<Table>`, `<TableHeader>`, `<TableBody>`, and `<TableRow>`.
+
+For instance, to get a fixed header on the table, override the `<Table>` props with `options`:
+
+```js
+export const PostList = (props) => (
+    <List {...props}>
+        <Datagrid options={{ fixedHeader: true, height: 400 }}>
+            ...
+        </Datagrid>
+    </List>
+);
+```
+
+To enable striped rows and row hover, override the `<TableBody>` props with `bodyOptions`:
+
+```js
+export const PostList = (props) => (
+    <List {...props}>
+        <Datagrid bodyOptions={{ stripedRows: true, showRowHover: true }}>
+            ...
+        </Datagrid>
+    </List>
+);
+```
+
+For a list of all the possible props that you can override via these options, please refer to [the material-ui `<Table>` component documentation](http://www.material-ui.com/#/components/table).
 
 ## The `<SingleFieldList>` component
 

--- a/src/mui/defaultTheme.js
+++ b/src/mui/defaultTheme.js
@@ -7,16 +7,4 @@ export default {
     inkBar: {
         backgroundColor: '#00bcd4',
     },
-    table: {
-        backgroundColor: 'white',
-        padding: '0px 24px',
-        width: '100%',
-        borderCollapse: 'collapse',
-        borderSpacing: 0,
-    },
-    tableRow: {
-        borderBottom: '1px solid rgb(224, 224, 224)',
-        color: 'rgba(0, 0, 0, 0.870588)',
-        height: 48,
-    },
 };

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -1,10 +1,14 @@
 import React, { Component, PropTypes } from 'react';
 import muiThemeable from 'material-ui/styles/muiThemeable';
+import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn } from 'material-ui/Table';
 import DatagridCell from './DatagridCell';
 import DatagridHeaderCell from './DatagridHeaderCell';
 import DatagridBody from './DatagridBody';
 
 const defaultStyles = {
+    table: {
+        tableLayout: 'auto',
+    },
     tbody: {
         height: 'inherit',
     },
@@ -35,6 +39,10 @@ const defaultStyles = {
  * Props:
  *  - styles
  *  - rowStyle
+ *  - options (passed as props to <Table>)
+ *  - headerOptions (passed as props to mui <TableHeader>)
+ *  - bodyOptions (passed as props to mui <TableBody>)
+ *  - rowOptions (passed as props to mui <TableRow>)
  *
  * @example Display all posts as a datagrid
  * const postRowStyle = (record, index) => ({
@@ -68,11 +76,11 @@ class Datagrid extends Component {
     }
 
     render() {
-        const { resource, children, ids, isLoading, data, currentSort, basePath, styles = defaultStyles, muiTheme, rowStyle } = this.props;
+        const { resource, children, ids, isLoading, data, currentSort, basePath, styles = defaultStyles, muiTheme, rowStyle, options, headerOptions, bodyOptions, rowOptions } = this.props;
         return (
-            <table style={muiTheme.table}>
-                <thead>
-                    <tr style={muiTheme.tableRow}>
+            <Table style={options && options.fixedHeader ? null : styles.table} fixedHeader={false} {...options}>
+                <TableHeader displaySelectAll={false} adjustForCheckbox={false} {...headerOptions}>
+                    <TableRow style={muiTheme.tableRow}>
                         {React.Children.map(children, (field, index) => (
                             <DatagridHeaderCell
                                 key={field.props.source || index}
@@ -84,30 +92,34 @@ class Datagrid extends Component {
                                 resource={resource}
                             />
                         ))}
-                    </tr>
-                </thead>
-                <DatagridBody resource={resource} ids={ids} data={data} basePath={basePath} styles={styles} rowStyle={rowStyle} isLoading={isLoading}>
+                    </TableRow>
+                </TableHeader>
+                <DatagridBody resource={resource} ids={ids} data={data} basePath={basePath} styles={styles} rowStyle={rowStyle} isLoading={isLoading} options={bodyOptions} rowOptions={rowOptions}>
                     {children}
                 </DatagridBody>
-            </table>
+            </Table>
         );
     }
 }
 
 Datagrid.propTypes = {
-    ids: PropTypes.arrayOf(PropTypes.any).isRequired,
-    isLoading: PropTypes.bool,
-    resource: PropTypes.string,
-    data: PropTypes.object.isRequired,
+    basePath: PropTypes.string,
+    bodyOptions: PropTypes.object,
     currentSort: PropTypes.shape({
         sort: PropTypes.string,
         order: PropTypes.string,
     }),
-    basePath: PropTypes.string,
+    data: PropTypes.object.isRequired,
+    headerOptions: PropTypes.object,
+    ids: PropTypes.arrayOf(PropTypes.any).isRequired,
+    isLoading: PropTypes.bool,
+    muiTheme: PropTypes.object,
+    options: PropTypes.object,
+    resource: PropTypes.string,
+    rowOptions: PropTypes.object,
+    rowStyle: PropTypes.func,
     setSort: PropTypes.func,
     styles: PropTypes.object,
-    muiTheme: PropTypes.object,
-    rowStyle: PropTypes.func,
 };
 
 Datagrid.defaultProps = {

--- a/src/mui/list/DatagridBody.js
+++ b/src/mui/list/DatagridBody.js
@@ -1,11 +1,12 @@
 import React, { PropTypes } from 'react';
 import shouldUpdate from 'recompose/shouldUpdate';
+import { TableBody, TableRow } from 'material-ui/Table';
 import DatagridCell from './DatagridCell';
 
-const DatagridBody = ({ resource, children, ids, data, basePath, styles, rowStyle }) => (
-    <tbody style={styles.tbody}>
+const DatagridBody = ({ resource, children, ids, data, basePath, styles, rowStyle, options, rowOptions, ...rest }) => (
+    <TableBody displayRowCheckbox={false} {...rest} {...options}>
         {ids.map((id, rowIndex) => (
-            <tr style={rowStyle ? rowStyle(data[id], rowIndex) : styles.tr} key={id}>
+            <TableRow style={rowStyle ? rowStyle(data[id], rowIndex) : styles.tr} key={id} {...rowOptions}>
                 {React.Children.map(children, (field, index) => (
                     <DatagridCell
                         key={`${id}-${field.props.source || index}`}
@@ -14,9 +15,9 @@ const DatagridBody = ({ resource, children, ids, data, basePath, styles, rowStyl
                         {...{ field, basePath, resource }}
                     />
                 ))}
-            </tr>
+            </TableRow>
         ))}
-    </tbody>
+    </TableBody>
 );
 
 DatagridBody.propTypes = {
@@ -25,6 +26,8 @@ DatagridBody.propTypes = {
     resource: PropTypes.string,
     data: PropTypes.object.isRequired,
     basePath: PropTypes.string,
+    options: PropTypes.object,
+    rowOptions: PropTypes.object,
     styles: PropTypes.object,
     rowStyle: PropTypes.func,
 };
@@ -34,4 +37,9 @@ DatagridBody.defaultProps = {
     ids: [],
 };
 
-export default shouldUpdate((props, nextProps) => nextProps.isLoading === false)(DatagridBody);
+const PureDatagridBody = shouldUpdate((props, nextProps) => nextProps.isLoading === false)(DatagridBody);
+
+// trick material-ui Table into thinking this is one of the child type it supports
+PureDatagridBody.muiName = 'TableBody';
+
+export default PureDatagridBody;

--- a/src/mui/list/DatagridCell.js
+++ b/src/mui/list/DatagridCell.js
@@ -2,10 +2,10 @@ import React, { PropTypes } from 'react';
 import defaultsDeep from 'lodash.defaultsdeep';
 import { TableRowColumn } from 'material-ui/Table';
 
-const DatagridCell = ({ field, record, basePath, resource, defaultStyle }) => {
-    const style = defaultsDeep({}, field.props.style, field.type.defaultProps ? field.type.defaultProps.style : {}, defaultStyle);
+const DatagridCell = ({ field, record, basePath, resource, style, defaultStyle, ...rest }) => {
+    const computedStyle = defaultsDeep({}, style, field.props.style, field.type.defaultProps ? field.type.defaultProps.style : {}, defaultStyle);
     return (
-        <TableRowColumn style={style}>
+        <TableRowColumn style={computedStyle} {...rest}>
             {React.cloneElement(field, { record, basePath, resource })}
         </TableRowColumn>
     );
@@ -16,6 +16,7 @@ DatagridCell.propTypes = {
     record: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     basePath: PropTypes.string,
     resource: PropTypes.string,
+    style: PropTypes.object,
     defaultStyle: PropTypes.shape({
         td: PropTypes.object,
         'td:first-child': PropTypes.object,


### PR DESCRIPTION
We didn't use material-ui's `<Table>` component because it divided the table width in equal columns. It turns out [that's configurable, but undocumented](https://github.com/callemall/material-ui/issues/4366#issuecomment-279841386). 

Therefore, we have no longer any reason not to use their components (apart from the fact that they're a bit slow, but that's not a big deal for datagrids our size). By switching to mui tables, we earn many options, like the ability to make striped rows, hover effect, fixed header, etc. Besides, their `<Table>` supports theming way better than our custom one.

The default design changes a bit, but not too much.

Before:

![image](https://cloud.githubusercontent.com/assets/99944/23095918/95387a30-f612-11e6-9af0-52ff484201ce.png)

After:

![image](https://cloud.githubusercontent.com/assets/99944/23095911/651f353c-f612-11e6-8b05-3ae7aa0ac7e6.png)


Closes #308