### PR TITLE
[RFR] Update image preview when dispatching new form value

### DIFF
--- a/src/mui/input/ImageInput.js
+++ b/src/mui/input/ImageInput.js
@@ -28,6 +28,15 @@ export class ImageInput extends Component {
         this.state = { files };
     }
 
+    componentWillReceiveProps(nextProps) {
+        let files = nextProps.input.value || [];
+        if (!Array.isArray(files)) {
+            files = [files];
+        }
+
+        this.setState({ files });
+    }
+
     onDrop = (files) => {
         const updatedFiles = [
             ...this.state.files,

--- a/src/mui/input/ImageInput.spec.js
+++ b/src/mui/input/ImageInput.spec.js
@@ -98,4 +98,38 @@ describe('<ImageInput />', () => {
         assert.deepEqual(previewImages.at(1).prop('record').title, 'A good old Bitmap!');
         assert.deepEqual(previewImages.at(1).prop('record').url, 'http://foo.com/qux.bmp');
     });
+
+    it('should update previews when updating input value', () => {
+        const wrapper = shallow(
+            <ImageInput
+                source="picture"
+                translate={x => x}
+                input={{
+                    value: {
+                        url: 'http://static.acme.com/foo.jpg',
+                    },
+                }}
+            >
+                <ImageField source="url" />
+            </ImageInput>,
+        );
+
+        const previewImage = wrapper.find('ImageField');
+        const previewUrl = previewImage.prop('record').url;
+        assert.equal(previewUrl, 'http://static.acme.com/foo.jpg');
+
+        wrapper.setProps({
+            input: {
+                value: {
+                    url: 'http://static.acme.com/bar.jpg',
+                },
+            },
+        });
+
+        wrapper.update();
+
+        const updatedPreviewImage = wrapper.find('ImageField');
+        const updatedPreviewUrl = updatedPreviewImage.prop('record').url;
+        assert.equal(updatedPreviewUrl, 'http://static.acme.com/bar.jpg');
+    });
 });


### PR DESCRIPTION
Currently, if we dispatch a new form value via `redux-form` like the following:

``` js
import { change } from 'redux-form';
import { put } from 'redux-saga/effects';

put(change('record-form', 'landscapeImage.url', mainImage.url)),
```

The image preview doesn't update, as it is only updated in `<ImageInput />` constructor. This PR fixes that.