### PR TITLE
[RFR] [BC Break] Update REST response format

### DIFF
--- a/docs/RestClients.md
+++ b/docs/RestClients.md
@@ -17,7 +17,7 @@ The `restClient` parameter of the `<Admin>` component, must be a function with t
  *
  * @example
  * restClient(GET_ONE, 'posts', { id: 123 })
- *  => new Promise(resolve => resolve({ id: 123, title: "hello, world" }))
+ *  => new Promise(resolve => resolve({ data: { id: 123, title: "hello, world" } }))
  *
  * @param {string} type Request type, e.g GET_LIST
  * @param {string} resource Resource name, e.g. "posts"
@@ -253,13 +253,13 @@ Possible types are:
 
 Type                 | Params format
 -------------------- | ----------------
-`GET_LIST`           | `{ pagination: { page: {int} , perPage: {int} }, sort: { field: {string}, order: {string} } }`
+`GET_LIST`           | `{ pagination: { page: {int} , perPage: {int} }, sort: { field: {string}, order: {string} }, filter: {Object} }`
 `GET_ONE`            | `{ id: {mixed} }`
 `CREATE`             | `{ data: {Object} }`
 `UPDATE`             | `{ id: {mixed}, data: {Object} }`
 `DELETE`             | `{ id: {mixed} }`
 `GET_MANY`           | `{ ids: {mixed[]} }`
-`GET_MANY_REFERENCE` | `{ target: {string}, id: {mixed}, pagination: { page: {int} , perPage: {int} }, sort: { field: {string}, order: {string} } }`
+`GET_MANY_REFERENCE` | `{ target: {string}, id: {mixed}, pagination: { page: {int} , perPage: {int} }, sort: { field: {string}, order: {string} }, filter: {Object} }`
 
 Examples:
 
@@ -267,13 +267,18 @@ Examples:
 restClient(GET_LIST, 'posts', {
     pagination: { page: 1, perPage: 5 },
     sort: { field: 'title', order: 'ASC' },
+    filter: { author_id: 12 },
 });
 restClient(GET_ONE, 'posts', { id: 123 });
 restClient(CREATE, 'posts', { title: "hello, world" });
 restClient(UPDATE, 'posts', { id: 123, { title: "hello, world!" } });
 restClient(DELETE, 'posts', { id: 123 });
 restClient(GET_MANY, 'posts', { ids: [123, 124, 125] });
-restClient(GET_MANY_REFERENCE, 'comments', { target: 'post_id', id: 123, sort: { field: 'created_at', order: 'DESC' } });
+restClient(GET_MANY_REFERENCE, 'comments', {
+    target: 'post_id',
+    id: 123,
+    sort: { field: 'created_at', order: 'DESC' }
+});
 ```
 
 ### Response Format
@@ -283,12 +288,12 @@ REST responses are objects. The format depends on the type.
 Type                 | Response format
 -------------------- | ----------------
 `GET_LIST`           | `{ data: {Record[]}, total: {int} }`
-`GET_ONE`            | `{Record}`
-`CREATE`             | `{Record}`
-`UPDATE`             | `{Record}`
-`DELETE`             | `{Record}`
-`GET_MANY`           | `{Record[]}`
-`GET_MANY_REFERENCE` | `{Record[]}`
+`GET_ONE`            | `{ data: {Record} }`
+`CREATE`             | `{ data: {Record} }`
+`UPDATE`             | `{ data: {Record} }`
+`DELETE`             | `{ data: {Record} }`
+`GET_MANY`           | `{ data: {Record[]} }`
+`GET_MANY_REFERENCE` | `{ data: {Record[]}, total: {int} }`
 
 A `{Record}` is an object literal with at least an `id` property, e.g. `{ id: 123, title: "hello, world" }`.
 
@@ -298,57 +303,67 @@ Examples:
 restClient(GET_LIST, 'posts', {
     pagination: { page: 1, perPage: 5 },
     sort: { field: 'title', order: 'ASC' },
-}).then(response => console.log(response));
+    filter: { author_id: 12 },
+})
+.then(response => console.log(response));
 // {
 //     data: [
-//         { id: 126, title: "allo?" },
-//         { id: 127, title: "bien le bonjour" },
-//         { id: 124, title: "good day sunshise" },
-//         { id: 123, title: "hello, world" },
-//         { id: 125, title: "howdy partner" },
+//         { id: 126, title: "allo?", author_id: 12 },
+//         { id: 127, title: "bien le bonjour", author_id: 12 },
+//         { id: 124, title: "good day sunshine", author_id: 12 },
+//         { id: 123, title: "hello, world", author_id: 12 },
+//         { id: 125, title: "howdy partner", author_id: 12 },
 //     ],
 //     total: 27
 // }
 
 restClient(GET_ONE, 'posts', { id: 123 })
-.then(record => console.log(record));
+.then(response => console.log(response));
 // {
-//     id: 123,
-//     title: "hello, world"
+//     data: { id: 123, title: "hello, world" }
 // }
 
-restClient(CREATE, 'posts', { title: "hello, world" });
+restClient(CREATE, 'posts', { title: "hello, world" })
+.then(response => console.log(response));
 // {
-//     id: 450,
-//     title: "hello, world"
+//     data: { id: 450, title: "hello, world" }
 // }
 
-restClient(UPDATE, 'posts', { id: 123, { title: "hello, world!" } });
+restClient(UPDATE, 'posts', { id: 123, { title: "hello, world!" } })
+.then(response => console.log(response));
 // {
-//     id: 123,
-//     title: "hello, world!"
+//     data: { id: 123, title: "hello, world!" }
 // }
 
-restClient(DELETE, 'posts', { id: 123 });
+restClient(DELETE, 'posts', { id: 123 })
+.then(response => console.log(response));
 // {
-//     id: 123,
-//     title: "hello, world"
+//     data: { id: 123, title: "hello, world" }
 // }
 
 restClient(GET_MANY, 'posts', { ids: [123, 124, 125] })
-.then(records => console.log(records));
-// [
-//     { id: 123, title: "hello, world" },
-//     { id: 124, title: "good day sunshise" },
-//     { id: 125, title: "howdy partner" },
-// ]
+.then(response => console.log(response));
+// {
+//     data: [
+//         { id: 123, title: "hello, world" },
+//         { id: 124, title: "good day sunshise" },
+//         { id: 125, title: "howdy partner" },
+//     ]
+// }
 
-restClient(GET_MANY_REFERENCE, 'comments', { target: 'post_id', id: 123, sort: { field: 'created_at', order: 'DESC' } });
-.then(records => console.log(records));
-// [
-//     { id: 667, title: "I agree", post_id: 123 },
-//     { id: 895, title: "I don't agree", post_id: 123 },
-// ]
+restClient(GET_MANY_REFERENCE, 'comments', {
+    target: 'post_id',
+    id: 123,
+    sort: { field: 'created_at', order: 'DESC' }
+});
+.then(response => console.log(response));
+// {
+//     data: [
+//         { id: 667, title: "I agree", post_id: 123 },
+//         { id: 895, title: "I don't agree", post_id: 123 },
+//     ],
+//     total: 2,
+// }
 ```
 
 ### Error Format

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "aor-json-rest-client": "~1.5.0",
+    "aor-json-rest-client": "2.0.0",
     "aor-language-french": "~1.5.0",
     "aor-rich-text-input": "~1.0.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",

