### PR TITLE
[RFR] Translate error messages

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -327,6 +327,12 @@ export const UserCreate = (props) => (
 
 Input validation functions receive the current field value, and the values of all fields of the current record. This allows for complex validation scenarios (e.g. validate that two passwords are the same).
 
+**Tip**: Validator functions receive the form `props` as third parameter, including the `translate` function. This lets you build internationalized validators:
+
+```js
+const required = (value, _, props) => value ? undefined : props.translate('myroot.validation.required');
+```
+
 **Tip**: The props of your Input components are passed to a redux-form `<Field>` component. So in addition to `validate`, you can also use `warn`.
 
 **Tip**: You can use *both* Form validation and input validation.

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -60,6 +60,12 @@ export default {
         },
         validation: {
             required: 'Required',
+            minLength: 'Must be %{min} characters at least',
+            maxLength: 'Must be %{max} characters or less',
+            minValue: 'Must be at least %{min}',
+            maxValue: 'Must be %{max} or less',
+            number: 'Must be a number',
+            email: 'Must be a valid email',
         },
     },
 };

--- a/src/mui/detail/Create.js
+++ b/src/mui/detail/Create.js
@@ -43,6 +43,7 @@ class Create extends Component {
                         resource,
                         basePath,
                         record: {},
+                        translate,
                     })}
                 </Card>
             </div>

--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -106,6 +106,7 @@ export class Edit extends Component {
                         resource,
                         basePath,
                         record: data,
+                        translate,
                     })}
                     {!data && <CardText>&nbsp;</CardText>}
                 </Card>

--- a/src/mui/form/validate.js
+++ b/src/mui/form/validate.js
@@ -4,26 +4,26 @@ const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"
 
 const isEmpty = value => (typeof value === 'undefined' || value === null || value === '');
 
-export const required = value => isEmpty(value) ? 'Required field' : undefined;
+export const required = (value, _, props) => isEmpty(value) ? props.translate('aor.validation.required') : undefined;
 
-export const minLength = min => value =>
-    value && value.length < min ? `Must be ${min} characters at least` : undefined;
+export const minLength = min => (value, _, props) =>
+    value && value.length < min ? props.translate('aor.validation.minLength', { min }) : undefined;
 
-export const maxLength = max => value =>
-    value && value.length > max ? `Must be ${max} characters or less` : undefined;
+export const maxLength = max => (value, _, props) =>
+    value && value.length > max ? props.translate('aor.validation.maxLength', { max }) : undefined;
 
-export const minValue = min => value =>
-    value && value < min ? `Must be at least ${min}` : undefined;
+export const minValue = min => (value, _, props) =>
+    value && value < min ? props.translate('aor.validation.minValue', { min }) : undefined;
 
-export const maxValue = max => value =>
-    value && value > max ? `Must be ${max} or less` : undefined;
+export const maxValue = max => (value, _, props) =>
+    value && value > max ? props.translate('aor.validation.maxValue', { max }) : undefined;
 
-export const number = value => value && isNaN(Number(value)) ? 'Must be a number' : undefined;
+export const number = (value, _, props) => value && isNaN(Number(value)) ? props.translate('aor.validation.number') : undefined;
 
-export const regex = (pattern, message) => value =>
-    value && !pattern.test(value) ? message : undefined;
+export const regex = (pattern, message) => (value, _, props) =>
+    value && typeof value === 'string' && !pattern.test(value) ? props.translate(message) : undefined;
 
-export const email = regex(EMAIL_REGEX, 'Must be a valid email');
+export const email = regex(EMAIL_REGEX, 'aor.validation.email');
 
-export const choices = (list, message) => value =>
-    value && list.indexOf(value) === -1 ? message : undefined;
+export const choices = (list, message) => (value, _, props) =>
+    value && list.indexOf(value) === -1 ? props.translate(message) : undefined;

--- a/src/mui/form/validate.spec.js
+++ b/src/mui/form/validate.spec.js
@@ -2,13 +2,21 @@ import assert from 'assert';
 import { required, minLength, maxLength, minValue, maxValue, number, regex, email, choices } from './validate';
 
 describe('Validators', () => {
-    const test = (func, inputs, output) => inputs.map(func).filter(v => v === output).length === inputs.length;
+    const test = (validator, inputs, message) =>
+        assert.deepEqual(
+            inputs
+                .map(input => validator(input, null, { translate: x => x }))
+                .filter(m => m === message)
+            ,
+            Array.apply(null, Array(inputs.length)).map(x => message)
+        );
+
     describe('required', () => {
         it('should return undefined if the value is not empty', () => {
             test(required, ['foo', 12], undefined);
         });
         it('should return an error message if the value is empty', () => {
-            test(required, [undefined, '', null], 'Required field');
+            test(required, [undefined, '', null], 'aor.validation.required');
         });
     });
     describe('minLength', () => {
@@ -22,7 +30,7 @@ describe('Validators', () => {
             test(minLength(5), ['12345', '123456'], undefined);
         });
         it('should return an error message if the value has smaller length than the given minimum', () => {
-            test(minLength(5), ['1234', '12'], 'Must be 5 characters at least');
+            test(minLength(5), ['1234', '12'], 'aor.validation.minLength');
         });
     });
     describe('maxLength', () => {
@@ -36,7 +44,7 @@ describe('Validators', () => {
             test(maxLength(5), ['12345', '123'], undefined);
         });
         it('should return an error message if the value has higher length than the given maximum', () => {
-            test(maxLength(10), ['12345678901'], 'Must be 10 characters or less');
+            test(maxLength(10), ['12345678901'], 'aor.validation.maxLength');
         });
     });
     describe('minValue', () => {
@@ -47,7 +55,7 @@ describe('Validators', () => {
             test(minValue(5), [5, 10, 5.5, '10'], undefined);
         });
         it('should return an error message if the value is lower than the given minimum', () => {
-            test(minValue(10), [1, 9.5, '5'], 'Must be at least 10');
+            test(minValue(10), [1, 9.5, '5'], 'aor.validation.minValue');
         });
     });
     describe('maxValue', () => {
@@ -58,7 +66,7 @@ describe('Validators', () => {
             test(maxValue(5), [5, 4, 4.5, '4'], undefined);
         });
         it('should return an error message if the value is higher than the given maximum', () => {
-            test(maxValue(10), [11, 10.5, '11'], 'Must be 10 or less');
+            test(maxValue(10), [11, 10.5, '11'], 'aor.validation.maxValue');
         });
     });
     describe('number', () => {
@@ -69,7 +77,7 @@ describe('Validators', () => {
             test(number, [123, '123', new Date(), 0, 2.5, -5], undefined);
         });
         it('should return an error message if the value is not a number', () => {
-            test(number, ['foo'], 'Must be a number');
+            test(number, ['foo'], 'aor.validation.number');
         });
     });
     describe('regex', () => {
@@ -97,7 +105,7 @@ describe('Validators', () => {
             test(email, ['foo@bar.com', 'john.doe@mydomain.co.uk'], undefined);
         });
         it('should return an error if the value is not a valid email', () => {
-            test(email, ['foo@bar', 'hello, world'], 'Must be a valid email');
+            test(email, ['foo@bar', 'hello, world'], 'aor.validation.email');
         });
     });
     describe('choices', () => {


### PR DESCRIPTION
This uses the new form validators, that's why it's committed to `next` rather than `master`.

Closes #307 
