### PR TITLE
[RFR] Simplify imports by exporting mui in the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `<Resource>` component is a configuration component that allows to define su
 ```js
 // in posts.js
 import React from 'react';
-import { List, Datagrid, Edit, Create, SimpleForm, DateField, TextField, EditButton, DisabledInput, TextInput, LongTextInput, DateInput } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, Edit, Create, SimpleForm, DateField, TextField, EditButton, DisabledInput, TextInput, LongTextInput, DateInput } from 'admin-on-rest';
 export PostIcon from 'material-ui/svg-icons/action/book';
 
 export const PostList = (props) => (

--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -82,7 +82,7 @@ Or, in the `<Edit>` page, as a [custom action](./CreateEdit.html#actions):
 // in src/comments/CommentEditActions.js
 import React from 'react';
 import { CardActions } from 'material-ui/Card';
-import { ListButton, DeleteButton } from 'admin-on-rest/lib/mui';
+import { ListButton, DeleteButton } from 'admin-on-rest';
 import ApproveButton from './ApproveButton';
 
 const CommentEditActions = ({ basePath, data }) => (

--- a/docs/AdminResource.md
+++ b/docs/AdminResource.md
@@ -324,7 +324,7 @@ Now, when a user browses to `/foo` or `/bar`, the components you defined will ap
 // in src/Foo.js
 import React from 'react';
 import { Card } from 'material-ui/Card';
-import { ViewTitle } from 'admin-on-rest/lib/mui';
+import { ViewTitle } from 'admin-on-rest';
 
 const Foo = () => (
     <Card>

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -40,7 +40,7 @@ export default App;
 
 // in src/posts.js
 import React from 'react';
-import { Create, Edit, SimpleForm, DisabledInput, TextInput, DateInput, LongTextInput, ReferenceManyField, Datagrid, TextField, DateField, EditButton } from 'admin-on-rest/lib/mui';
+import { Create, Edit, SimpleForm, DisabledInput, TextInput, DateInput, LongTextInput, ReferenceManyField, Datagrid, TextField, DateField, EditButton } from 'admin-on-rest';
 import RichTextInput from 'aor-rich-text-input';
 
 export const PostCreate = (props) => (
@@ -116,7 +116,7 @@ You can replace the list of default actions by your own element using the `actio
 import { CardActions } from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 import NavigationRefresh from 'material-ui/svg-icons/navigation/refresh';
