### PR TITLE
Fix documentation link errors

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -75,7 +75,7 @@ export const CommentList = (props) =>
     </List>;
 ```
 
-Or, in the `<Edit>` page, as a [custom action](./CreateEdit.html#actions):
+Or, in the `<Edit>` page, as a [custom action](./CreateEdit.md#actions):
 
 {% raw %}
 ```js
@@ -107,7 +107,7 @@ export const CommentEdit = (props) =>
 
 ## Using The REST Client Instead of Fetch
 
-The previous code uses `fetch()`, which means it has to make raw HTTP requests. The REST logic often requires a bit of HTTP plumbing to deal with query parameters, encoding, headers, body formatting, etc. It turns out you probably already have a function that maps from a REST request to an HTTP request: the [REST Client](./RestClients.html). So it's a good idea to use this function instead of `fetch` - provided you have exported it:
+The previous code uses `fetch()`, which means it has to make raw HTTP requests. The REST logic often requires a bit of HTTP plumbing to deal with query parameters, encoding, headers, body formatting, etc. It turns out you probably already have a function that maps from a REST request to an HTTP request: the [REST Client](./RestClients.md). So it's a good idea to use this function instead of `fetch` - provided you have exported it:
 
 ```js
 // in src/restClient.js

--- a/docs/AdminResource.md
+++ b/docs/AdminResource.md
@@ -65,7 +65,7 @@ The only required prop, it must be a function returning a promise, with the foll
 const restClient = (type, resource, params) => new Promise();
 ```
 
-The `restClient` is also the ideal place to add custom HTTP headers, authentication, etc. The [Rest Clients Chapter](./RestClients.html) of the documentation lists available REST clients, and how to build your own.
+The `restClient` is also the ideal place to add custom HTTP headers, authentication, etc. The [Rest Clients Chapter](./RestClients.md) of the documentation lists available REST clients, and how to build your own.
 
 ### `title`
 
