### PR TITLE
[RFR] Add `linkType` to ReferenceField

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -263,7 +263,45 @@ With this configuration, `<ReferenceField>` wraps the comment title in a link to
 </Admin>
 ```
 
-**Tip**: Admin-on-rest accumulates and deduplicates the ids of the referenced records to make *one* `GET_MANY` call for the entire list, instead of n `GET_ONE` calls. So for instance, if the API returns the following list of comments:
+`<ReferenceField>` add link to the reference record's `<Edit>` view by default.
+
+```js
+// Link to `/users/:userId` (`<Edit>` view))
+<ReferenceField label="User" source="userId" reference="users">
+    <TextField source="name" />
+</ReferenceField>
+
+// This is equivalent to the above
+<ReferenceField label="User" source="userId" reference="users" linkType="edit">
+    <TextField source="name" />
+</ReferenceField>
+```
+
+You can set `linkType` attribute to "show" to link to the `<Show>` view.
+
+```js
+// Link to `/users/:userId/show` (Show link)
+<ReferenceField label="User" source="userId" reference="users" linkType="edit">
+    <TextField source="name" />
+</ReferenceField>
+```
+
+You can also prevent `<ReferenceField>` from adding link to children by setting
+`linkType` to other values.
+
+```js
+// No link
+<ReferenceField label="User" source="userId" reference="users" linkType="">
+    <TextField source="name" />
+</ReferenceField>
+
+// Custom link
+<ReferenceField label="User" source="userId" reference="users" linkType="none">
+    <FunctionField render={record => (<a href={record.homepage}>{record.name}</a>)} />
+</ReferenceField>
+```
+
+**Tip**: Admin-on-rest uses `CRUD_GET_ONE_REFERENCE` action to accumulate and deduplicate the ids of the referenced records to make *one* `GET_MANY` call for the entire list, instead of n `GET_ONE` calls. So for instance, if the API returns the following list of comments:
 
 ```js
 [

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -248,7 +248,7 @@ export const CommentList = (props) => (
 );
 ```
 
-With this configuration, `<ReferenceField>` wraps the comment title in a link to the related post `<Edit>` view.
+With this configuration, `<ReferenceField>` wraps the comment title in a link to the related post `<Edit>` page.
 
 ![ReferenceField](./img/reference-field.png)
 
@@ -263,41 +263,20 @@ With this configuration, `<ReferenceField>` wraps the comment title in a link to
 </Admin>
 ```
 
-`<ReferenceField>` add link to the reference record's `<Edit>` view by default.
+To change the link from the `<Edit>` page to the `<Show>` page, set the `linkType` prop to "show".
 
 ```js
-// Link to `/users/:userId` (`<Edit>` view))
-<ReferenceField label="User" source="userId" reference="users">
-    <TextField source="name" />
-</ReferenceField>
-
-// This is equivalent to the above
-<ReferenceField label="User" source="userId" reference="users" linkType="edit">
+<ReferenceField label="User" source="userId" reference="users" linkType="show">
     <TextField source="name" />
 </ReferenceField>
 ```
 
-You can set `linkType` attribute to "show" to link to the `<Show>` view.
-
-```js
-// Link to `/users/:userId/show` (Show link)
-<ReferenceField label="User" source="userId" reference="users" linkType="edit">
-    <TextField source="name" />
-</ReferenceField>
-```
-
-You can also prevent `<ReferenceField>` from adding link to children by setting
-`linkType` to other values.
+You can also prevent `<ReferenceField>` from adding link to children by setting `linkType` to `false`.
 
 ```js
 // No link
-<ReferenceField label="User" source="userId" reference="users" linkType="">
+<ReferenceField label="User" source="userId" reference="users" linkType={false}>
     <TextField source="name" />
-</ReferenceField>
-
-// Custom link
-<ReferenceField label="User" source="userId" reference="users" linkType="none">
-    <FunctionField render={record => (<a href={record.homepage}>{record.name}</a>)} />
 </ReferenceField>
 ```
 

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -23,7 +23,7 @@ import linkToRecord from '../../util/linkToRecord';
  * Set the linkType prop to "show" to link to the <Show> page instead.
  *
  * @example
- * <ReferenceField label="User" source="userId" reference="users" linkType="edit">
+ * <ReferenceField label="User" source="userId" reference="users" linkType="show">
  *     <TextField source="name" />
  * </ReferenceField>
  *

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -4,12 +4,39 @@ import { Link } from 'react-router';
 import LinearProgress from 'material-ui/LinearProgress';
 import get from 'lodash.get';
 import { crudGetOneReference as crudGetOneReferenceAction } from '../../actions/referenceActions';
-import linkToRecord from '../../util/linkToRecord'
+import linkToRecord from '../../util/linkToRecord';
 
 /**
- * @example
- * <ReferenceField label="Post" source="post_id" reference="posts">
- *     <TextField source="title" />
+ * @example Link to `/users/:userId` (`<Edit>` view)
+ * <ReferenceField label="User" source="userId" reference="users">
+ *     <TextField source="name" />
+ * </ReferenceField>
+ *
+ * This is equivalent to:
+ *
+ * @example Link to `/users/:userId` (`<Edit>` view)
+ * <ReferenceField label="User" source="userId" reference="users" linkType="edit">
+ *     <TextField source="name" />
+ * </ReferenceField>
+ *
+ * You can set `linkType` to `"show"` to link to the `<Show>` view.
+ *
+ * @example Link to `/users/:userId/show` (`<Show>` view)
+ * <ReferenceField label="User" source="userId" reference="users" linkType="edit">
+ *     <TextField source="name" />
+ * </ReferenceField>
+ *
+ * You can also prevent `<ReferenceField>` from adding link to children by setting
+ * `linkType` to other values.
+ *
+ * @example No link
+ * <ReferenceField label="User" source="userId" reference="users" linkType="">
+ *     <TextField source="name" />
+ * </ReferenceField>
+ *
+ * @example Custom link
+ * <ReferenceField label="User" source="userId" reference="users" linkType="none">
+ *     <FunctionField render={record => (<a href={record.homepage}>{record.name}</a>)} />
  * </ReferenceField>
  */
 export class ReferenceField extends Component {
@@ -24,7 +51,7 @@ export class ReferenceField extends Component {
     }
 
     render() {
-        const { record, source, reference, referenceRecord, basePath, allowEmpty, children, elStyle } = this.props;
+        const { record, source, reference, referenceRecord, basePath, allowEmpty, children, elStyle, linkType } = this.props;
         if (React.Children.count(children) !== 1) {
             throw new Error('<ReferenceField> only accepts a single child');
         }
@@ -32,16 +59,30 @@ export class ReferenceField extends Component {
             return <LinearProgress />;
         }
         const rootPath = basePath.split('/').slice(0, -1).join('/');
-        return (
-            <Link style={elStyle} to={linkToRecord(`${rootPath}/${reference}`, get(record, source))}>
-                {React.cloneElement(children, {
-                    record: referenceRecord,
-                    resource: reference,
-                    allowEmpty,
-                    basePath,
-                })}
-            </Link>
-        );
+        const href = linkToRecord(`${rootPath}/${reference}`, get(record, source));
+        const child = React.cloneElement(children, {
+            record: referenceRecord,
+            resource: reference,
+            allowEmpty,
+            basePath,
+        });
+        if (linkType === "edit") {
+            return (<Link style={elStyle} to={href}>
+                {child}
+            </Link>);
+        } else if (linkType === "show") {
+            return (<Link style={elStyle} to={href + '/show'}>
+                {child}
+            </Link>);
+        } else {
+            return React.cloneElement(children, {
+                record: referenceRecord,
+                resource: reference,
+                style: elStyle,
+                allowEmpty,
+                basePath,
+            });
+        }
     }
 }
 
@@ -57,6 +98,7 @@ ReferenceField.propTypes = {
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
     source: PropTypes.string.isRequired,
+    linkType: PropTypes.string.isRequired,
 };
 
 ReferenceField.defaultProps = {
@@ -64,6 +106,7 @@ ReferenceField.defaultProps = {
     referenceRecord: null,
     record: {},
     allowEmpty: false,
+    linkType: "edit",
 };
 
 function mapStateToProps(state, props) {

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -62,7 +62,7 @@ export class ReferenceField extends Component {
             allowEmpty,
             basePath,
         });
-        if (linkType === 'edit') {
+        if (linkType === 'edit' || linkType === true) {
             return <Link style={elStyle} to={href}>{child}</Link>;
         }
         if (linkType === 'show') {

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -90,7 +90,10 @@ ReferenceField.propTypes = {
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
     source: PropTypes.string.isRequired,
-    linkType: PropTypes.string.isRequired,
+    linkType: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+    ]).isRequired,
 };
 
 ReferenceField.defaultProps = {

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -7,36 +7,32 @@ import { crudGetOneReference as crudGetOneReferenceAction } from '../../actions/
 import linkToRecord from '../../util/linkToRecord';
 
 /**
- * @example Link to `/users/:userId` (`<Edit>` view)
+ * Fetch reference record, and delegate rendering to child component.
+ *
+ * The reference prop sould be the name of one of the <Resource> components
+ * added as <Admin> child.
+ *
+ * @example
  * <ReferenceField label="User" source="userId" reference="users">
  *     <TextField source="name" />
  * </ReferenceField>
  *
- * This is equivalent to:
+ * By default, includes a link to the <Edit> page of the related record
+ * (`/users/:userId` in the previous example).
  *
- * @example Link to `/users/:userId` (`<Edit>` view)
- * <ReferenceField label="User" source="userId" reference="users" linkType="edit">
- *     <TextField source="name" />
- * </ReferenceField>
+ * Set the linkType prop to "show" to link to the <Show> page instead.
  *
- * You can set `linkType` to `"show"` to link to the `<Show>` view.
- *
- * @example Link to `/users/:userId/show` (`<Show>` view)
+ * @example
  * <ReferenceField label="User" source="userId" reference="users" linkType="edit">
  *     <TextField source="name" />
  * </ReferenceField>
  *
  * You can also prevent `<ReferenceField>` from adding link to children by setting
- * `linkType` to other values.
+ * `linkType` to false.
  *
- * @example No link
- * <ReferenceField label="User" source="userId" reference="users" linkType="">
+ * @example
+ * <ReferenceField label="User" source="userId" reference="users" linkType={false}>
  *     <TextField source="name" />
- * </ReferenceField>
- *
- * @example Custom link
- * <ReferenceField label="User" source="userId" reference="users" linkType="none">
- *     <FunctionField render={record => (<a href={record.homepage}>{record.name}</a>)} />
  * </ReferenceField>
  */
 export class ReferenceField extends Component {
@@ -66,23 +62,19 @@ export class ReferenceField extends Component {
             allowEmpty,
             basePath,
         });
-        if (linkType === "edit") {
-            return (<Link style={elStyle} to={href}>
-                {child}
-            </Link>);
-        } else if (linkType === "show") {
-            return (<Link style={elStyle} to={href + '/show'}>
-                {child}
-            </Link>);
-        } else {
-            return React.cloneElement(children, {
-                record: referenceRecord,
-                resource: reference,
-                style: elStyle,
-                allowEmpty,
-                basePath,
-            });
+        if (linkType === 'edit') {
+            return <Link style={elStyle} to={href}>{child}</Link>;
         }
+        if (linkType === 'show') {
+            return <Link style={elStyle} to={`${href}/show`}>{child}</Link>;
+        }
+        return React.cloneElement(children, {
+            record: referenceRecord,
+            resource: reference,
+            style: elStyle,
+            allowEmpty,
+            basePath,
+        });
     }
 }
 
@@ -106,7 +98,7 @@ ReferenceField.defaultProps = {
     referenceRecord: null,
     record: {},
     allowEmpty: false,
-    linkType: "edit",
+    linkType: 'edit',
 };
 
 function mapStateToProps(state, props) {

--- a/src/mui/field/ReferenceField.spec.js
+++ b/src/mui/field/ReferenceField.spec.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import { ReferenceField } from './ReferenceField';
+import TextField from './TextField';
+
+describe('<ReferenceField />', () => {
+    it('should render a link to the Edit page of the related record by default', () => {
+        const wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="bar"
+                basePath=""
+                crudGetOneReference={() => {}}
+            >
+                    <TextField source="title" />
+            </ReferenceField>
+        );
+        const linkElement = wrapper.find('Link');
+        assert.equal(linkElement.prop('to'), '/bar/123');
+    });
+    it('should render a link to the Show page of the related record when the linkType is show', () => {
+        const wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="bar"
+                basePath=""
+                linkType="show"
+                crudGetOneReference={() => {}}
+            >
+                    <TextField source="title" />
+            </ReferenceField>
+        );
+        const linkElement = wrapper.find('Link');
+        assert.equal(linkElement.prop('to'), '/bar/123/show');
+    });
+    it('should render no link when the linkType is false', () => {
+        const wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="bar"
+                basePath=""
+                linkType={false}
+                crudGetOneReference={() => {}}
+            >
+                    <TextField source="title" />
+            </ReferenceField>
+        );
+        const linkElement = wrapper.find('Link');
+        assert.equal(linkElement.length, 0);
+    });
+});


### PR DESCRIPTION
Supersedes #486 by fixing coding standards and documentation, and adding tests.

Fixes #247.