### PR TITLE
[RFR] Fix Edit view shows stale data

### DIFF
--- a/src/mui/form/SimpleForm.js
+++ b/src/mui/form/SimpleForm.js
@@ -41,6 +41,7 @@ SimpleForm.propTypes = {
 const ReduxForm = reduxForm({
     form: 'record-form',
     validate: validateForm,
+    enableReinitialize: true,
 })(SimpleForm);
 
 const mapStateToProps = (state, props) => ({

--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -83,6 +83,7 @@ TabbedForm.defaultProps = {
 const ReduxForm = reduxForm({
     form: 'record-form',
     validate: validateForm,
+    enableReinitialize: true,
 })(TabbedForm);
 
 

--- a/src/reducer/resource/data.js
+++ b/src/reducer/resource/data.js
@@ -45,8 +45,10 @@ const addRecords = (newRecords = [], oldRecords) => {
     // remove outdated old records
     const latestValidDate = new Date();
     latestValidDate.setTime(latestValidDate.getTime() - cacheDuration);
-    const oldValidRecordIds = Object.keys(oldRecords.fetchedAt)
-        .filter(id => oldRecords.fetchedAt[id] > latestValidDate);
+    const oldValidRecordIds = oldRecords.fetchedAt
+        ? Object.keys(oldRecords.fetchedAt)
+            .filter(id => oldRecords.fetchedAt[id] > latestValidDate)
+        : [];
     const oldValidRecords = oldValidRecordIds.reduce((prev, id) => {
         prev[id] = oldRecords[id]; // eslint-disable-line no-param-reassign
         return prev;


### PR DESCRIPTION
Our optimistic rendering strategy used to conflict with redux-form. When navigating to an `<Edit>` view, we use the current state (usually filled up by the `<List>` view) to prefill the form via redux-form's `initialValues`. Then we fetch the up-to-date record via a `CRUD_GET_ONE` action. When the REST server arrives, we update the state with the updated record, which updates the (connected) `<Edit>` view. 

But rerendering the `<Edit>` view just updates the ùinitialValues`, and by default redux-form doesn't listen to changes of this attribute (see https://github.com/erikras/redux-form/issues/176 and http://redux-form.com/6.5.0/examples/initializeFromState/). Passing `enableReinitialize: true` solves the problem.

Closes #305