### PR TITLE
[RFR] Improve loader rendering speed

### DIFF
--- a/src/mui/button/EditButton.js
+++ b/src/mui/button/EditButton.js
@@ -23,12 +23,12 @@ EditButton.propTypes = {
 };
 
 const enhance = compose(
-    translate,
     shouldUpdate((props, nextProps) =>
         props.record
         && props.record.id !== nextProps.record.id
         || props.basePath !== nextProps.basePath
     ),
+    translate,
 );
 
 export default enhance(EditButton);

--- a/src/mui/button/ShowButton.js
+++ b/src/mui/button/ShowButton.js
@@ -23,12 +23,12 @@ ShowButton.propTypes = {
 };
 
 const enhance = compose(
-    translate,
     shouldUpdate((props, nextProps) =>
         props.record
         && props.record.id !== nextProps.record.id
         || props.basePath !== nextProps.basePath
     ),
+    translate,
 );
 
 export default enhance(ShowButton);

--- a/src/mui/layout/AppBar.js
+++ b/src/mui/layout/AppBar.js
@@ -2,16 +2,13 @@ import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import pure from 'recompose/pure';
 import MuiAppBar from 'material-ui/AppBar';
-import CircularProgress from 'material-ui/CircularProgress';
 
-const AppBar = ({ title, isLoading, onLeftIconButtonTouchTap }) => {
+const AppBar = ({ title, onLeftIconButtonTouchTap }) => {
     const Title = <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>{title}</Link>;
-    const RightElement = isLoading ? <CircularProgress color="#fff" size={30} thickness={2} style={{ margin: 8 }} /> : <span />;
-    return <MuiAppBar title={Title} iconElementRight={RightElement} onLeftIconButtonTouchTap={onLeftIconButtonTouchTap} />;
+    return <MuiAppBar title={Title} onLeftIconButtonTouchTap={onLeftIconButtonTouchTap} />;
 };
 
 AppBar.propTypes = {
-    isLoading: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired,
     onLeftIconButtonTouchTap: PropTypes.func.isRequired,
 };

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -2,7 +2,8 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
-import autoprefixer from 'material-ui/utils/autoprefixer';
+import autoprefixer from 'material-ui/utils/autoprefixer'
+import CircularProgress from 'material-ui/CircularProgress';;
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import AppBar from './AppBar';
 import Notification from './Notification';
@@ -25,6 +26,13 @@ const styles = {
     },
     content: {
         flex: 1,
+    },
+    loader: {
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        margin: 16,
+        zIndex: 1200,
     },
 };
 
@@ -53,12 +61,18 @@ class Layout extends Component {
         return (
             <MuiThemeProvider muiTheme={muiTheme}>
                 <div style={prefixedStyles.main}>
-                    <AppBar title={title} isLoading={isLoading} onLeftIconButtonTouchTap={this.toggleSidebar} />
+                    <AppBar title={title} onLeftIconButtonTouchTap={this.toggleSidebar} />
                     <div className="body" style={prefixedStyles.body}>
                         <div style={prefixedStyles.content}>{children}</div>
                         <Menu resources={route.resources} logout={logout} open={sidebarOpen} />
                     </div>
                     <Notification />
+                    {isLoading && <CircularProgress
+                        color="#fff"
+                        size={30}
+                        thickness={2}
+                        style={styles.loader}
+                    />}
                 </div>
             </MuiThemeProvider>
         );


### PR DESCRIPTION
Avoid rendering the entire `<AppBar>` on every refresh by moving the loader out of it (saves about 30ms).