### PR TITLE
Allow use of custom label for ImageInput drop area

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -316,6 +316,14 @@ Previews are enabled using `<ImageInput>` children, as following:
 
 This component accepts all [react-dropzone properties](https://github.com/okonet/react-dropzone#features), in addition to those of admin-on-rest. For instance, if you need to upload several images at once, just add the `multiple` DropZone attribute to your `<ImageInput />` field.
 
+If the default Dropzone label don't fit with your need, you can pass a `placeholder` attribute to overwrite it. The attribute can be anything React can render (`React.PropTypes.node`):
+
+``` js
+<ImageInput source="pictures" label="Related pictures" accept="image/*" placeholder={<p>Drop your file here</p>}>
+    <ImageField source="src" title="title" />
+</ImageInput>
+```
+
 Note that the image upload returns a [File](https://developer.mozilla.org/en/docs/Web/API/File) object. It is your responsibility to handle it depending on your API behavior. You can for instance encode it in base64, or send it as a multi-part form data.
 
 ## `<LongTextInput>`

--- a/src/mui/input/ImageInput.js
+++ b/src/mui/input/ImageInput.js
@@ -66,7 +66,11 @@ export class ImageInput extends Component {
     };
 
     label() {
-        const { translate } = this.props;
+        const { translate, placeholder } = this.props;
+
+        if (placeholder) {
+            return placeholder;
+        }
 
         if (this.props.multiple) {
             return (
@@ -134,6 +138,7 @@ ImageInput.propTypes = {
     minSize: PropTypes.number,
     multiple: PropTypes.bool,
     style: PropTypes.object,
+    placeholder: PropTypes.node,
 };
 
 ImageInput.defaultProps = {

--- a/src/mui/input/ImageInput.spec.js
+++ b/src/mui/input/ImageInput.spec.js
@@ -44,6 +44,32 @@ describe('<ImageInput />', () => {
         test(true, 'aor.input.image.upload_several');
     });
 
+    it('should display correct custom label', () => {
+        const test = (expectedLabel) => {
+            const wrapper = shallow((
+                <ImageInput
+                    dropAreaLabel={expectedLabel}
+                    input={{
+                        value: {
+                            picture: null,
+                        },
+                    }}
+                    translate={x => x}
+                    source="picture"
+                />
+            ));
+
+            assert.ok(wrapper.find('Dropzone').contains(expectedLabel));
+        };
+        const CustomLabel = () => (
+            <div>Custom label</div>
+        );
+
+        test('custom label');
+        test(<h1>Custom label</h1>);
+        test(<CustomLabel />);
+    });
+
     describe('Image Preview', () => {
         it('should display file preview using child as preview component', () => {
             const wrapper = shallow((

--- a/src/mui/input/ImageInput.spec.js
+++ b/src/mui/input/ImageInput.spec.js
@@ -48,7 +48,7 @@ describe('<ImageInput />', () => {
         const test = (expectedLabel) => {
             const wrapper = shallow((
                 <ImageInput
-                    dropAreaLabel={expectedLabel}
+                    placeholder={expectedLabel}
                     input={{
                         value: {
                             picture: null,


### PR DESCRIPTION
Add a `dropAreaLabel` property which can contains any node.

Used to render the `Dropzone` label on `ImageInput`.