### PR TITLE
[RFR] Fix refresh on Edit clears data

### DIFF
--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -20,7 +20,6 @@ export class Edit extends Component {
         super(props);
         this.state = {
             key: 0,
-            record: props.data,
         };
         this.handleSubmit = this.handleSubmit.bind(this);
     }
@@ -31,7 +30,6 @@ export class Edit extends Component {
 
     componentWillReceiveProps(nextProps) {
         if (this.props.data !== nextProps.data) {
-            this.setState({ record: nextProps.data }); // FIXME: erases user entry when fetch response arrives late
             if (this.fullRefresh) {
                 this.fullRefresh = false;
                 this.setState({ key: this.state.key + 1 });
@@ -102,6 +100,7 @@ export class Edit extends Component {
                     })}
                     <ViewTitle title={titleElement} />
                     {data && React.cloneElement(children, {
+                        form: `record-form-${key}`,
                         onSubmit: this.handleSubmit,
                         resource,
                         basePath,

--- a/src/mui/form/SimpleForm.js
+++ b/src/mui/form/SimpleForm.js
@@ -39,7 +39,6 @@ const enhance = compose(
         initialValues: getDefaultValues(state, props),
     })),
     reduxForm({
-        form: 'record-form',
         validate: validateForm,
         enableReinitialize: true,
     }),

--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -81,7 +81,6 @@ const enhance = compose(
         initialValues: getDefaultValues(state, props),
     })),
     reduxForm({
-        form: 'record-form',
         validate: validateForm,
         enableReinitialize: true,
     }),


### PR DESCRIPTION
Closes #451 

The problem was that we increment the `<Card>` component `key` to force remounting of all input components, which should trigger fetching of related records for `<ReferenceInput>` fields (see #290).

So far so good, but what's surprising is that React first *mounts* the new Card version, then *unmounts* the old Card version. And this is not good for the enclosed form:

1. A new instance of the `<SimpleForm>` component is mounted
2. Because it shares the same form name (`record-form`), the reduxForm instance is unchanged
3. The old instance of the `<SimpleForm>` component is unmounted 
4. Upon unmount, the reduxForm instance is destroyed. Unfortunately, it's the same as before, because it has the name `record-form`
5. All further updates on the form fail because the form is destroyed.

The solution is to create multiple instances of reduxForm to avoid destroying the new one.