### PR TITLE
Fix Admin component crash while rendering if first resource isn't loaded yet

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -36,7 +36,7 @@ const Admin = ({
     loginPage,
     logoutButton,
 }) => {
-    const resources = React.Children.map(children, ({ props }) => props);
+    const resources = React.Children.map(children, ({ props }) => props) || [];
     const reducer = combineReducers({
         admin: adminReducer(resources),
         locale: localeReducer(locale),

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -58,7 +58,7 @@ const Admin = ({
     sagaMiddleware.run(saga);
 
     const history = syncHistoryWithStore(hashHistory, store);
-    const firstResource = resources[0].name;
+    const firstResource = resources[0];
     const onEnter = authClient ?
         params => (nextState, replace, callback) => authClient(AUTH_CHECK, params)
             .then(() => params && params.scrollToTop ? window.scrollTo(0, 0) : null)
@@ -86,7 +86,9 @@ const Admin = ({
         <Provider store={store}>
             <TranslationProvider messages={messages}>
                 <Router history={history}>
-                    {dashboard ? undefined : <Redirect from="/" to={`/${firstResource}`} />}
+                    {!dashboard && firstResource &&
+                      <Redirect from="/" to={`/${firstResource.name}`} />
+                    }
                     <Route path="/login" component={LoginPage} />
                     <Route path="/" component={Layout} resources={resources}>
                         {customRoutes && customRoutes()}


### PR DESCRIPTION
Hi there,

Just a little fix that prevents the `Admin` component from crashing at render time when the first `Resource` wasn't (yet) loaded.

Also as the children node isn't marked as required, it should be fair to allow no children at all.
In such case, the resources variable was undefined, as the [`React.children.map` doc](https://facebook.github.io/react/docs/react-api.html#react.children.map) suggests.