### PR TITLE
Ensure pagination params are integers

### DIFF
--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -144,8 +144,9 @@ export class List extends Component {
     updateData(query) {
         const params = query || this.getQuery();
         const { sort, order, page, perPage, filter } = params;
+        const pagination = { page: parseInt(page, 10), perPage: parseInt(perPage, 10) };
         const permanentFilter = this.props.filter;
-        this.props.crudGetList(this.props.resource, { page, perPage }, { field: sort, order }, { ...filter, ...permanentFilter });
+        this.props.crudGetList(this.props.resource, pagination, { field: sort, order }, { ...filter, ...permanentFilter });
     }
 
     setSort = sort => this.changeParams({ type: SET_SORT, payload: sort });


### PR DESCRIPTION
When page and perPage are taken from the url query, they will be strings, this can cause problems downstream in the rest client, which expects ints