### PR TITLE
Adding switch to submit on enter behaviour to <SimpleForm> and <TabbedForm>

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -146,6 +146,9 @@ export const PostEdit = (props) => (
 
 The `<SimpleForm>` component receives the `record` as prop from its parent component. It is responsible for rendering the actual form. It is also responsible for validating the form data. Finally, it receives a `handleSubmit` function as prop, to be called with the updated record as argument when the user submits the form.
 
+By default the `<SimpleForm>` submits the form when the user presses `ENTER`, if you want
+to change this behaviour you can pass `false` for the `submitOnEnter` property.
+
 The `<SimpleForm>` renders its child components line by line (within `<div>` components). It uses `redux-form`.
 
 ![post edition form](./img/post-edition.png)
@@ -170,6 +173,9 @@ export const PostCreate = (props) => (
 ## The `<TabbedForm>` component
 
 Just like `<SimpleForm>`, `<TabbedForm>` receives the `record` prop, renders the actual form, and handles form validation on submit. However, the `<TabbedForm>` component renders inputs grouped by tab. The tabs are set by using `<FormTab>` components, which expect a `label` and an `icon` prop.
+
+By default the `<TabbedForm>` submits the form when the user presses `ENTER`, if you want
+to change this behaviour you can pass `false` for the `submitOnEnter` property.
 
 ![tabbed form](./img/tabbed-form.gif)
 

--- a/src/mui/button/SaveButton.js
+++ b/src/mui/button/SaveButton.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { submit } from 'redux-form';
 import RaisedButton from 'material-ui/RaisedButton';
 import FlatButton from 'material-ui/FlatButton';
 import ContentSave from 'material-ui/svg-icons/content/save';
@@ -13,8 +14,8 @@ export class SaveButton extends Component {
         if (this.props.saving) {
             // prevent double submission
             e.preventDefault();
-        } else if (!this.props.submitOnEnter && this.props.handleSubmit) {
-            this.props.handleSubmit();
+        } else if (!this.props.submitOnEnter) {
+            this.props.dispatch(submit('record-form'));
         }
     }
 
@@ -54,11 +55,6 @@ SaveButton.propTypes = {
     saving: PropTypes.bool,
     translate: PropTypes.func.isRequired,
     submitOnEnter: PropTypes.bool,
-    handleSubmit: PropTypes.func,
-};
-
-SaveButton.defaultProps = {
-    submitOnEnter: true,
 };
 
 const mapStateToProps = state => ({

--- a/src/mui/button/SaveButton.js
+++ b/src/mui/button/SaveButton.js
@@ -15,6 +15,7 @@ export class SaveButton extends Component {
             // prevent double submission
             e.preventDefault();
         } else if (!this.props.submitOnEnter) {
+            // explicit submission of the form needed because button type is 'button', not 'submit'
             this.props.submit();
         }
     }

--- a/src/mui/button/SaveButton.js
+++ b/src/mui/button/SaveButton.js
@@ -15,7 +15,7 @@ export class SaveButton extends Component {
             // prevent double submission
             e.preventDefault();
         } else if (!this.props.submitOnEnter) {
-            this.props.dispatch(submit('record-form'));
+            this.props.submit();
         }
     }
 
@@ -61,4 +61,6 @@ const mapStateToProps = state => ({
     saving: state.admin.saving,
 });
 
-export default connect(mapStateToProps)(translate(SaveButton));
+const mapDispatchToProps = ({ submit: () => submit('record-form') });
+
+export default connect(mapStateToProps, mapDispatchToProps)(translate(SaveButton));

--- a/src/mui/button/SaveButton.js
+++ b/src/mui/button/SaveButton.js
@@ -7,20 +7,23 @@ import ContentSave from 'material-ui/svg-icons/content/save';
 import CircularProgress from 'material-ui/CircularProgress';
 import translate from '../../i18n/translate';
 
-class SaveButton extends Component {
+export class SaveButton extends Component {
 
     handleClick = (e) => {
         if (this.props.saving) {
             // prevent double submission
             e.preventDefault();
+        } else if (!this.props.submitOnEnter && this.props.handleSubmit) {
+            this.props.handleSubmit();
         }
     }
 
     render() {
-        const { saving, label = 'aor.action.save', raised = true, translate } = this.props;
+        const { saving, label = 'aor.action.save', raised = true, translate, submitOnEnter } = this.props;
+        const type = submitOnEnter ? 'submit' : 'button';
         return raised
             ? <RaisedButton
-                type="submit"
+                type={type}
                 label={label && translate(label)}
                 icon={saving ? <CircularProgress size={25} thickness={2} /> : <ContentSave />}
                 onClick={this.handleClick}
@@ -31,7 +34,7 @@ class SaveButton extends Component {
                 }}
             />
             : <FlatButton
-                type="submit"
+                type={type}
                 label={label && translate(label)}
                 icon={saving ? <CircularProgress size={25} thickness={2} /> : <ContentSave />}
                 onClick={this.handleClick}
@@ -50,6 +53,12 @@ SaveButton.propTypes = {
     raised: PropTypes.bool,
     saving: PropTypes.bool,
     translate: PropTypes.func.isRequired,
+    submitOnEnter: PropTypes.bool,
+    handleSubmit: PropTypes.func,
+};
+
+SaveButton.defaultProps = {
+    submitOnEnter: true,
 };
 
 const mapStateToProps = state => ({

--- a/src/mui/button/SaveButton.spec.js
+++ b/src/mui/button/SaveButton.spec.js
@@ -1,0 +1,88 @@
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import React from 'react';
+import simple from 'simple-mock';
+
+import { SaveButton } from './SaveButton';
+
+const translate = (label) => label;
+
+describe('<SaveButton />', () => {
+    it('should render <RaisedButton /> when raised is true', () => {
+        const wrapper = shallow(
+            <SaveButton raised={true} translate={translate} />
+        );
+
+        assert.equal(wrapper.type().muiName, 'RaisedButton');
+    });
+
+    it('should render <FlatButton /> when raised is false', () => {
+        const wrapper = shallow(
+            <SaveButton raised={false} translate={translate} />
+        );
+
+        assert.equal(wrapper.type().muiName, 'FlatButton');
+    });
+
+    it('should render as submit type when submitOnEnter is true', () => {
+        const raisedButtonWrapper = shallow(
+            <SaveButton raised={true} submitOnEnter={true} translate={translate} />
+        );
+        const flatButtonWrapper = shallow(
+            <SaveButton raised={false} submitOnEnter={true} translate={translate} />
+        );
+
+        assert.equal(raisedButtonWrapper.prop('type'), 'submit');
+        assert.equal(flatButtonWrapper.prop('type'), 'submit');
+    });
+
+    it('should not call handleSubmit when clicked while submitOnEnter is true and no saving in in progress', () => {
+        const handleSubmit = simple.mock(() => {});
+        const raisedButtonWrapper = shallow(
+            <SaveButton raised={true} submitOnEnter={true} translate={translate} handleSubmit={handleSubmit} saving={false} />
+        );
+        const flatButtonWrapper = shallow(
+            <SaveButton raised={false} submitOnEnter={true} translate={translate} handleSubmit={handleSubmit} saving={false} />
+        );
+
+        raisedButtonWrapper.simulate('click');
+        flatButtonWrapper.simulate('click');
+
+        assert.equal(handleSubmit.callCount, 0);
+    });
+
+    it('should call handleSubmit when clicked while submitOnEnter is false and no saving is in progress', () => {
+        const handleSubmit = simple.mock(() => {});
+        const raisedButtonWrapper = shallow(
+            <SaveButton raised={true} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={false} />
+        );
+        const flatButtonWrapper = shallow(
+            <SaveButton raised={false} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={false} />
+        );
+
+        raisedButtonWrapper.simulate('click');
+        assert.equal(handleSubmit.callCount, 1);
+        flatButtonWrapper.simulate('click');
+        assert.equal(handleSubmit.callCount, 2);
+    });
+
+    it('should not call handleSubmit when clicked while submitOnEnter is false and saving is in progress', () => {
+        const handleSubmit = simple.mock(() => {});
+        const event = {
+          preventDefault: simple.mock(() => {})
+        };
+        const raisedButtonWrapper = shallow(
+            <SaveButton raised={true} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={true} />
+        );
+        const flatButtonWrapper = shallow(
+            <SaveButton raised={false} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={true} />
+        );
+
+        raisedButtonWrapper.simulate('click', event);
+        assert.equal(event.preventDefault.callCount, 1);
+        flatButtonWrapper.simulate('click', event);
+        assert.equal(event.preventDefault.callCount, 2);
+
+        assert.equal(handleSubmit.callCount, 0);
+    });
+});

--- a/src/mui/button/SaveButton.spec.js
+++ b/src/mui/button/SaveButton.spec.js
@@ -52,19 +52,18 @@ describe('<SaveButton />', () => {
     });
 
     it('should trigger submit action when clicked while submitOnEnter is false and no saving is in progress', () => {
-        const dispatch = sinon.spy();
+        const submit = sinon.spy();
         const raisedButtonWrapper = shallow(
-            <SaveButton raised={true} submitOnEnter={false} translate={translate} dispatch={dispatch} saving={false} />
+            <SaveButton raised={true} submitOnEnter={false} translate={translate} submit={submit} saving={false} />
         );
         const flatButtonWrapper = shallow(
-            <SaveButton raised={false} submitOnEnter={false} translate={translate} dispatch={dispatch} saving={false} />
+            <SaveButton raised={false} submitOnEnter={false} translate={translate} submit={submit} saving={false} />
         );
 
         raisedButtonWrapper.simulate('click');
-        assert(dispatch.calledOnce);
-        assert(dispatch.calledWith({ type: sinon.match(/SUBMIT$/), meta: { form: 'record-form' } }));
+        assert(submit.calledOnce);
         flatButtonWrapper.simulate('click');
-        assert(dispatch.calledTwice);
+        assert(submit.calledTwice);
     });
 
     it('should not trigger submit action when clicked while submitOnEnter is false and saving is in progress', () => {

--- a/src/mui/button/SaveButton.spec.js
+++ b/src/mui/button/SaveButton.spec.js
@@ -36,47 +36,48 @@ describe('<SaveButton />', () => {
         assert.equal(flatButtonWrapper.prop('type'), 'submit');
     });
 
-    it('should not call handleSubmit when clicked while submitOnEnter is true and no saving in in progress', () => {
-        const handleSubmit = sinon.spy();
+    it('should not trigger submit action when clicked while submitOnEnter is true and no saving in in progress', () => {
+        const dispatch = sinon.spy();
         const raisedButtonWrapper = shallow(
-            <SaveButton raised={true} submitOnEnter={true} translate={translate} handleSubmit={handleSubmit} saving={false} />
+            <SaveButton raised={true} submitOnEnter={true} translate={translate} dispatch={dispatch} saving={false} />
         );
         const flatButtonWrapper = shallow(
-            <SaveButton raised={false} submitOnEnter={true} translate={translate} handleSubmit={handleSubmit} saving={false} />
+            <SaveButton raised={false} submitOnEnter={true} translate={translate} dispatch={dispatch} saving={false} />
         );
 
         raisedButtonWrapper.simulate('click');
         flatButtonWrapper.simulate('click');
 
-        assert(handleSubmit.notCalled);
+        assert(dispatch.notCalled);
     });
 
-    it('should call handleSubmit when clicked while submitOnEnter is false and no saving is in progress', () => {
-        const handleSubmit = sinon.spy();
+    it('should trigger submit action when clicked while submitOnEnter is false and no saving is in progress', () => {
+        const dispatch = sinon.spy();
         const raisedButtonWrapper = shallow(
-            <SaveButton raised={true} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={false} />
+            <SaveButton raised={true} submitOnEnter={false} translate={translate} dispatch={dispatch} saving={false} />
         );
         const flatButtonWrapper = shallow(
-            <SaveButton raised={false} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={false} />
+            <SaveButton raised={false} submitOnEnter={false} translate={translate} dispatch={dispatch} saving={false} />
         );
 
         raisedButtonWrapper.simulate('click');
-        assert(handleSubmit.calledOnce);
+        assert(dispatch.calledOnce);
+        assert(dispatch.calledWith({ type: sinon.match(/SUBMIT$/), meta: { form: 'record-form' } }));
         flatButtonWrapper.simulate('click');
-        assert(handleSubmit.calledTwice);
+        assert(dispatch.calledTwice);
     });
 
-    it('should not call handleSubmit when clicked while submitOnEnter is false and saving is in progress', () => {
-        const handleSubmit = sinon.spy();
+    it('should not trigger submit action when clicked while submitOnEnter is false and saving is in progress', () => {
+        const dispatch = sinon.spy();
         const event = {
           preventDefault: sinon.spy(),
         };
 
         const raisedButtonWrapper = shallow(
-            <SaveButton raised={true} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={true} />
+            <SaveButton raised={true} submitOnEnter={false} translate={translate} dispatch={dispatch} saving={true} />
         );
         const flatButtonWrapper = shallow(
-            <SaveButton raised={false} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={true} />
+            <SaveButton raised={false} submitOnEnter={false} translate={translate} dispatch={dispatch} saving={true} />
         );
 
         raisedButtonWrapper.simulate('click', event);
@@ -84,6 +85,6 @@ describe('<SaveButton />', () => {
         flatButtonWrapper.simulate('click', event);
         assert(event.preventDefault.calledTwice);
 
-        assert(handleSubmit.notCalled);
+        assert(dispatch.notCalled);
     });
 });

--- a/src/mui/button/SaveButton.spec.js
+++ b/src/mui/button/SaveButton.spec.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import React from 'react';
-import simple from 'simple-mock';
+import sinon from 'sinon';
 
 import { SaveButton } from './SaveButton';
 
@@ -37,7 +37,7 @@ describe('<SaveButton />', () => {
     });
 
     it('should not call handleSubmit when clicked while submitOnEnter is true and no saving in in progress', () => {
-        const handleSubmit = simple.mock(() => {});
+        const handleSubmit = sinon.spy();
         const raisedButtonWrapper = shallow(
             <SaveButton raised={true} submitOnEnter={true} translate={translate} handleSubmit={handleSubmit} saving={false} />
         );
@@ -48,11 +48,11 @@ describe('<SaveButton />', () => {
         raisedButtonWrapper.simulate('click');
         flatButtonWrapper.simulate('click');
 
-        assert.equal(handleSubmit.callCount, 0);
+        assert(handleSubmit.notCalled);
     });
 
     it('should call handleSubmit when clicked while submitOnEnter is false and no saving is in progress', () => {
-        const handleSubmit = simple.mock(() => {});
+        const handleSubmit = sinon.spy();
         const raisedButtonWrapper = shallow(
             <SaveButton raised={true} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={false} />
         );
@@ -61,16 +61,17 @@ describe('<SaveButton />', () => {
         );
 
         raisedButtonWrapper.simulate('click');
-        assert.equal(handleSubmit.callCount, 1);
+        assert(handleSubmit.calledOnce);
         flatButtonWrapper.simulate('click');
-        assert.equal(handleSubmit.callCount, 2);
+        assert(handleSubmit.calledTwice);
     });
 
     it('should not call handleSubmit when clicked while submitOnEnter is false and saving is in progress', () => {
-        const handleSubmit = simple.mock(() => {});
+        const handleSubmit = sinon.spy();
         const event = {
-          preventDefault: simple.mock(() => {})
+          preventDefault: sinon.spy(),
         };
+
         const raisedButtonWrapper = shallow(
             <SaveButton raised={true} submitOnEnter={false} translate={translate} handleSubmit={handleSubmit} saving={true} />
         );
@@ -79,10 +80,10 @@ describe('<SaveButton />', () => {
         );
 
         raisedButtonWrapper.simulate('click', event);
-        assert.equal(event.preventDefault.callCount, 1);
+        assert(event.preventDefault.calledOnce);
         flatButtonWrapper.simulate('click', event);
-        assert.equal(event.preventDefault.callCount, 2);
+        assert(event.preventDefault.calledTwice);
 
-        assert.equal(handleSubmit.callCount, 0);
+        assert(handleSubmit.notCalled);
     });
 });

--- a/src/mui/form/SimpleForm.js
+++ b/src/mui/form/SimpleForm.js
@@ -7,11 +7,11 @@ import getDefaultValues from './getDefaultValues';
 import FormField from './FormField';
 import Toolbar from './Toolbar';
 
+const noop = () => {};
+
 export const SimpleForm = ({ children, handleSubmit, invalid, record, resource, basePath, submitOnEnter }) => {
-    const formOnSubmit = submitOnEnter ? handleSubmit : function noop() {};
-    const toolbarProps = submitOnEnter ? {} : { submitOnEnter: submitOnEnter, handleSubmit: handleSubmit };
     return (
-        <form onSubmit={formOnSubmit} className="simple-form">
+        <form onSubmit={ submitOnEnter ? handleSubmit : noop } className="simple-form">
             <div style={{ padding: '0 1em 1em 1em' }}>
                 {React.Children.map(children, input => input && (
                     <div key={input.props.source} className={`aor-input-${input.props.source}`} style={input.props.style}>
@@ -19,7 +19,7 @@ export const SimpleForm = ({ children, handleSubmit, invalid, record, resource, 
                     </div>
                 ))}
             </div>
-            <Toolbar invalid={invalid} {...toolbarProps} />
+            <Toolbar invalid={invalid} submitOnEnter={submitOnEnter} />
         </form>
     );
 };

--- a/src/mui/form/SimpleForm.js
+++ b/src/mui/form/SimpleForm.js
@@ -7,18 +7,22 @@ import getDefaultValues from './getDefaultValues';
 import FormField from './FormField';
 import Toolbar from './Toolbar';
 
-export const SimpleForm = ({ children, handleSubmit, invalid, record, resource, basePath }) => (
-    <form onSubmit={handleSubmit} className="simple-form">
-        <div style={{ padding: '0 1em 1em 1em' }}>
-            {React.Children.map(children, input => input && (
-                <div key={input.props.source} className={`aor-input-${input.props.source}`} style={input.props.style}>
-                    <FormField input={input} resource={resource} record={record} basePath={basePath} />
-                </div>
-            ))}
-        </div>
-        <Toolbar invalid={invalid} />
-    </form>
-);
+export const SimpleForm = ({ children, handleSubmit, invalid, record, resource, basePath, submitOnEnter }) => {
+    const formOnSubmit = submitOnEnter ? handleSubmit : function noop() {};
+    const toolbarProps = submitOnEnter ? {} : { submitOnEnter: submitOnEnter, handleSubmit: handleSubmit };
+    return (
+        <form onSubmit={formOnSubmit} className="simple-form">
+            <div style={{ padding: '0 1em 1em 1em' }}>
+                {React.Children.map(children, input => input && (
+                    <div key={input.props.source} className={`aor-input-${input.props.source}`} style={input.props.style}>
+                        <FormField input={input} resource={resource} record={record} basePath={basePath} />
+                    </div>
+                ))}
+            </div>
+            <Toolbar invalid={invalid} {...toolbarProps} />
+        </form>
+    );
+};
 
 SimpleForm.propTypes = {
     children: PropTypes.node,
@@ -32,6 +36,11 @@ SimpleForm.propTypes = {
     resource: PropTypes.string,
     basePath: PropTypes.string,
     validate: PropTypes.func,
+    submitOnEnter: PropTypes.bool,
+};
+
+SimpleForm.defaultProps = {
+    submitOnEnter: true,
 };
 
 const enhance = compose(

--- a/src/mui/form/SimpleForm.spec.js
+++ b/src/mui/form/SimpleForm.spec.js
@@ -41,7 +41,7 @@ describe('<SimpleForm />', () => {
         assert.equal(button.prop('submitOnEnter'), false);
     });
 
-    it('should pass handleSubmit to the form and not pass submitOnEnter to <Toolbar /> when submitOnEnter is true', () => {
+    it('should pass handleSubmit to the form and pass submitOnEnter to <Toolbar /> when submitOnEnter is true', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
             <SimpleForm submitOnEnter={true} handleSubmit={handleSubmit}>

--- a/src/mui/form/SimpleForm.spec.js
+++ b/src/mui/form/SimpleForm.spec.js
@@ -38,7 +38,7 @@ describe('<SimpleForm />', () => {
         assert.notStrictEqual(form.prop('onSubmit'), handleSubmit);
 
         const button = wrapper.find('Toolbar');
-        assert.equal(button.prop('submitOnEnter'), true);
+        assert.equal(button.prop('submitOnEnter'), false);
         assert.equal(button.prop('handleSubmit'), handleSubmit);
     });
 

--- a/src/mui/form/SimpleForm.spec.js
+++ b/src/mui/form/SimpleForm.spec.js
@@ -27,7 +27,7 @@ describe('<SimpleForm />', () => {
         assert.equal(button.length, 1);
     });
 
-    it('should not pass handleSubmit to the form and pass submitOnEnter and handleSumit to <Toolbar /> when submitOnEnter is false', () => {
+    it('should not pass handleSubmit to the form and pass submitOnEnter to <Toolbar /> when submitOnEnter is false', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
             <SimpleForm submitOnEnter={false} handleSubmit={handleSubmit}>
@@ -39,10 +39,9 @@ describe('<SimpleForm />', () => {
 
         const button = wrapper.find('Toolbar');
         assert.equal(button.prop('submitOnEnter'), false);
-        assert.equal(button.prop('handleSubmit'), handleSubmit);
     });
 
-    it('should pass handleSubmit to the form and not pass submitOnEnter and handleSumit to <Toolbar /> when submitOnEnter is true', () => {
+    it('should pass handleSubmit to the form and not pass submitOnEnter to <Toolbar /> when submitOnEnter is true', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
             <SimpleForm submitOnEnter={true} handleSubmit={handleSubmit}>
@@ -53,7 +52,6 @@ describe('<SimpleForm />', () => {
         assert.strictEqual(form.prop('onSubmit'), handleSubmit);
 
         const button = wrapper.find('Toolbar');
-        assert.strictEqual(button.prop('submitOnEnter'), undefined);
-        assert.strictEqual(button.prop('handleSubmit'), undefined);
+        assert.strictEqual(button.prop('submitOnEnter'), true);
     });
 });

--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -8,6 +8,8 @@ import Toolbar from './Toolbar';
 import getDefaultValues from './getDefaultValues';
 import translate from '../../i18n/translate';
 
+const noop = () => {};
+
 export class TabbedForm extends Component {
     constructor(props) {
         super(props);
@@ -22,10 +24,8 @@ export class TabbedForm extends Component {
 
     render() {
         const { children, contentContainerStyle, handleSubmit, invalid, record, resource, basePath, translate, submitOnEnter } = this.props;
-        const formOnSubmit = submitOnEnter ? handleSubmit : function noop() {};
-        const toolbarProps = submitOnEnter ? {} : { submitOnEnter: submitOnEnter, handleSubmit: handleSubmit };
         return (
-            <form onSubmit={formOnSubmit} className="tabbed-form">
+            <form onSubmit={ submitOnEnter ? handleSubmit : noop } className="tabbed-form">
                 <div style={{ padding: '0 1em 1em 1em' }}>
                     <Tabs
                         value={this.state.value}
@@ -45,7 +45,7 @@ export class TabbedForm extends Component {
                         )}
                     </Tabs>
                 </div>
-                <Toolbar invalid={invalid} {...toolbarProps} />
+                <Toolbar invalid={invalid} submitOnEnter={submitOnEnter} />
             </form>
         );
     }

--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -21,9 +21,11 @@ export class TabbedForm extends Component {
     };
 
     render() {
-        const { children, contentContainerStyle, handleSubmit, invalid, record, resource, basePath, translate } = this.props;
+        const { children, contentContainerStyle, handleSubmit, invalid, record, resource, basePath, translate, submitOnEnter } = this.props;
+        const formOnSubmit = submitOnEnter ? handleSubmit : function noop() {};
+        const toolbarProps = submitOnEnter ? {} : { submitOnEnter: submitOnEnter, handleSubmit: handleSubmit };
         return (
-            <form onSubmit={handleSubmit} className="tabbed-form">
+            <form onSubmit={formOnSubmit} className="tabbed-form">
                 <div style={{ padding: '0 1em 1em 1em' }}>
                     <Tabs
                         value={this.state.value}
@@ -43,7 +45,7 @@ export class TabbedForm extends Component {
                         )}
                     </Tabs>
                 </div>
-                <Toolbar invalid={invalid} />
+                <Toolbar invalid={invalid} {...toolbarProps} />
             </form>
         );
     }
@@ -63,10 +65,12 @@ TabbedForm.propTypes = {
     basePath: PropTypes.string,
     translate: PropTypes.func,
     validate: PropTypes.func,
+    submitOnEnter: PropTypes.bool,
 };
 
 TabbedForm.defaultProps = {
     contentContainerStyle: { borderTop: 'solid 1px #e0e0e0' },
+    submitOnEnter: true,
 };
 
 const enhance = compose(

--- a/src/mui/form/TabbedForm.spec.js
+++ b/src/mui/form/TabbedForm.spec.js
@@ -40,7 +40,7 @@ describe('<TabbedForm />', () => {
         assert.notStrictEqual(form.prop('onSubmit'), handleSubmit);
 
         const button = wrapper.find('Toolbar');
-        assert.equal(button.prop('submitOnEnter'), true);
+        assert.equal(button.prop('submitOnEnter'), false);
         assert.equal(button.prop('handleSubmit'), handleSubmit);
     });
 

--- a/src/mui/form/TabbedForm.spec.js
+++ b/src/mui/form/TabbedForm.spec.js
@@ -2,26 +2,29 @@ import assert from 'assert';
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { SimpleForm } from './SimpleForm';
-import TextInput from '../input/TextInput';
+import { TabbedForm } from './TabbedForm';
+import FormTab from './FormTab';
 
-describe('<SimpleForm />', () => {
-    it('should embed a form with given component children', () => {
+const translate = (label) => label;
+
+describe('<TabbedForm />', () => {
+    it('should render tabs', () => {
         const wrapper = shallow(
-            <SimpleForm>
-                <TextInput source="name" />
-                <TextInput source="city" />
-            </SimpleForm>
+            <TabbedForm translate={translate}>
+              <FormTab />
+              <FormTab />
+            </TabbedForm>
         );
-        const inputs = wrapper.find('FormField');
-        assert.deepEqual(inputs.map(i => i.prop('input').props.source), ['name', 'city']);
+        const tabsContainer = wrapper.find('Tabs');
+        assert.equal(tabsContainer.length, 1);
+        const tabs = wrapper.find('FormTab');
+        assert.equal(tabs.length, 2);
     });
 
     it('should display <Toolbar />', () => {
         const wrapper = shallow(
-            <SimpleForm>
-                <TextInput source="name" />
-            </SimpleForm>
+            <TabbedForm translate={translate}>
+            </TabbedForm>
         );
         const button = wrapper.find('Toolbar');
         assert.equal(button.length, 1);
@@ -30,9 +33,8 @@ describe('<SimpleForm />', () => {
     it('should not pass handleSubmit to the form and pass submitOnEnter and handleSumit to <Toolbar /> when submitOnEnter is false', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
-            <SimpleForm submitOnEnter={false} handleSubmit={handleSubmit}>
-                <TextInput source="name" />
-            </SimpleForm>
+            <TabbedForm translate={translate} submitOnEnter={false} handleSubmit={handleSubmit}>
+            </TabbedForm>
         );
         const form = wrapper.find('form');
         assert.notStrictEqual(form.prop('onSubmit'), handleSubmit);
@@ -45,9 +47,8 @@ describe('<SimpleForm />', () => {
     it('should pass handleSubmit to the form and not pass submitOnEnter and handleSumit to <Toolbar /> when submitOnEnter is true', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
-            <SimpleForm submitOnEnter={true} handleSubmit={handleSubmit}>
-                <TextInput source="name" />
-            </SimpleForm>
+            <TabbedForm translate={translate} submitOnEnter={true} handleSubmit={handleSubmit}>
+            </TabbedForm>
         );
         const form = wrapper.find('form');
         assert.strictEqual(form.prop('onSubmit'), handleSubmit);

--- a/src/mui/form/TabbedForm.spec.js
+++ b/src/mui/form/TabbedForm.spec.js
@@ -30,7 +30,7 @@ describe('<TabbedForm />', () => {
         assert.equal(button.length, 1);
     });
 
-    it('should not pass handleSubmit to the form and pass submitOnEnter and handleSumit to <Toolbar /> when submitOnEnter is false', () => {
+    it('should not pass handleSubmit to the form and pass submitOnEnter to <Toolbar /> when submitOnEnter is false', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
             <TabbedForm translate={translate} submitOnEnter={false} handleSubmit={handleSubmit}>
@@ -41,10 +41,9 @@ describe('<TabbedForm />', () => {
 
         const button = wrapper.find('Toolbar');
         assert.equal(button.prop('submitOnEnter'), false);
-        assert.equal(button.prop('handleSubmit'), handleSubmit);
     });
 
-    it('should pass handleSubmit to the form and not pass submitOnEnter and handleSumit to <Toolbar /> when submitOnEnter is true', () => {
+    it('should pass handleSubmit to the form and not pass submitOnEnter to <Toolbar /> when submitOnEnter is true', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
             <TabbedForm translate={translate} submitOnEnter={true} handleSubmit={handleSubmit}>
@@ -54,7 +53,6 @@ describe('<TabbedForm />', () => {
         assert.strictEqual(form.prop('onSubmit'), handleSubmit);
 
         const button = wrapper.find('Toolbar');
-        assert.strictEqual(button.prop('submitOnEnter'), undefined);
-        assert.strictEqual(button.prop('handleSubmit'), undefined);
+        assert.strictEqual(button.prop('submitOnEnter'), true);
     });
 });

--- a/src/mui/form/TabbedForm.spec.js
+++ b/src/mui/form/TabbedForm.spec.js
@@ -43,7 +43,7 @@ describe('<TabbedForm />', () => {
         assert.equal(button.prop('submitOnEnter'), false);
     });
 
-    it('should pass handleSubmit to the form and not pass submitOnEnter to <Toolbar /> when submitOnEnter is true', () => {
+    it('should pass handleSubmit to the form and pass submitOnEnter to <Toolbar /> when submitOnEnter is true', () => {
         const handleSubmit = () => {};
         const wrapper = shallow(
             <TabbedForm translate={translate} submitOnEnter={true} handleSubmit={handleSubmit}>

--- a/src/mui/form/Toolbar.js
+++ b/src/mui/form/Toolbar.js
@@ -14,19 +14,19 @@ const styles = {
     },
 };
 
-const Toolbar = ({ invalid, submitOnEnter = true, handleSubmit = null }) => (
+const Toolbar = ({ invalid, submitOnEnter = true }) => (
     <Responsive
         small={
             <MuiToolbar style={styles.mobileToolbar} noGutter>
                 <ToolbarGroup>
-                    <SaveButton invalid={invalid} submitOnEnter={submitOnEnter} handleSubmit={handleSubmit} raised={false} />
+                    <SaveButton invalid={invalid} submitOnEnter={submitOnEnter} raised={false} />
                 </ToolbarGroup>
             </MuiToolbar>
         }
         medium={
             <MuiToolbar>
                 <ToolbarGroup>
-                    <SaveButton invalid={invalid} submitOnEnter={submitOnEnter} handleSubmit={handleSubmit} />
+                    <SaveButton invalid={invalid} submitOnEnter={submitOnEnter} />
                 </ToolbarGroup>
             </MuiToolbar>
         }

--- a/src/mui/form/Toolbar.js
+++ b/src/mui/form/Toolbar.js
@@ -14,19 +14,19 @@ const styles = {
     },
 };
 
-const Toolbar = ({ invalid }) => (
+const Toolbar = ({ invalid, submitOnEnter = true, handleSubmit = null }) => (
     <Responsive
         small={
             <MuiToolbar style={styles.mobileToolbar} noGutter>
                 <ToolbarGroup>
-                    <SaveButton invalid={invalid} raised={false} />
+                    <SaveButton invalid={invalid} submitOnEnter={submitOnEnter} handleSubmit={handleSubmit} raised={false} />
                 </ToolbarGroup>
             </MuiToolbar>
         }
         medium={
             <MuiToolbar>
                 <ToolbarGroup>
-                    <SaveButton invalid={invalid} />
+                    <SaveButton invalid={invalid} submitOnEnter={submitOnEnter} handleSubmit={handleSubmit} />
                 </ToolbarGroup>
             </MuiToolbar>
         }


### PR DESCRIPTION
I needed this functionality because I've added `react-google-maps` with the `<Searchbox/>` to my form. But if the user was selecting from the searchbox by pressing enter on the keyboard and not by clicking on one of the results, the form got submitted. 

I found this comment https://github.com/erikras/redux-form/issues/572#issuecomment-268905929 on how to disable this auto submit behaviour.

~~I added `simple-mock` as a dependency as I needed spying on methods, I chose this one over `sinon` because this is smaller and has no dependencies. If you have anything against this library or if I have missed that there is already a mocking lib included I can amend the code.~~
I realised `sinon` was already added as a dependency.

This change doesn't break backward compatibility.


ps: awesome project! great work guys!