-import { ListButton, ShowButton, DeleteButton } from 'admin-on-rest/lib/mui';
+import { ListButton, ShowButton, DeleteButton } from 'admin-on-rest';
 
 const cardActionStyle = {
     zIndex: 2,
@@ -180,7 +180,7 @@ Here are all the props accepted by the `<TabbedForm>` component:
 
 {% raw %}
 ```js
-import { TabbedForm, FormTab } from 'admin-on-rest/lib/mui'
+import { TabbedForm, FormTab } from 'admin-on-rest'
 
 export const PostEdit = (props) => (
     <Edit {...props}>

--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -35,7 +35,7 @@ import Dashboard from './Dashboard';
 import { PostList, PostCreate, PostEdit, PostShow } from './Post';
 import { CommentList, CommentEdit, CommentCreate } from './Comment';
 import { UserList, UserEdit, UserCreate } from './User';
-import { Delete, Layout } from 'admin-on-rest/lib/mui';
+import { Delete, Layout } from 'admin-on-rest';
 // your app labels
 import messages from './i18n';
 

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -10,7 +10,7 @@ A `Field` component displays a given property of a REST resource. Such component
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Datagrid, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -65,7 +65,7 @@ Then you can display the author first name as follows:
 Displays a boolean value as a check.
 
 ``` js
-import { BooleanField } from 'admin-on-rest/lib/mui';
+import { BooleanField } from 'admin-on-rest';
 
 <BooleanField source="commentable" />
 ```
@@ -77,7 +77,7 @@ import { BooleanField } from 'admin-on-rest/lib/mui';
 Displays a value inside a ["Chip"](http://www.material-ui.com/#/components/chip), which is Material UI's term for a label.
 
 ``` js
-import { ChipField } from 'admin-on-rest/lib/mui';
+import { ChipField } from 'admin-on-rest';
 
 <ChipField source="category" />
 ```
@@ -87,7 +87,7 @@ import { ChipField } from 'admin-on-rest/lib/mui';
 This field type is especially useful for one to many relationships, e.g. to display a list of books for a given author:
 
 ``` js
-import { ChipField, SingleFieldList, ReferenceManyField } from 'admin-on-rest/lib/mui';
+import { ChipField, SingleFieldList, ReferenceManyField } from 'admin-on-rest';
 
 <ReferenceManyField reference="books" target="author_id">
     <SingleFieldList>
@@ -101,7 +101,7 @@ import { ChipField, SingleFieldList, ReferenceManyField } from 'admin-on-rest/li
 Displays a date or datetime using the browser locale (thanks to `Date.toLocaleDateString()` and `Date.toLocaleString()`).
 
 ``` js
-import { DateField } from 'admin-on-rest/lib/mui';
+import { DateField } from 'admin-on-rest';
 
 <DateField source="publication_date" />
 ```
@@ -141,7 +141,7 @@ See [Intl.DateTimeformat documentation](https://developer.mozilla.org/fr/docs/We
 `<EmailField>` displays an email as a `<a href="mailto:" />` link.
 
 ``` js
-import { EmailField } from 'admin-on-rest/lib/mui';
+import { EmailField } from 'admin-on-rest';
 
 <EmailField source="personal_email" />
 ```
@@ -151,7 +151,7 @@ import { EmailField } from 'admin-on-rest/lib/mui';
 If you need a special function to render a field, `<FunctionField>` is the perfect match. It passes the `record` to a `render` function supplied by the developer. For instance, to display the full name of a `user` record based on `first_name` and `last_name` properties:
 
 ```js
-import { FunctionField } from 'admin-on-rest/lib/mui'
+import { FunctionField } from 'admin-on-rest'
 
 <FunctionField label="Name" render={record => `${record.first_name} ${record.last_name}`} />
 ```
@@ -163,7 +163,7 @@ import { FunctionField } from 'admin-on-rest/lib/mui'
 If you need to display an image provided by your API, you can use the `<ImageField />` component:
 
 ``` js
-import { ImageField } from 'admin-on-rest/lib/mui';
+import { ImageField } from 'admin-on-rest';
 
 <ImageField source="url" title="title" />
 ```
@@ -194,7 +194,7 @@ If Intl is not available, it outputs number as is (and ignores the `locales` and
 
 {% raw %}
 ```js
-import { NumberField }  from 'admin-on-rest/lib/mui';
+import { NumberField }  from 'admin-on-rest';
 
 <NumberField source="score" />
 // renders the record { id: 1234, score: 567 } as
@@ -234,7 +234,7 @@ For instance, here is how to fetch the `post` related to `comment` records, and 
 
 ```js
 import React from 'react';
-import { List, Datagrid, ReferenceField, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, ReferenceField, TextField } from 'admin-on-rest';
 
 export const CommentList = (props) => (
     <List {...props}>
@@ -295,7 +295,7 @@ For instance, here is how to fetch the `comments` related to a `post` record, an
 
 ```js
 import React from 'react';
-import { List, Datagrid, ChipField, ReferenceManyField, SingleFieldList, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, ChipField, ReferenceManyField, SingleFieldList, TextField } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -319,7 +319,7 @@ You can use a `<Datagrid>` instead of a `<SingleFieldList>` - but not inside ano
 
 ```js
 import React from 'react';
-import { Edit, Datagrid, SimpleForm, DisabledInput, DateField, EditButton, ReferenceManyField, TextField, TextInput } from 'admin-on-rest/lib/mui';
+import { Edit, Datagrid, SimpleForm, DisabledInput, DateField, EditButton, ReferenceManyField, TextField, TextInput } from 'admin-on-rest';
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -373,7 +373,7 @@ Also, you can filter the query used to populate the possible values. Use the `fi
 This component displays some HTML content. The content is "rich" (i.e. unescaped) by default.
 
 ``` js
-import { RichTextField } from 'admin-on-rest/lib/mui';
+import { RichTextField } from 'admin-on-rest';
 
 <RichTextField source="body" />
 ```
@@ -383,7 +383,7 @@ import { RichTextField } from 'admin-on-rest/lib/mui';
 The `stripTags` attribute (`false` by default) allows you to remove any HTML markup, preventing some display glitches (which is especially useful in list views).
 
 ``` js
-import { RichTextField } from 'admin-on-rest/lib/mui';
+import { RichTextField } from 'admin-on-rest';
 
 <RichTextField source="body" stripTags />
 ```
@@ -393,7 +393,7 @@ import { RichTextField } from 'admin-on-rest/lib/mui';
 The most simple as all fields, `<TextField>` simply displays the record property as plain text.
 
 ``` js
-import { TextField } from 'admin-on-rest/lib/mui';
+import { TextField } from 'admin-on-rest';
 
 <TextField label="Author Name" source="name" />
 ```
@@ -403,7 +403,7 @@ import { TextField } from 'admin-on-rest/lib/mui';
 `<UrlField>` displays an url in an `< a href="">` tag.
 
 ``` js
-import { UrlField } from 'admin-on-rest/lib/mui';
+import { UrlField } from 'admin-on-rest';
 
 <UrlField source="site_url" />
 ```
@@ -498,7 +498,7 @@ It's as easy as writing:
 
 ```js
 import React, { PropTypes } from 'react';
-import { List, Datagrid, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField } from 'admin-on-rest';
 
 const FullNameField = ({ record = {} }) => <span>{record.firstName} {record.lastName}</span>;
 FullNameField.defaultProps = { label: 'Name' };

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -10,7 +10,7 @@ An `Input` component displays an input, or a dropdown list, a list of radio butt
 ```js
 // in src/posts.js
 import React from 'react';
-import { Edit, DisabledInput, LongTextInput, ReferenceInput, SelectInput, SimpleForm, TextInput } from 'admin-on-rest/lib/mui';
+import { Edit, DisabledInput, LongTextInput, ReferenceInput, SelectInput, SimpleForm, TextInput } from 'admin-on-rest';
 
 export const PostEdit = (props) => (
     <Edit title={PostTitle} {...props}>
@@ -71,7 +71,7 @@ Then you can display a text input to edit the author first name as follows:
 To let users choose a value in a list using a dropdown with autocompletion, use `<AutocompleteInput>`. It renders using [Material ui's `<AutoComplete>` component](http://www.material-ui.com/#/components/auto-complete) and a `fuzzySearch` filter. Set the `choices` attribute to determine the options list (with `id`, `name` tuples).
 
 ```js
-import { AutocompleteInput } from 'admin-on-rest/lib/mui';
+import { AutocompleteInput } from 'admin-on-rest';
 
 <AutocompleteInput source="category" choices={[
     { id: 'programming', name: 'Programming' },
@@ -104,7 +104,7 @@ const optionRenderer = choice => `${choice.first_name} ${choice.last_name}`;
 You can customize the `filter` function used to filter the results. By default, it's `AutoComplete.fuzzyFilter`, but you can use any of [the functions provided by `AutoComplete`](http://www.material-ui.com/#/components/auto-complete), or a function of your own (`(searchText: string, key: string) => boolean`):
 
 ```js
-import { AutocompleteInput } from 'admin-on-rest/lib/mui';
+import { AutocompleteInput } from 'admin-on-rest';
 import AutoComplete from 'material-ui/AutoComplete';
 
 <AutocompleteInput source="category" filter={AutoComplete.caseInsensitiveFilter} choices={choices} />
@@ -126,7 +126,7 @@ Refer to [Material UI Autocomplete documentation](http://www.material-ui.com/#/c
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<AutocompleteInput>` with [`<ReferenceInput>`](#referenceinput), and leave the `choices` empty:
 
 ```js
-import { AutocompleteInput, ReferenceInput } from 'admin-on-rest/lib/mui'
+import { AutocompleteInput, ReferenceInput } from 'admin-on-rest'
 
 <ReferenceInput label="Post" source="post_id" reference="posts">
     <AutocompleteInput optionText="title" />
@@ -142,7 +142,7 @@ import { AutocompleteInput, ReferenceInput } from 'admin-on-rest/lib/mui'
 `<BooleanInput />` is a toggle button allowing you to attribute a `true` or `false` value to a record field.
 
 ``` js
-import { BooleanInput } from 'admin-on-rest/lib/mui';
+import { BooleanInput } from 'admin-on-rest';
 
 <BooleanInput label="Allow comments?" source="commentable" />
 ```
@@ -154,7 +154,7 @@ This input does not handle `null` values. You would need the `<NullableBooleanIn
 `<NullableBooleanInput />` renders as a dropdown list, allowing to choose between true, false, and null values.
 
 ``` js
-import { NullableBooleanInput } from 'admin-on-rest/lib/mui';
+import { NullableBooleanInput } from 'admin-on-rest';
 
 <NullableBooleanInput label="Allow comments?" source="commentable" />
 ```
@@ -166,7 +166,7 @@ import { NullableBooleanInput } from 'admin-on-rest/lib/mui';
 If you want to let the user choose multiple values among a list of possible values by showing them all, `<CheckboxGroupInput>` is the right component. Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
 ```js
-import { CheckboxGroupInput } from 'admin-on-rest/lib/mui';
+import { CheckboxGroupInput } from 'admin-on-rest';
 
 <CheckboxGroupInput source="category" choices={[
     { id: 'programming', name: 'Programming' },
@@ -226,7 +226,7 @@ Refer to [Material UI Checkbox documentation](http://www.material-ui.com/#/compo
 Ideal for editing dates, `<DateInput>` renders a beautiful [Date Picker](http://www.material-ui.com/#/components/date-picker) with full localization support.
 
 ``` js
-import { DateInput } from 'admin-on-rest/lib/mui';
+import { DateInput } from 'admin-on-rest';
 
 <DateInput source="published_at" />
 ```
@@ -256,7 +256,7 @@ Refer to [Material UI Datepicker documentation](http://www.material-ui.com/#/com
 When you want to display a record property in an `<Edit>` form without letting users update it (such as for auto-incremented primary keys), use the `<DisabledInput>`:
 
 ``` js
-import { DisabledInput } from 'admin-on-rest/lib/mui';
+import { DisabledInput } from 'admin-on-rest';
 
 <DisabledInput source="id" />
 ```
@@ -267,7 +267,7 @@ import { DisabledInput } from 'admin-on-rest/lib/mui';
 
 ```js
 // in src/posts.js
-import { Edit, LongTextInput, SimpleForm, TextField } from 'admin-on-rest/lib/mui';
+import { Edit, LongTextInput, SimpleForm, TextField } from 'admin-on-rest';
 
 export const PostEdit = (props) => (
     <Edit {...props}>
@@ -283,7 +283,7 @@ export const PostEdit = (props) => (
 
 ```js
 // in src/posts.js
-import { Edit, LongTextInput, SimpleForm } from 'admin-on-rest/lib/mui';
+import { Edit, LongTextInput, SimpleForm } from 'admin-on-rest';
 const titleStyle = { textOverflow: 'ellipsis', overflow: 'hidden', maxWidth: '20em' };
 const Title = ({ record }) => <span style={titleStyle}>{record.title}</span>;
 Title.defaultProps = {
@@ -323,7 +323,7 @@ Note that the image upload returns a [File](https://developer.mozilla.org/en/doc
 `<LongTextInput>` is the best choice for multiline text values. It renders as an auto expandable textarea.
 
 ``` js
-import { LongTextInput } from 'admin-on-rest/lib/mui';
+import { LongTextInput } from 'admin-on-rest';
 
 <LongTextInput source="teaser" />
 ```
@@ -335,7 +335,7 @@ import { LongTextInput } from 'admin-on-rest/lib/mui';
 `<NumberInput>` translates to a HTMl `<input type="number">`. It is necessary for numeric values because of a [known React bug](https://github.com/facebook/react/issues/1425), which prevents using the more generic [`<TextInput>`](#textinput) in that case.
 
 ``` js
-import { NumberInput } from 'admin-on-rest/lib/mui';
+import { NumberInput } from 'admin-on-rest';
 
 <NumberInput source="nb_views" />
 ```
@@ -351,7 +351,7 @@ You can customize the `step` props (which defaults to "any"):
 If you want to let the user choose a value among a list of possible values by showing them all (instead of hiding them behind a dropdown list, as in [`<SelectInput>`](#selectinput)), `<RadioButtonGroupInput>` is the right component. Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
 ```js
-import { RadioButtonGroupInput } from 'admin-on-rest/lib/mui';
+import { RadioButtonGroupInput } from 'admin-on-rest';
 
 <RadioButtonGroupInput source="category" choices={[
     { id: 'programming', name: 'Programming' },
@@ -409,7 +409,7 @@ Refer to [Material UI SelectField documentation](http://www.material-ui.com/#/co
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<RadioButtonGroupInput>` with [`<ReferenceInput>`](#referenceinput), and leave the `choices` empty:
 
 ```js
-import { RadioButtonGroupInput, ReferenceInput } from 'admin-on-rest/lib/mui'
+import { RadioButtonGroupInput, ReferenceInput } from 'admin-on-rest'
 
 <ReferenceInput label="Author" source="author_id" reference="authors">
     <RadioButtonGroupInput optionText="last_name" />
@@ -425,7 +425,7 @@ This means you can use `<ReferenceInput>` with any of [`<SelectInput>`](#selecti
 The component expects a `source` and a `reference` attributes. For instance, to make the `post_id` for a `comment` editable:
 
 ```js
-import { ReferenceInput, SelectInput } from 'admin-on-rest/lib/mui'
+import { ReferenceInput, SelectInput } from 'admin-on-rest'
 
 <ReferenceInput label="Post" source="post_id" reference="posts">
     <SelectInput optionText="title" />
@@ -437,7 +437,7 @@ import { ReferenceInput, SelectInput } from 'admin-on-rest/lib/mui'
 Set the `allowEmpty` prop when the empty value is allowed.
 
 ```js
-import { ReferenceInput, SelectInput } from 'admin-on-rest/lib/mui'
+import { ReferenceInput, SelectInput } from 'admin-on-rest'
 
 <ReferenceInput label="Post" source="post_id" reference="posts" allowEmpty>
     <SelectInput optionText="title" />
@@ -533,7 +533,7 @@ You can customize the rich text editor toolbar using the `toolbar` attribute, as
 To let users choose a value in a list using a dropdown, use `<SelectInput>`. It renders using [Material ui's `<SelectField>`](http://www.material-ui.com/#/components/select-field). Set the `choices` attribute to determine the options (with `id`, `name` tuples):
 
 ```js
-import { SelectInput } from 'admin-on-rest/lib/mui';
+import { SelectInput } from 'admin-on-rest';
 
 <SelectInput source="category" choices={[
     { id: 'programming', name: 'Programming' },
@@ -601,7 +601,7 @@ Refer to [Material UI SelectField documentation](http://www.material-ui.com/#/co
 **Tip**: If you want to populate the `choices` attribute with a list of related records, you should decorate `<SelectInput>` with [`<ReferenceInput>`](#referenceinput), and leave the `choices` empty:
 
 ```js
-import { SelectInput, ReferenceInput } from 'admin-on-rest/lib/mui'
+import { SelectInput, ReferenceInput } from 'admin-on-rest'
 
 <ReferenceInput label="Author" source="author_id" reference="authors">
     <SelectInput optionText="last_name" />
@@ -615,7 +615,7 @@ If, instead of showing choices as a dropdown list, you prefer to display them as
 `<TextInput>` is the most common input. It is used for texts, emails, URL or passwords. In translates to an HTML `<input>` tag.
 
 ``` js
-import { TextInput } from 'admin-on-rest/lib/mui';
+import { TextInput } from 'admin-on-rest';
 
 <TextInput source="title" />
 ```
@@ -678,7 +678,7 @@ This component lacks a label. Admin-on-rest provides the `<Labeled>` component f
 ```js
 // in LatLongInput.js
 import { Field } from 'redux-form';
-import { Labeled } from 'admin-on-rest/lib/mui';
+import { Labeled } from 'admin-on-rest';
 const LatLngInput = () => (
     <Labeled label="position">
         <span>
@@ -768,7 +768,7 @@ Instead of HTML `input` elements, you can use admin-on-rest components in `<Fiel
 ```js
 // in LatLongInput.js
 import { Field } from 'redux-form';
-import { NumberInput } from 'admin-on-rest/lib/mui';
+import { NumberInput } from 'admin-on-rest';
 const LatLngInput = () => (
     <span>
         <Field name="lat" component={NumberInput} label="latitude" />

--- a/docs/List.md
+++ b/docs/List.md
@@ -44,7 +44,7 @@ export default App;
 
 // in src/posts.js
 import React from 'react';
-import { List, Datagrid, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -60,8 +60,6 @@ export const PostList = (props) => (
 That's enough to display the post list:
 
 ![Simple posts list](./img/simple-post-list.png)
-
-Notice that the `<List>`, `<Datagrid>`, and `<TextField>` components that we use here are from `admin-on-rest/lib/mui` - these are Material UI components.
 
 ### Page Title
 
@@ -242,7 +240,7 @@ It renders as many columns as it receives `<Field>` children.
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Datagrid, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -364,7 +362,7 @@ For mobile devices, a `<Datagrid>` is often unusable - there is simply not enoug
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, SimpleList } from 'admin-on-rest/lib/mui';
+import { List, SimpleList } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -384,7 +382,7 @@ export const PostList = (props) => (
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Responsive, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'admin-on-rest/lib/mui';
+import { List, Responsive, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -92,7 +92,7 @@ It expects element props named `small`, `medium`, and `large`. It displays the e
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Responsive, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'admin-on-rest/lib/mui';
+import { List, Responsive, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -225,8 +225,7 @@ import { connect } from 'react-redux';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import CircularProgress from 'material-ui/CircularProgress';
 import injectTapEventPlugin from 'react-tap-event-plugin';
-import { AppBar, Sidebar, Notification } from 'admin-on-rest/lib/mui';
-import { setSidebarVisibility as setSidebarVisibilityAction } from 'admin-on-rest';
+import { AppBar, Sidebar, Notification, setSidebarVisibility as setSidebarVisibilityAction } from 'admin-on-rest';
 
 injectTapEventPlugin();
 

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -58,7 +58,7 @@ The `<Admin>` component contains `<Resource>` components, each resource being ma
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Datagrid, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -70,8 +70,6 @@ export const PostList = (props) => (
     </List>
 );
 ```
-
-Notice that the components we use here are from `admin-on-rest/lib/mui` - these are Material UI components.
 
 The main component of the post list is a `<List>` component, responsible for grabbing the information from the url, displaying the page title, and handling pagination. This list then delegates the display of the actual list of posts to a `<Datagrid>`, responsible for displaying a table with one row for each post. As for which columns should be displayed in this table, that's what the bunch of `<TextField>` components are for, each mapping a different source field in the API response.
 
@@ -88,7 +86,7 @@ So far, you've only seen `<TextField>`, but if the API sends resources with othe
 ```js
 // in src/users.js
 import React from 'react';
-import { List, Datagrid, EmailField, TextField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, EmailField, TextField } from 'admin-on-rest';
 
 export const UserList = (props) => (
     <List title="All users" {...props}>
@@ -157,7 +155,7 @@ Admin-on-REST knows how to take advantage of these foreign keys to fetch referen
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Datagrid, TextField, EmailField, ReferenceField } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, TextField, EmailField, ReferenceField } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -186,7 +184,7 @@ An admin interface is usually for more than seeing remote data - it's for editin
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Edit, Create, Datagrid, ReferenceField, TextField, EditButton, DisabledInput, LongTextInput, ReferenceInput, SelectInput, SimpleForm, TextInput } from 'admin-on-rest/lib/mui';
+import { List, Edit, Create, Datagrid, ReferenceField, TextField, EditButton, DisabledInput, LongTextInput, ReferenceInput, SelectInput, SimpleForm, TextInput } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -271,7 +269,7 @@ There is not much to configure in a deletion view. To add removal abilities to a
 
 ```js
 // in src/App.js
-import { Delete } from 'admin-on-rest/lib/mui';
+import { Delete } from 'admin-on-rest';
 
 const App = () => (
     <Admin restClient={jsonServerRestClient('http://jsonplaceholder.typicode.com')}>
@@ -293,7 +291,7 @@ Admin-on-rest can use input components to create a multi-criteria search engine 
 
 ```js
 // in src/posts.js
-import { Filter, ReferenceInput, SelectInput, TextInput } from 'admin-on-rest/lib/mui';
+import { Filter, ReferenceInput, SelectInput, TextInput } from 'admin-on-rest';
 
 const PostFilter = (props) => (
     <Filter {...props}>
@@ -431,7 +429,7 @@ First, you should know that you don't have to use a `<Datagrid>` as `<List>` chi
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, SimpleList } from 'admin-on-rest/lib/mui';
+import { List, SimpleList } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -451,7 +449,7 @@ That works fine on mobile, but now the desktop user experience is worse. The bes
 ```js
 // in src/posts.js
 import React from 'react';
-import { List, Responsive, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'admin-on-rest/lib/mui';
+import { List, Responsive, SimpleList, Datagrid, TextField, ReferenceField, EditButton } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ The `<Resource>` component is a configuration component that allows to define su
 ```js
 // in posts.js
 import React from 'react';
-import { List, Datagrid, Edit, Create, SimpleForm, DateField, TextField, EditButton, DisabledInput, TextInput, LongTextInput, DateInput } from 'admin-on-rest/lib/mui';
+import { List, Datagrid, Edit, Create, SimpleForm, DateField, TextField, EditButton, DisabledInput, TextInput, LongTextInput, DateInput } from 'admin-on-rest';
 export PostIcon from 'material-ui/svg-icons/action/book';
 
 export const PostList = (props) => (

--- a/example/app.js
+++ b/example/app.js
@@ -2,9 +2,8 @@ import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 
-import { Admin, Resource, englishMessages, resolveBrowserLocale } from 'admin-on-rest';
+import { Admin, Resource, Delete, englishMessages, resolveBrowserLocale } from 'admin-on-rest';
 import jsonRestClient from 'aor-json-rest-client';
-import { Delete } from 'admin-on-rest/mui';
 import frenchMessages from 'aor-language-french';
 
 import addUploadFeature from './addUploadFeature';

--- a/example/comments.js
+++ b/example/comments.js
@@ -18,8 +18,8 @@ import {
     SimpleForm,
     TextField,
     TextInput,
-} from 'admin-on-rest/mui';
-import { translate } from 'admin-on-rest';
+    translate,
+} from 'admin-on-rest';
 import PersonIcon from 'material-ui/svg-icons/social/person';
 import Avatar from 'material-ui/Avatar';
 import { Card, CardActions, CardHeader, CardText } from 'material-ui/Card';

--- a/example/posts.js
+++ b/example/posts.js
@@ -29,9 +29,9 @@ import {
     TabbedForm,
     TextField,
     TextInput,
-} from 'admin-on-rest/mui';
+    translate,
+} from 'admin-on-rest';
 import RichTextInput from 'aor-rich-text-input';
-import { translate } from 'admin-on-rest';
 import Chip from 'material-ui/Chip';
 export PostIcon from 'material-ui/svg-icons/action/book';
 import { Link } from 'react-router';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export * from './actions';
 export * from './auth';
 export * from './i18n';
+export * from './mui';
 export adminReducer from './reducer';
 export localeReducer from './reducer/locale';
 export queryReducer from './reducer/resource/list/queryReducer';


### PR DESCRIPTION
We initially thought that we'd offer support for other UI Kits than material ui. This made `imports` systematically harder, since developers had to think whether the script they imported was mui related or not. Also, we probably won't do it ourselves, and there are other ways to bundle another version of admin-on-rest with a different ui kit.

By exporting the `mui` components in the root, every import is simpler.