### PR TITLE
[RFR] Fix NullableBooleanInput

### DIFF
--- a/src/mui/input/NullableBooleanInput.js
+++ b/src/mui/input/NullableBooleanInput.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import SelectInput from './SelectInput';
 import translate from '../../i18n/translate';
 
-export const NullableBooleanInput = ({ input, meta: { touched, error }, label, source, elStyle, resource, translate }) => (
+export const NullableBooleanInput = ({ input, meta, label, source, elStyle, resource, translate }) => (
     <SelectInput
         input={input}
         label={label}
@@ -13,7 +13,7 @@ export const NullableBooleanInput = ({ input, meta: { touched, error }, label, s
             { id: false, name: translate('aor.boolean.false') },
             { id: true, name: translate('aor.boolean.true') },
         ]}
-        errorText={touched && error}
+        meta={meta}
         style={elStyle}
     />
 );

--- a/src/mui/input/NullableBooleanInput.spec.js
+++ b/src/mui/input/NullableBooleanInput.spec.js
@@ -25,19 +25,19 @@ describe('<NullableBooleanInput />', () => {
         it('should not be displayed if field is pristine', () => {
             const wrapper = shallow(<NullableBooleanInput source="foo" {...defaultProps} meta={{ touched: false }} />);
             const SelectInputElement = wrapper.find('SelectInput');
-            assert.equal(SelectInputElement.prop('errorText'), false);
+            assert.equal(SelectInputElement.prop('errorText'), undefined);
         });
 
         it('should not be displayed if field has been touched but is valid', () => {
             const wrapper = shallow(<NullableBooleanInput source="foo" {...defaultProps} meta={{ touched: true, error: false }} />);
             const SelectInputElement = wrapper.find('SelectInput');
-            assert.equal(SelectInputElement.prop('errorText'), false);
+            assert.equal(SelectInputElement.prop('errorText'), undefined);
         });
 
         it('should be displayed if field has been touched and is invalid', () => {
             const wrapper = shallow(<NullableBooleanInput source="foo" {...defaultProps} meta={{ touched: true, error: 'Required field.' }} />);
             const SelectInputElement = wrapper.find('SelectInput');
-            assert.equal(SelectInputElement.prop('errorText'), 'Required field.');
+            assert.deepEqual(SelectInputElement.prop('meta'), { touched: true, error: 'Required field.' });
         });
     });
 });


### PR DESCRIPTION
Our own `<SelectInput>` doesn't have an `errorText` prop, but it expects a `meta` prop.

Closes #507 
