### PR TITLE
Layout: fix IE11 compatibility

### DIFF
--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -16,6 +16,11 @@ import { setSidebarVisibility as setSidebarVisibilityAction } from '../../action
 injectTapEventPlugin();
 
 const styles = {
+    wrapper: {
+        // Avoid IE bug with Flexbox, see #467
+        display: 'flex',
+        flexDirection: 'column',
+    },
     main: {
         display: 'flex',
         flexDirection: 'column',
@@ -70,6 +75,7 @@ class Layout extends Component {
         if (!prefixedStyles.main) {
             // do this once because user agent never changes
             const prefix = autoprefixer(muiTheme);
+            prefixedStyles.wrapper = prefix(styles.wrapper);
             prefixedStyles.main = prefix(styles.main);
             prefixedStyles.body = prefix(styles.body);
             prefixedStyles.bodySmall = prefix(styles.bodySmall);
@@ -78,21 +84,23 @@ class Layout extends Component {
         }
         return (
             <MuiThemeProvider muiTheme={muiTheme}>
-                <div style={prefixedStyles.main}>
-                    { width !== 1 && <AppBar title={title} />}
-                    <div className="body" style={width === 1 ? prefixedStyles.bodySmall : prefixedStyles.body}>
-                        <div style={width === 1 ? prefixedStyles.contentSmall : prefixedStyles.content}>{children}</div>
-                        <Sidebar theme={theme}>
-                            {menu}
-                        </Sidebar>
+                <div style={prefixedStyles.wrapper}>
+                    <div style={prefixedStyles.main}>
+                        { width !== 1 && <AppBar title={title} />}
+                        <div className="body" style={width === 1 ? prefixedStyles.bodySmall : prefixedStyles.body}>
+                            <div style={width === 1 ? prefixedStyles.contentSmall : prefixedStyles.content}>{children}</div>
+                            <Sidebar theme={theme}>
+                                {menu}
+                            </Sidebar>
+                        </div>
+                        <Notification />
+                        {isLoading && <CircularProgress
+                            color="#fff"
+                            size={width === 1 ? 20 : 30}
+                            thickness={2}
+                            style={styles.loader}
+                        />}
                     </div>
-                    <Notification />
-                    {isLoading && <CircularProgress
-                        color="#fff"
-                        size={width === 1 ? 20 : 30}
-                        thickness={2}
-                        style={styles.loader}
-                    />}
                 </div>
             </MuiThemeProvider>
         );


### PR DESCRIPTION
Before:
![capture d ecran 2017-03-17 a 15 19 18](https://cloud.githubusercontent.com/assets/900947/24047620/8f2c039a-0b26-11e7-9fe4-9067af932c0f.png)

After:
![capture d ecran 2017-03-17 a 15 18 14](https://cloud.githubusercontent.com/assets/900947/24047623/9241f1c0-0b26-11e7-81ff-a487fe277f5b.png)

See:
- https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
- https://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/

Fix #467