### PR TITLE
[RFR] Allow to pass custom onBlur, onChange and onFocus on Number and Text inputs

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -38,7 +38,7 @@ All input components accept the following attributes:
 Some other props are progressively implemented. The `<TextInput />` and `<NumberInput />` inputs also accept following props:
 
 * `onBlur`: a function to call when the form field loses focus. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html), or the current value of the field.
-* `onChange`: a function to call when the form field is changed. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html) or the new value of the field.
+* `onChange`: a function to call when the form field is changed. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html), or the new value of the field.
 * `onFocus`: a function to call when the field receives focus. It takes the `event` as argument.
 
 ```js

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -35,7 +35,7 @@ All input components accept the following attributes:
 * `style`: A style object to customize the look and feel of the field container (e.g. the `<div>` in a form).
 * `elStyle`: A style object to customize the look and feel of the field element itself
 
-Some other props are progressively implemented. Hence, the `<TextInput />` and `<NumberInput />` inputs also accept following props:
+Some other props are progressively implemented. The `<TextInput />` and `<NumberInput />` inputs also accept following props:
 
 * `onBlur`: a function to call when the form field loses focus. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html) or the current value of the field.
 * `onChange`: a function to call when the form field is changed. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html) or the new value of the field.

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -35,6 +35,11 @@ All input components accept the following attributes:
 * `style`: A style object to customize the look and feel of the field container (e.g. the `<div>` in a form).
 * `elStyle`: A style object to customize the look and feel of the field element itself
 
+Some other props are progressively implemented. Hence, the `<TextInput />` and `<NumberInput />` inputs also accept following props:
+
+* `onBlur`: a function to call when the form field loses focus. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html) or the current value of the field.
+* `onChange`: a function to call when the form field is changed. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html) or the new value of the field.
+* `onFocus`: a function to call when the field receives focus. It takes the `event` as argument.
 
 ```js
 <TextInput source="zb_title" label="Title" />

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -37,7 +37,7 @@ All input components accept the following attributes:
 
 Some other props are progressively implemented. The `<TextInput />` and `<NumberInput />` inputs also accept following props:
 
