### PR TITLE
Missing status in fetch when error is thrown

### DIFF
--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,3 +1,13 @@
+class ErrorStatus {
+    constructor(message, status) {
+        this.name = 'ErrorStatus';
+        this.message = message;
+        this.status = status;
+        this.stack = new Error().stack;
+    }
+}
+ErrorStatus.prototype = Object.create(Error.prototype);
+
 export const fetchJson = (url, options = {}) => {
     const requestHeaders = options.headers || new Headers({
         Accept: 'application/json',
@@ -24,7 +34,7 @@ export const fetchJson = (url, options = {}) => {
                 // not json, no big deal
             }
             if (status < 200 || status >= 300) {
-                return Promise.reject(new Error((json && json.message) || statusText));
+                return Promise.reject(new ErrorStatus((json && json.message) || statusText, status));
             }
             return { status, headers, body, json };
         });


### PR DESCRIPTION
The app nevers logout because the status is missing from the error.
The status is needed here :
https://github.com/marmelab/admin-on-rest/blob/master/src/sideEffect/saga/auth.js#L7

don't know if it's the best way to define the custom error like this.
Maybe we could just throw a simple object ?