--- a/src/reducer/references/oneToMany.js
+++ b/src/reducer/references/oneToMany.js
@@ -7,7 +7,7 @@ export default (previousState = initialState, { type, payload, meta }) => {
     case CRUD_GET_MANY_REFERENCE_SUCCESS:
         return {
             ...previousState,
-            [meta.relatedTo]: payload.map(record => record.id),
+            [meta.relatedTo]: payload.data.map(record => record.id),
         };
     default:
         return previousState;

--- a/src/reducer/resource/data.js
+++ b/src/reducer/resource/data.js
@@ -79,14 +79,13 @@ export default resource => (previousState = initialState, { payload, meta }) => 
     }
     switch (meta.fetchResponse) {
     case GET_LIST:
-        return addRecords(payload.data, previousState);
     case GET_MANY:
     case GET_MANY_REFERENCE:
-        return addRecords(payload, previousState);
+        return addRecords(payload.data, previousState);
     case GET_ONE:
     case UPDATE:
     case CREATE:
-        return addRecords([payload], previousState);
+        return addRecords([payload.data], previousState);
     default:
         return previousState;
     }

--- a/src/rest/jsonServer.js
+++ b/src/rest/jsonServer.js
@@ -93,17 +93,18 @@ export default (apiUrl, httpClient = fetchJson) => {
         const { headers, json } = response;
         switch (type) {
         case GET_LIST:
+        case GET_MANY_REFERENCE:
             if (!headers.has('x-total-count')) {
                 throw new Error('The X-Total-Count header is missing in the HTTP Response. The jsonServer REST client expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare X-Total-Count in the Access-Control-Expose-Headers header?');
             }
             return {
-                data: json.map(x => x),
+                data: json,
                 total: parseInt(headers.get('x-total-count').split('/').pop(), 10),
             };
         case CREATE:
-            return { ...params.data, id: json.id };
+            return { data: { ...params.data, id: json.id } };
         default:
-            return json;
+            return { data: json };
         }
     };
 

--- a/src/rest/simple.js
+++ b/src/rest/simple.js
@@ -96,17 +96,18 @@ export default (apiUrl, httpClient = fetchJson) => {
         const { headers, json } = response;
         switch (type) {
         case GET_LIST:
+        case GET_MANY_REFERENCE:
             if (!headers.has('content-range')) {
                 throw new Error('The Content-Range header is missing in the HTTP Response. The simple REST client expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare Content-Range in the Access-Control-Expose-Headers header?');
             }
             return {
-                data: json.map(x => x),
+                data: json,
                 total: parseInt(headers.get('content-range').split('/').pop(), 10),
             };
         case CREATE:
-            return { ...params.data, id: json.id };
+            return { data: { ...params.data, id: json.id } };
         default:
-            return json;
+            return { data: json };
         }
     };
 


### PR DESCRIPTION
This changes the expected return format of the `restClient`. Now it must systematically return an object with a `data` property.

```diff
 Type                 | Response format
 -------------------- | ----------------
 `GET_LIST`           | `{ data: {Record[]}, total: {int} }`
-`GET_ONE`            | `{Record}`
-`CREATE`             | `{Record}`
-`UPDATE`             | `{Record}`
-`DELETE`             | `{Record}`
-`GET_MANY`           | `{Record[]}`
-`GET_MANY_REFERENCE` | `{Record[]}`
+`GET_ONE`            | `{ data: {Record} }`
+`CREATE`             | `{ data: {Record} }`
+`UPDATE`             | `{ data: {Record} }`
+`DELETE`             | `{ data: {Record} }`
+`GET_MANY`           | `{ data: {Record[]} }`
+`GET_MANY_REFERENCE` | `{ data: {Record[]}, total: {int} }`
```

This removes a potential surprise for developers trying to build their own rest client.

Caution: This breaks all existing REST clients. Once merged, I'll notify the third-party rest client authors to help them migrate.

Refs #347