### PR TITLE
Allow to override redirect path when auth check fails

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -128,7 +128,7 @@ For instance, to check for the existence of the token in local storage:
 
 ```js
 // in src/authClient.js
-import { AUTH_LOGIN, AUTH_LOGOUT } from 'admin-on-rest';
+import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_CHECK } from 'admin-on-rest';
 
 export default (type, params) => {
     if (type === AUTH_LOGIN) {
@@ -144,13 +144,31 @@ export default (type, params) => {
 };
 ```
 
-If the promise is rejected, admin-on-rest redirects to the `/login` page.
+If the promise is rejected, admin-on-rest redirects by default to the `/login` page. You can override where to redirect the user by passing an argument with a `redirectTo` property to the rejected promise:
+
+```js
+// in src/authClient.js
+import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_CHECK } from 'admin-on-rest';
+
+export default (type, params) => {
+    if (type === AUTH_LOGIN) {
+        // ...
+    }
+    if (type === AUTH_LOGOUT) {
+        // ...
+    }
+    if (type === AUTH_CHECK) {
+        return localStorage.getItem('username') ? Promise.resolve() : Promise.reject({ redirectTo: '/no-access' });
+    }
+    return Promise.reject('Unkown method');
+};
+```
 
 **Tip**: For the `AUTH_CHECK` call, the `params` argument contains the `resource` name, so you can implement different checks for different resources:
 
 ```js
 // in src/authClient.js
-import { AUTH_LOGIN, AUTH_LOGOUT } from 'admin-on-rest';
+import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_CHECK } from 'admin-on-rest';
 
 export default (type, params) => {
     if (type === AUTH_LOGIN) {

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -64,7 +64,7 @@ const Admin = ({
             .then(() => params && params.scrollToTop ? window.scrollTo(0, 0) : null)
             .catch(e => {
                 replace({
-                    pathname: '/login',
+                    pathname: (e && e.rediretTo) || '/login',
                     state: { nextPathname: nextState.location.pathname },
                 })
             })

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -64,7 +64,7 @@ const Admin = ({
             .then(() => params && params.scrollToTop ? window.scrollTo(0, 0) : null)
             .catch(e => {
                 replace({
-                    pathname: (e && e.rediretTo) || '/login',
+                    pathname: (e && e.redirectTo) || '/login',
                     state: { nextPathname: nextState.location.pathname },
                 })
             })


### PR DESCRIPTION
I would like to differentiate where to redirect users when auth check fails. If user is not logged in, the default redirect to `/login` is fine, but when user is logged in and authorization fails, I would like to redirect to e.g `/no-access`.

I'm not 100% comfortable with the suggested implementation, but at least it's a conversation starter.