### PR TITLE
Allow to execute crud actions without redirect

### DIFF
--- a/src/actions/dataActions.js
+++ b/src/actions/dataActions.js
@@ -35,9 +35,9 @@ export const CRUD_CREATE_LOADING = 'CRUD_CREATE_LOADING';
 export const CRUD_CREATE_FAILURE = 'CRUD_CREATE_FAILURE';
 export const CRUD_CREATE_SUCCESS = 'CRUD_CREATE_SUCCESS';
 
-export const crudCreate = (resource, data, basePath, silent = false) => ({
+export const crudCreate = (resource, data, basePath, redirect = true) => ({
     type: CRUD_CREATE,
-    payload: { data, basePath, silent },
+    payload: { data, basePath, redirect },
     meta: { resource, fetch: CREATE, cancelPrevious: false },
 });
 
@@ -46,9 +46,9 @@ export const CRUD_UPDATE_LOADING = 'CRUD_UPDATE_LOADING';
 export const CRUD_UPDATE_FAILURE = 'CRUD_UPDATE_FAILURE';
 export const CRUD_UPDATE_SUCCESS = 'CRUD_UPDATE_SUCCESS';
 
-export const crudUpdate = (resource, id, data, previousData, basePath, silent = false) => ({
+export const crudUpdate = (resource, id, data, previousData, basePath, redirect = true) => ({
     type: CRUD_UPDATE,
-    payload: { id, data, previousData, basePath, silent },
+    payload: { id, data, previousData, basePath, redirect },
     meta: { resource, fetch: UPDATE, cancelPrevious: false },
 });
 
@@ -57,9 +57,9 @@ export const CRUD_DELETE_LOADING = 'CRUD_DELETE_LOADING';
 export const CRUD_DELETE_FAILURE = 'CRUD_DELETE_FAILURE';
 export const CRUD_DELETE_SUCCESS = 'CRUD_DELETE_SUCCESS';
 
-export const crudDelete = (resource, id, basePath, silent = false) => ({
+export const crudDelete = (resource, id, basePath, redirect = true) => ({
     type: CRUD_DELETE,
-    payload: { id, basePath, silent },
+    payload: { id, basePath, redirect },
     meta: { resource, fetch: DELETE, cancelPrevious: false },
 });
 

--- a/src/actions/dataActions.js
+++ b/src/actions/dataActions.js
@@ -13,10 +13,10 @@ export const CRUD_GET_LIST_LOADING = 'CRUD_GET_LIST_LOADING';
 export const CRUD_GET_LIST_FAILURE = 'CRUD_GET_LIST_FAILURE';
 export const CRUD_GET_LIST_SUCCESS = 'CRUD_GET_LIST_SUCCESS';
 
-export const crudGetList = (resource, pagination, sort, filter) => ({
+export const crudGetList = (resource, pagination, sort, filter, cancelPrevious = true) => ({
     type: CRUD_GET_LIST,
     payload: { pagination, sort, filter },
-    meta: { resource, fetch: GET_LIST, cancelPrevious: true },
+    meta: { resource, fetch: GET_LIST, cancelPrevious },
 });
 
 export const CRUD_GET_ONE = 'CRUD_GET_ONE';
@@ -35,9 +35,9 @@ export const CRUD_CREATE_LOADING = 'CRUD_CREATE_LOADING';
 export const CRUD_CREATE_FAILURE = 'CRUD_CREATE_FAILURE';
 export const CRUD_CREATE_SUCCESS = 'CRUD_CREATE_SUCCESS';
 
-export const crudCreate = (resource, data, basePath) => ({
+export const crudCreate = (resource, data, basePath, silent = false) => ({
     type: CRUD_CREATE,
-    payload: { data, basePath },
+    payload: { data, basePath, silent },
     meta: { resource, fetch: CREATE, cancelPrevious: false },
 });
 
@@ -46,9 +46,9 @@ export const CRUD_UPDATE_LOADING = 'CRUD_UPDATE_LOADING';
 export const CRUD_UPDATE_FAILURE = 'CRUD_UPDATE_FAILURE';
 export const CRUD_UPDATE_SUCCESS = 'CRUD_UPDATE_SUCCESS';
 
-export const crudUpdate = (resource, id, data, previousData, basePath) => ({
+export const crudUpdate = (resource, id, data, previousData, basePath, silent = false) => ({
     type: CRUD_UPDATE,
-    payload: { id, data, previousData, basePath },
+    payload: { id, data, previousData, basePath, silent },
     meta: { resource, fetch: UPDATE, cancelPrevious: false },
 });
 
@@ -57,9 +57,9 @@ export const CRUD_DELETE_LOADING = 'CRUD_DELETE_LOADING';
 export const CRUD_DELETE_FAILURE = 'CRUD_DELETE_FAILURE';
 export const CRUD_DELETE_SUCCESS = 'CRUD_DELETE_SUCCESS';
 
-export const crudDelete = (resource, id, basePath) => ({
+export const crudDelete = (resource, id, basePath, silent = false) => ({
     type: CRUD_DELETE,
-    payload: { id, basePath },
+    payload: { id, basePath, silent },
     meta: { resource, fetch: DELETE, cancelPrevious: false },
 });
 

--- a/src/actions/dataActions.js
+++ b/src/actions/dataActions.js
@@ -13,10 +13,10 @@ export const CRUD_GET_LIST_LOADING = 'CRUD_GET_LIST_LOADING';
 export const CRUD_GET_LIST_FAILURE = 'CRUD_GET_LIST_FAILURE';
 export const CRUD_GET_LIST_SUCCESS = 'CRUD_GET_LIST_SUCCESS';
 
-export const crudGetList = (resource, pagination, sort, filter, cancelPrevious = true) => ({
+export const crudGetList = (resource, pagination, sort, filter) => ({
     type: CRUD_GET_LIST,
     payload: { pagination, sort, filter },
-    meta: { resource, fetch: GET_LIST, cancelPrevious },
+    meta: { resource, fetch: GET_LIST, cancelPrevious: true },
 });
 
 export const CRUD_GET_ONE = 'CRUD_GET_ONE';

--- a/src/sideEffect/saga/crudResponse.js
+++ b/src/sideEffect/saga/crudResponse.js
@@ -26,17 +26,17 @@ function* handleResponse({ type, requestPayload, error, payload }) {
         return requestPayload.redirect ? yield [
             put(showNotification('aor.notification.updated')),
             put(push(requestPayload.basePath)),
-        ] : yield [];
+        ] : yield [put(showNotification('aor.notification.updated'))];
     case CRUD_CREATE_SUCCESS:
         return requestPayload.redirect ? yield [
             put(showNotification('aor.notification.created')),
             put(push(linkToRecord(requestPayload.basePath, payload.id))),
-        ] : yield [];
+        ] : yield [put(showNotification('aor.notification.created'))];
     case CRUD_DELETE_SUCCESS:
         return requestPayload.redirect ? yield [
             put(showNotification('aor.notification.deleted')),
             put(push(requestPayload.basePath)),
-        ] : yield [];
+        ] : yield [put(showNotification('aor.notification.deleted'))];
     case CRUD_GET_ONE_FAILURE:
         return requestPayload.basePath ? yield [
             put(showNotification('aor.notification.item_doesnt_exist', 'warning')),

--- a/src/sideEffect/saga/crudResponse.js
+++ b/src/sideEffect/saga/crudResponse.js
@@ -23,17 +23,17 @@ import linkToRecord from '../../util/linkToRecord';
 function* handleResponse({ type, requestPayload, error, payload }) {
     switch (type) {
     case CRUD_UPDATE_SUCCESS:
-        return !requestPayload.silent ? yield [
+        return requestPayload.redirect ? yield [
             put(showNotification('aor.notification.updated')),
             put(push(requestPayload.basePath)),
         ] : yield [];
     case CRUD_CREATE_SUCCESS:
-        return !requestPayload.silent ? yield [
+        return requestPayload.redirect ? yield [
             put(showNotification('aor.notification.created')),
             put(push(linkToRecord(requestPayload.basePath, payload.id))),
         ] : yield [];
     case CRUD_DELETE_SUCCESS:
-        return !requestPayload.silent ? yield [
+        return requestPayload.redirect ? yield [
             put(showNotification('aor.notification.deleted')),
             put(push(requestPayload.basePath)),
         ] : yield [];

--- a/src/sideEffect/saga/crudResponse.js
+++ b/src/sideEffect/saga/crudResponse.js
@@ -23,20 +23,20 @@ import linkToRecord from '../../util/linkToRecord';
 function* handleResponse({ type, requestPayload, error, payload }) {
     switch (type) {
     case CRUD_UPDATE_SUCCESS:
-        return yield [
+        return !requestPayload.silent ? yield [
             put(showNotification('aor.notification.updated')),
             put(push(requestPayload.basePath)),
-        ];
+        ] : yield [];
     case CRUD_CREATE_SUCCESS:
-        return yield [
+        return !requestPayload.silent ? yield [
             put(showNotification('aor.notification.created')),
             put(push(linkToRecord(requestPayload.basePath, payload.id))),
-        ];
+        ] : yield [];
     case CRUD_DELETE_SUCCESS:
-        return yield [
+        return !requestPayload.silent ? yield [
             put(showNotification('aor.notification.deleted')),
             put(push(requestPayload.basePath)),
-        ];
+        ] : yield [];
     case CRUD_GET_ONE_FAILURE:
         return requestPayload.basePath ? yield [
             put(showNotification('aor.notification.item_doesnt_exist', 'warning')),


### PR DESCRIPTION
I'm making a form where users can batch create multiple resources at once. This change lets me reuse existing actions, but wait with notification/redirect until all resources are created. 

It's a bit annoying to get redirected say ten times in a couple of seconds:)