-* `onBlur`: a function to call when the form field loses focus. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html) or the current value of the field.
+* `onBlur`: a function to call when the form field loses focus. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html), or the current value of the field.
 * `onChange`: a function to call when the form field is changed. It expects to either receive the [React SyntheticEvent](https://facebook.github.io/react/docs/events.html) or the new value of the field.
 * `onFocus`: a function to call when the field receives focus. It takes the `event` as argument.
 

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -15,13 +15,25 @@ import FieldTitle from '../../util/FieldTitle';
  * The object passed as `options` props is passed to the material-ui <TextField> component
  */
 class NumberInput extends Component {
-    /**
-     * Necessary because of a React bug on <input type="number">
-     * @see https://github.com/facebook/react/issues/1425
-     */
     handleBlur = (event) => {
+        this.props.onBlur(event);
         this.props.input.onBlur(event);
-        this.props.input.onChange(parseFloat(this.props.input.value));
+
+        /**
+         * Necessary because of a React bug on <input type="number">
+         * @see https://github.com/facebook/react/issues/1425
+         */
+        this.handleChange(parseFloat(this.props.input.value));
+    }
+
+    handleFocus = (event) => {
+        this.props.onFocus(event);
+        this.props.input.onFocus(event);
+    }
+
+    handleChange = (event) => {
+        this.props.onChange(event);
+        this.props.input.onChange(event);
     }
 
     render() {
@@ -30,6 +42,8 @@ class NumberInput extends Component {
             <TextField
                 {...input}
                 onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                onChange={this.handleChange}
                 type="number"
                 step={step}
                 floatingLabelText={<FieldTitle label={label} source={source} resource={resource} />}
@@ -48,7 +62,9 @@ NumberInput.propTypes = {
     label: PropTypes.string,
     meta: PropTypes.object,
     name: PropTypes.string,
+    onBlur: PropTypes.func,
     onChange: PropTypes.func,
+    onFocus: PropTypes.func,
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,
@@ -58,6 +74,9 @@ NumberInput.propTypes = {
 
 NumberInput.defaultProps = {
     addField: true,
+    onBlur: () => {},
+    onChange: () => {},
+    onFocus: () => {},
     options: {},
     step: 'any',
 };

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -19,7 +19,8 @@ class NumberInput extends Component {
      * Necessary because of a React bug on <input type="number">
      * @see https://github.com/facebook/react/issues/1425
      */
-    handleBlur = () => {
+    handleBlur = (event) => {
+        this.props.input.onBlur(event);
         this.props.input.onChange(parseFloat(this.props.input.value));
     }
 
@@ -27,8 +28,7 @@ class NumberInput extends Component {
         const { elStyle, input, label, meta: { touched, error }, options, source, step, resource } = this.props;
         return (
             <TextField
-                value={input.value}
-                onChange={input.onChange}
+                {...input}
                 onBlur={this.handleBlur}
                 type="number"
                 step={step}

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -15,9 +15,9 @@ import FieldTitle from '../../util/FieldTitle';
  * The object passed as `options` props is passed to the material-ui <TextField> component
  */
 class NumberInput extends Component {
-    handleBlur = (event) => {
-        this.props.onBlur(event);
-        this.props.input.onBlur(event);
+    handleBlur = (eventOrValue) => {
+        this.props.onBlur(eventOrValue);
+        this.props.input.onBlur(eventOrValue);
 
         /**
          * Necessary because of a React bug on <input type="number">
@@ -31,9 +31,9 @@ class NumberInput extends Component {
         this.props.input.onFocus(event);
     }
 
-    handleChange = (event) => {
-        this.props.onChange(event);
-        this.props.input.onChange(event);
+    handleChange = (eventOrValue) => {
+        this.props.onChange(eventOrValue);
+        this.props.input.onChange(eventOrValue);
     }
 
     render() {

--- a/src/mui/input/NumberInput.spec.js
+++ b/src/mui/input/NumberInput.spec.js
@@ -29,9 +29,37 @@ describe('<NumberInput />', () => {
 
     it('should return a numeric value', () => {
         const onChange = sinon.spy();
-        const wrapper = shallow(<NumberInput {...defaultProps} input={{ value: '2', onChange }} />);
+        const wrapper = shallow(
+            <NumberInput
+                {...defaultProps}
+                input={{
+                    value: '2',
+                    onBlur: () => {},
+                    onChange,
+                }}
+            />,
+        );
+
         const TextFieldElement = wrapper.find('TextField').first();
         TextFieldElement.simulate('blur');
         assert.deepEqual(onChange.args, [[2]]);
+    });
+
+    it('should call redux-form onBlur handler when blurred', () => {
+        const onBlur = sinon.spy();
+        const wrapper = shallow(
+            <NumberInput
+                {...defaultProps}
+                input={{
+                    value: '2',
+                    onBlur,
+                    onChange: () => {},
+                }}
+            />,
+        );
+
+        const TextFieldElement = wrapper.find('TextField').first();
+        TextFieldElement.simulate('blur', 'event');
+        assert.deepEqual(onBlur.args[0], ['event']);
     });
 });

--- a/src/mui/input/NumberInput.spec.js
+++ b/src/mui/input/NumberInput.spec.js
@@ -2,14 +2,20 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import NumberInput from './NumberInput';
 
 describe('<NumberInput />', () => {
     const defaultProps = {
         source: 'foo',
         meta: {},
-        input: {},
+        input: {
+            onBlur: () => {},
+            onChange: () => {},
+            onFocus: () => {},
+        },
+        onChange: () => {},
+        onBlur: () => {},
+        onFocus: () => {},
     };
 
     it('should use a mui TextField', () => {
@@ -20,46 +26,89 @@ describe('<NumberInput />', () => {
         assert.equal(TextFieldElement.prop('type'), 'number');
     });
 
-    it('should call props `input.onChange` method when changed', () => {
-        const onChange = sinon.spy();
-        const wrapper = shallow(<NumberInput {...defaultProps} input={{ value: 2, onChange }} />);
-        wrapper.find('TextField').simulate('change', null, 3);
-        assert.deepEqual(onChange.args, [[null, '3']]);
+    describe('onChange event', () => {
+        it('should be customizable via the `onChange` prop', () => {
+            const onChange = sinon.spy();
+
+            const props = { ...defaultProps };
+            const wrapper = shallow(<NumberInput {...props} onChange={onChange} />);
+
+            wrapper.find('TextField').simulate('change', 3);
+            assert.deepEqual(onChange.args, [[3]]);
+        });
+
+        it('should keep calling redux-form original event', () => {
+            const onChange = sinon.spy();
+
+            const wrapper = shallow(<NumberInput {...defaultProps} input={{ value: 2, onChange }} />);
+            wrapper.find('TextField').simulate('change', 3);
+            assert.deepEqual(onChange.args, [[3]]);
+        });
     });
 
-    it('should return a numeric value', () => {
-        const onChange = sinon.spy();
-        const wrapper = shallow(
-            <NumberInput
-                {...defaultProps}
-                input={{
-                    value: '2',
-                    onBlur: () => {},
-                    onChange,
-                }}
-            />,
-        );
+    describe('onFocus event', () => {
+        it('should be customizable via the `onFocus` prop', () => {
+            const onFocus = sinon.spy();
 
-        const TextFieldElement = wrapper.find('TextField').first();
-        TextFieldElement.simulate('blur');
-        assert.deepEqual(onChange.args, [[2]]);
+            const props = { ...defaultProps };
+            const wrapper = shallow(<NumberInput {...props} onFocus={onFocus} />);
+
+            wrapper.find('TextField').simulate('focus', 3);
+            assert.deepEqual(onFocus.args, [[3]]);
+        });
+
+        it('should keep calling redux-form original event', () => {
+            const onFocus = sinon.spy();
+
+            const wrapper = shallow(<NumberInput {...defaultProps} input={{ value: 2, onFocus }} />);
+            wrapper.find('TextField').simulate('focus', 3);
+            assert.deepEqual(onFocus.args, [[3]]);
+        });
     });
 
-    it('should call redux-form onBlur handler when blurred', () => {
-        const onBlur = sinon.spy();
-        const wrapper = shallow(
-            <NumberInput
-                {...defaultProps}
-                input={{
-                    value: '2',
+    describe('onBlur event', () => {
+        it('should be customizable via the `onBlur` prop', () => {
+            const onBlur = sinon.spy();
+
+            const props = { ...defaultProps };
+            const wrapper = shallow(<NumberInput {...props} onBlur={onBlur} />);
+
+            wrapper.find('TextField').simulate('blur', 3);
+            assert.deepEqual(onBlur.args, [[3]]);
+        });
+
+        it('should keep calling redux-form original event', () => {
+            const onBlur = sinon.spy();
+
+            const props = {
+                ...defaultProps,
+                input: {
+                    ...defaultProps.input,
                     onBlur,
-                    onChange: () => {},
-                }}
-            />,
-        );
+                },
+            };
 
-        const TextFieldElement = wrapper.find('TextField').first();
-        TextFieldElement.simulate('blur', 'event');
-        assert.deepEqual(onBlur.args[0], ['event']);
+            const wrapper = shallow(<NumberInput {...props} />);
+            wrapper.find('TextField').simulate('blur', 3);
+            assert.deepEqual(onBlur.args, [[3]]);
+        });
+
+        it('should cast value as a numeric one', () => {
+            const onChange = sinon.spy();
+            const wrapper = shallow(
+                <NumberInput
+                    {...defaultProps}
+                    input={{
+                        value: '2',
+                        onBlur: () => {},
+                        onChange,
+                    }}
+                />,
+            );
+
+            const TextFieldElement = wrapper.find('TextField').first();
+            TextFieldElement.simulate('blur');
+            assert.deepEqual(onChange.args, [[2]]);
+        });
     });
 });

--- a/src/mui/input/TextInput.js
+++ b/src/mui/input/TextInput.js
@@ -18,8 +18,7 @@ import FieldTitle from '../../util/FieldTitle';
  */
 const TextInput = ({ input, label, meta: { touched, error }, options, type, source, elStyle, resource }) => (
     <TextField
-        value={input.value}
-        onChange={input.onChange}
+        {...input}
         type={type}
         floatingLabelText={<FieldTitle label={label} source={source} resource={resource} />}
         errorText={touched && error}

--- a/src/mui/input/TextInput.js
+++ b/src/mui/input/TextInput.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import TextField from 'material-ui/TextField';
 import FieldTitle from '../../util/FieldTitle';
 
@@ -16,16 +16,49 @@ import FieldTitle from '../../util/FieldTitle';
  *
  * The object passed as `options` props is passed to the material-ui <TextField> component
  */
-const TextInput = ({ input, label, meta: { touched, error }, options, type, source, elStyle, resource }) => (
-    <TextField
-        {...input}
-        type={type}
-        floatingLabelText={<FieldTitle label={label} source={source} resource={resource} />}
-        errorText={touched && error}
-        style={elStyle}
-        {...options}
-    />
-);
+export class TextInput extends Component {
+    handleBlur = (eventOrValue) => {
+        this.props.onBlur(eventOrValue);
+        this.props.input.onBlur(eventOrValue);
+    }
+
+    handleFocus = (event) => {
+        this.props.onFocus(event);
+        this.props.input.onFocus(event);
+    }
+
+    handleChange = (eventOrValue) => {
+        this.props.onChange(eventOrValue);
+        this.props.input.onChange(eventOrValue);
+    }
+
+    render() {
+        const {
+            elStyle,
+            input,
+            label,
+            meta: { touched, error },
+            options,
+            resource,
+            source,
+            type,
+        } = this.props;
+
+        return (
+            <TextField
+                {...input}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                onChange={this.handleChange}
+                type={type}
+                floatingLabelText={<FieldTitle label={label} source={source} resource={resource} />}
+                errorText={touched && error}
+                style={elStyle}
+                {...options}
+            />
+        );
+    }
+}
 
 TextInput.propTypes = {
     addField: PropTypes.bool.isRequired,
@@ -34,7 +67,9 @@ TextInput.propTypes = {
     label: PropTypes.string,
     meta: PropTypes.object,
     name: PropTypes.string,
+    onBlur: PropTypes.func,
     onChange: PropTypes.func,
+    onFocus: PropTypes.func,
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,
@@ -44,6 +79,9 @@ TextInput.propTypes = {
 
 TextInput.defaultProps = {
     addField: true,
+    onBlur: () => {},
+    onChange: () => {},
+    onFocus: () => {},
     options: {},
     type: 'text',
 };

--- a/src/mui/input/TextInput.spec.js
+++ b/src/mui/input/TextInput.spec.js
@@ -1,6 +1,8 @@
-import React from 'react';
-import assert from 'assert';
 import { shallow } from 'enzyme';
+import assert from 'assert';
+import React from 'react';
+import sinon from 'sinon';
+
 import TextInput from './TextInput';
 
 describe('<TextInput />', () => {
@@ -24,6 +26,20 @@ describe('<TextInput />', () => {
         const TextFieldElement = wrapper.find('TextField');
         assert.equal(TextFieldElement.length, 1);
         assert.equal(TextFieldElement.prop('type'), 'password');
+    });
+
+    it('should call redux-form onBlur handler when blurred', () => {
+        const onBlur = sinon.spy();
+        const wrapper = shallow(
+            <TextInput
+                {...defaultProps}
+                input={{ onBlur }}
+            />,
+        );
+
+        const TextFieldElement = wrapper.find('TextField').first();
+        TextFieldElement.simulate('blur', 'event');
+        assert.deepEqual(onBlur.args[0], ['event']);
     });
 
     describe('error message', () => {


### PR DESCRIPTION
Indeed, Redux Form sends `FOCUS` and `BLUR` actions on focus and blur respectively. It is especially used for asynchronous form validation.

![image](https://cloud.githubusercontent.com/assets/688373/23366522/49a39a90-fd07-11e6-89d7-502c06c4a488.png)

This PR does **not** fix all inputs, but only the Text and Number inputs. Indeed, it would need additional work, especially for the `<Autocomplete />` field.