### PR TITLE
[RFR] Refactor Filters to use redux-form new onChange method

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-tap-event-plugin": "~2.0.0",
     "recompose": "~0.21.2",
     "redux": "~3.6.0",
-    "redux-form": "~6.5.0",
+    "redux-form": "~6.6.1",
     "redux-saga": "~0.14.2",
     "reselect": "~2.5.4"
   }

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -23,8 +23,15 @@ class Filter extends Component {
 
     setFilters = debounce((filters) => {
         if (!shallowEqual(filters, this.filters)) { // fix for redux-form bug with onChange and enableReinitialize
-            this.props.setFilters(filters);
-            this.filters = filters;
+            const filtersWithoutEmpty = filters;
+            Object.keys(filtersWithoutEmpty).forEach((filterName) => {
+                if (filtersWithoutEmpty[filterName] === '') {
+                    // remove empty filter from query
+                    delete filtersWithoutEmpty[filterName];
+                }
+            })
+            this.props.setFilters(filtersWithoutEmpty);
+            this.filters = filtersWithoutEmpty;
         }
     }, this.props.debounce)
 

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -1,33 +1,58 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
+import debounce from 'lodash.debounce';
+
 import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
 
-const Filter = ({ resource, context, children, showFilter, hideFilter, displayedFilters, filterValues }) => (
-    context === 'form' ?
-        <FilterForm
-            resource={resource}
-            filters={React.Children.toArray(children)}
-            hideFilter={hideFilter}
-            displayedFilters={displayedFilters}
-            initialValues={filterValues}
-        /> :
-        <FilterButton
-            resource={resource}
-            filters={React.Children.toArray(children)}
-            showFilter={showFilter}
-            displayedFilters={displayedFilters}
-            filterValues={filterValues}
-        />
-);
+class Filter extends Component {
+    constructor(props) {
+        super(props);
+        if (props.setFilters) {
+            this.debouncedSetFilters = debounce(props.setFilters, 500);
+        }
+    }
+    componentWillUnmount() {
+        this.debouncedSetFilters.cancel();
+    }
+    renderButton() {
+        const { resource, children, showFilter, displayedFilters, filterValues } = this.props;
+        return (
+            <FilterButton
+                resource={resource}
+                filters={React.Children.toArray(children)}
+                showFilter={showFilter}
+                displayedFilters={displayedFilters}
+                filterValues={filterValues}
+            />
+        );
+    }
+    renderForm() {
+        const { resource, children, hideFilter, displayedFilters, filterValues } = this.props;
+        return (
+            <FilterForm
+                resource={resource}
+                filters={React.Children.toArray(children)}
+                hideFilter={hideFilter}
+                displayedFilters={displayedFilters}
+                initialValues={filterValues}
+                setFilters={this.debouncedSetFilters}
+            />
+        );
+    }
+    render() {
+        return this.props.context === 'button' ? this.renderButton() : this.renderForm();
+    }
+}
 
 Filter.propTypes = {
     children: PropTypes.node,
-    resource: PropTypes.string.isRequired,
-    context: React.PropTypes.oneOf(['form', 'button']),
-    showFilter: React.PropTypes.func,
-    hideFilter: React.PropTypes.func,
+    context: PropTypes.oneOf(['form', 'button']),
     displayedFilters: PropTypes.object,
     filterValues: PropTypes.object,
+    hideFilter: React.PropTypes.func,
+    setFilters: PropTypes.func,
+    showFilter: React.PropTypes.func,
+    resource: PropTypes.string.isRequired,
 };
 
 export default Filter;

--- a/src/mui/list/FilterForm.js
+++ b/src/mui/list/FilterForm.js
@@ -84,7 +84,7 @@ const enhance = compose(
     translate,
     reduxForm({
         form: 'filterForm',
-        //enableReinitialize: true, // combined with onChange, creates repeated calls
+        enableReinitialize: true,
         onChange: (values, dispatch, props) => props.setFilters(values),
     }),
 );

--- a/src/mui/list/FilterForm.js
+++ b/src/mui/list/FilterForm.js
@@ -9,7 +9,7 @@ import translate from '../../i18n/translate';
 
 const styles = {
     card: { float: 'right', marginTop: '-14px', paddingTop: 0, display: 'flex', alignItems: 'flex-end' },
-    body: { display: 'inline-block', display: 'flex', alignItems: 'flex-end' },
+    body: { display: 'flex', alignItems: 'flex-end' },
     spacer: { width: 48 },
     icon: { color: '#00bcd4', maddingBottom: 0 },
     clearFix: { clear: 'right' },
@@ -82,7 +82,11 @@ FilterForm.propTypes = {
 
 const enhance = compose(
     translate,
-    reduxForm({ form: 'filterForm' }),
+    reduxForm({
+        form: 'filterForm',
+        //enableReinitialize: true, // combined with onChange, creates repeated calls
+        onChange: (values, dispatch, props) => props.setFilters(values),
+    }),
 );
 
 export default enhance(FilterForm);

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -274,7 +274,6 @@ const getQuery = createSelector(
 
 function mapStateToProps(state, props) {
     const resourceState = state.admin[props.resource];
-
     return {
         query: getQuery(props),
         params: resourceState.list.params,


### PR DESCRIPTION
Allows to use a custom `<Filter>` component, e.g. to force filter form submission before issuing REST request. Also, this allows to customize the filter debounce delay. Lastly, it allows to move filter-related logic out of the `<List>` component.