@@ -172,7 +172,7 @@ For more details on predefined themes and custom themes, refer to the [Material 
 
 If you want to deeply customize the app header, the menu, or the notifications, the best way is to provide a custom layout component. It must contain a `{children}` placeholder, where admin-on-rest will render the resources. If you use material UI fields and inputs, it *must* contain a `<MuiThemeProvider>` element. And finally, if you want to show the spinner in the app header when the app fetches data in the background, the Layout should connect to the redux store.
 
-Use the [default layout](https://github.com/marmelab/admin-on-rest/blob/master/src/mui/layout/Layout.js) as a starting point, and check [the Theming documentation](./Theming.html#using-a-custom-layout) for examples.
+Use the [default layout](https://github.com/marmelab/admin-on-rest/blob/master/src/mui/layout/Layout.js) as a starting point, and check [the Theming documentation](./Theming.md#using-a-custom-layout) for examples.
 
 ```js
 // in src/App.js
@@ -357,7 +357,7 @@ const App = () => (
 );
 ```
 
-The [Authentication documentation](./Authentication.html) explains how to implement these functions in detail.
+The [Authentication documentation](./Authentication.md) explains how to implement these functions in detail.
 
 ### `loginPage`
 
@@ -373,7 +373,7 @@ const App = () => (
 );
 ```
 
-See The [Authentication documentation](./Authentication.html#customizing-the-login-and-logout-components) for more explanations.
+See The [Authentication documentation](./Authentication.md#customizing-the-login-and-logout-components) for more explanations.
 
 ### `logoutButton`
 
@@ -392,7 +392,7 @@ const App = () => (
 
 ### Internationalization
 
-The `locale` and `messages` props let you translate the GUI. The [Translation Documentation](./Translation.html) details this process.
+The `locale` and `messages` props let you translate the GUI. The [Translation Documentation](./Translation.md) details this process.
 
 ## The `<Resource>` component
 
@@ -481,4 +481,4 @@ const App = () => (
 
 ## Using admin-on-rest without `<Admin>` and `<Resource>`
 
-Using `<Admin>` and `<Resource>` is completely optional. If you feel like bootstrapping a redux app yourself, it's totally possible. Head to [Including in another app](./CustomApp.html) for a detailed how-to.
+Using `<Admin>` and `<Resource>` is completely optional. If you feel like bootstrapping a redux app yourself, it's totally possible. Head to [Including in another app](./CustomApp.md) for a detailed how-to.

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -67,7 +67,7 @@ Upon receiving a 403 response, the admin app shows the Login page. `authClient` 
 
 ## Sending Credentials to the REST API
 
-To use the credentials when calling REST API routes, you have to tweak, this time, the `restClient`. As explained in the [REST client documentation](RestClients.html#adding-custom-headers), `simpleRestClient` and `jsonServerRestClient` take an `httpClient` as second parameter. That's the place where you can change request headers, cookies, etc.
+To use the credentials when calling REST API routes, you have to tweak, this time, the `restClient`. As explained in the [REST client documentation](RestClients.md#adding-custom-headers), `simpleRestClient` and `jsonServerRestClient` take an `httpClient` as second parameter. That's the place where you can change request headers, cookies, etc.
 
 For instance, to pass the token obtained during login as an `Authorization` header, configure the REST client as follows:
 
@@ -215,4 +215,4 @@ const App = () => (
 
 **Tip**: The `authClient` function is automatically passed as prop to your custom `LoginPage` and `LogoutButton` components.
 
-**Tip**: If you want to use Redux and Saga to handle credentials and authorization, you will need to register  [custom reducers](./AdminResource.html#customreducers) and [custom sagas](./AdminResource.html#customsagas) in the `<Admin>` component.
+**Tip**: If you want to use Redux and Saga to handle credentials and authorization, you will need to register  [custom reducers](./AdminResource.md#customreducers) and [custom sagas](./AdminResource.md#customsagas) in the `<Admin>` component.

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -5,7 +5,7 @@ title: "The Create and Edit Views"
 
 # The Create and Edit Views
 
-The Create and Edit views both display a form, initialized with an empty record (for the Create view) or with a record fetched from the API (for the Edit view). The `<Create>` and `<Edit>` components then delegate the actual rendering of the form to a form component - usually `<SimpleForm>`. This form component uses its children ([`<Input>`](./Inputs.html) components) to render each form input.
+The Create and Edit views both display a form, initialized with an empty record (for the Create view) or with a record fetched from the API (for the Edit view). The `<Create>` and `<Edit>` components then delegate the actual rendering of the form to a form component - usually `<SimpleForm>`. This form component uses its children ([`<Input>`](./Inputs.md) components) to render each form input.
 
 ![post creation form](./img/create-view.png)
 

--- a/docs/CustomApp.md
+++ b/docs/CustomApp.md
@@ -9,7 +9,7 @@ The `<Admin>` tag is a great shortcut got be up and running with admin-on-rest i
 
 Beware that you need to know about [redux](http://redux.js.org/), [react-router](https://github.com/reactjs/react-router), and [redux-saga](https://github.com/yelouafi/redux-saga) to go further.
 
-**Tip**: Before going for the Custom App route, explore all the options of [the `<Admin>` component](./AdminResource.html##the-admin-component). They allow you to add custom routes, custom reducers, custom sagas, and customize the layout.
+**Tip**: Before going for the Custom App route, explore all the options of [the `<Admin>` component](./AdminResource.md##the-admin-component). They allow you to add custom routes, custom reducers, custom sagas, and customize the layout.
 
 Here is the main code for bootstrapping an admin-on-rest application with 3 resources: `posts`, `comments`, and `users`:
 

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -56,9 +56,9 @@ Then you can display the author first name as follows:
 <TextField source="author.firstName" />
 ```
 
-**Tip**: If you want to format a field according to the value, use a higher-order component to do conditional formatting, as described in the [Theming documentation](./Theming.html#conditional-formatting).
+**Tip**: If you want to format a field according to the value, use a higher-order component to do conditional formatting, as described in the [Theming documentation](./Theming.md#conditional-formatting).
 
-**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.html#translating-resource-and-field-names) for details.
+**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.md#translating-resource-and-field-names) for details.
 
 ## `<BooleanField>`
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -30,7 +30,7 @@ All input components accept the following attributes:
 
 * `source`: Property name of your entity to view/edit. This attribute is required.
 * `defaultValue`: Value to be set when the property is `null` or `undefined`.
-* `validation`: Validation rules for the current property (see the [Validation Documentation](./CreateEdit.html#validation))
+* `validation`: Validation rules for the current property (see the [Validation Documentation](./CreateEdit.md#validation))
 * `label`: Used as a table header of an input label. Defaults to the `source` when omitted.
 * `style`: A style object to customize the look and feel of the field container (e.g. the `<div>` in a form).
 * `elStyle`: A style object to customize the look and feel of the field element itself
@@ -64,7 +64,7 @@ Then you can display a text input to edit the author first name as follows:
 <TextInput source="author.firstName" />
 ```
 
-**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.html#translating-resource-and-field-names) for details.
+**Tip**: If your interface has to support multiple languages, don't use the `label` prop, and put the localized labels in a dictionary instead. See the [Translation documentation](./Translation.md#translating-resource-and-field-names) for details.
 
 ## `<AutocompleteInput>`
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -226,7 +226,7 @@ export const PostList = (props) => (
 
 ## The `<Datagrid>` component
 
-The datagrid component renders a list of records as a table. It is usually used as a child of the [`<List>`](#the-list-component) and [`<ReferenceManyField>`](./Fields.html#referencemanyfield) components.
+The datagrid component renders a list of records as a table. It is usually used as a child of the [`<List>`](#the-list-component) and [`<ReferenceManyField>`](./Fields.md#referencemanyfield) components.
 
 Here are all the props accepted by the component:
 
@@ -306,7 +306,7 @@ export const PostList = (props) => (
 ```
 {% endraw %}
 
-**Tip**: if you want to go even further and apply a custom style cell by cell, check out the [Conditional Formatting section of the Theming chapter](./Theming.html#conditional-formatting.)
+**Tip**: if you want to go even further and apply a custom style cell by cell, check out the [Conditional Formatting section of the Theming chapter](./Theming.md#conditional-formatting.)
 
 ### Row Style Function
 


### PR DESCRIPTION
In the GitHub docs for admin-on-rest, most links are pointing to a `.html` extension which returns a 404 page from GitHub. I replaced them with a `.md` extension. Things look great. However, there are several places where this is this case and I am wondering if this is what you intended, if this PR gets merged, I will go further and replace all `.html `links to a` .md `

**Note:** Only `.html` links that points to resources within admin-on-rest and not to an external resource(s) will be updated. 
