### PR TITLE
Reflect validation changes to docs and prop types for input/form

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -58,9 +58,9 @@ export const PostEdit = (props) => (
     <Edit title={<PostTitle />} {...props}>
         <SimpleForm>
             <DisabledInput label="Id" source="id" />
-            <TextInput source="title" validation={{ required: true }} />
-            <LongTextInput source="teaser" validation={{ required: true }} />
-            <RichTextInput source="body" validation={{ required: true }} />
+            <TextInput source="title" validate={required} />
+            <LongTextInput source="teaser" validate={required} />
+            <RichTextInput source="body" validate={required} />
             <DateInput label="Publication date" source="published_at" />
             <ReferenceManyField label="Comments" reference="comments" target="post_id">
                 <Datagrid>
@@ -187,16 +187,16 @@ export const PostEdit = (props) => (
         <TabbedForm>
             <FormTab label="summary">
                 <DisabledInput label="Id" source="id" />
-                <TextInput source="title" validation={{ required: true }} />
-                <LongTextInput source="teaser" validation={{ required: true }} />
+                <TextInput source="title" validate={required} />
+                <LongTextInput source="teaser" validate={required} />
             </FormTab>
             <FormTab label="body">
-                <RichTextInput source="body" validation={{ required: true }} addLabel={false} />
+                <RichTextInput source="body" validate={required} addLabel={false} />
             </FormTab>
             <FormTab label="Miscellaneous">
                 <TextInput label="Password (if protected post)" source="password" type="password" />
                 <DateInput label="Publication date" source="published_at" />
-                <NumberInput source="average_note" validation={{ min: 0 }} />
+                <NumberInput source="average_note" validate={[ number, minValue(0) ]} />
                 <BooleanInput label="Allow comments?" source="commentable" defaultValue />
                 <DisabledInput label="Nb views" source="views" />
             </FormTab>
@@ -319,7 +319,7 @@ export const UserCreate = (props) => (
     <Create {...props}>
         <SimpleForm>
             <TextInput label="First Name" source="firstName" validate={[ required, maxLength(15) ]} />
-            <TextInput label="Age" source="age" validation={[ required, number, minValue(18) ]}/>
+            <TextInput label="Age" source="age" validate={[ required, number, minValue(18) ]}/>
         </SimpleForm>
     </Create>
 );
@@ -359,9 +359,9 @@ export const UserCreate = (props) => (
     <Create {...props}>
         <SimpleForm>
             <TextInput label="First Name" source="firstName" validate={[ required, minLength(2), maxLength(15) ]} />
-            <TextInput label="Email" source="email" validation={email} />
-            <TextInput label="Age" source="age" validation={[ number, minValue(18) ]}/>
-            <TextInput label="Zip Code" source="zip" validation={regex(/^\d{5}$/, 'Must be a valid Zip Code')}/>
+            <TextInput label="Email" source="email" validate={email} />
+            <TextInput label="Age" source="age" validate={[ number, minValue(18) ]}/>
+            <TextInput label="Zip Code" source="zip" validate={regex(/^\d{5}$/, 'Must be a valid Zip Code')}/>
             <SelectInput label="Sex" source="sex" choices={[
                 { id: 'm', name: 'Male' },
                 { id: 'f', name: 'Female' },

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -30,7 +30,7 @@ All input components accept the following attributes:
 
 * `source`: Property name of your entity to view/edit. This attribute is required.
 * `defaultValue`: Value to be set when the property is `null` or `undefined`.
-* `validation`: Validation rules for the current property (see the [Validation Documentation](./CreateEdit.html#validation))
+* `validate`: Validation rules for the current property (see the [Validation Documentation](./CreateEdit.html#validation))
 * `label`: Used as a table header of an input label. Defaults to the `source` when omitted.
 * `style`: A style object to customize the look and feel of the field container (e.g. the `<div>` in a form).
 * `elStyle`: A style object to customize the look and feel of the field element itself

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -86,7 +86,7 @@ That's enough to display the post list:
 
 ![Simple posts list](./img/simple-post-list.png)
 
-The list is already functional: you can creorder it by clicking on column headers, or change pages by using the bottom pagination controls.
+The list is already functional: you can reorder it by clicking on column headers, or change pages by using the bottom pagination controls.
 
 ## Field Types
 

--- a/src/mui/form/SimpleForm.js
+++ b/src/mui/form/SimpleForm.js
@@ -31,7 +31,7 @@ SimpleForm.propTypes = {
     record: PropTypes.object,
     resource: PropTypes.string,
     basePath: PropTypes.string,
-    validation: PropTypes.func,
+    validate: PropTypes.func,
 };
 
 const enhance = compose(

--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -62,7 +62,7 @@ TabbedForm.propTypes = {
     resource: PropTypes.string,
     basePath: PropTypes.string,
     translate: PropTypes.func,
-    validation: PropTypes.func,
+    validate: PropTypes.func,
 };
 
 TabbedForm.defaultProps = {

--- a/src/mui/input/LongTextInput.js
+++ b/src/mui/input/LongTextInput.js
@@ -25,7 +25,10 @@ LongTextInput.propTypes = {
     options: PropTypes.object,
     resource: PropTypes.string,
     source: PropTypes.string,
-    validation: PropTypes.object,
+    validate: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.arrayOf(PropTypes.func)
+    ]),
 };
 
 LongTextInput.defaultProps = {

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -70,7 +70,10 @@ NumberInput.propTypes = {
     resource: PropTypes.string,
     source: PropTypes.string,
     step: PropTypes.string.isRequired,
-    validation: PropTypes.object,
+    validate: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.arrayOf(PropTypes.func)
+    ]),
 };
 
 NumberInput.defaultProps = {

--- a/src/mui/input/TextInput.js
+++ b/src/mui/input/TextInput.js
@@ -75,7 +75,10 @@ TextInput.propTypes = {
     resource: PropTypes.string,
     source: PropTypes.string,
     type: PropTypes.string,
-    validation: PropTypes.object,
+    validate: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.arrayOf(PropTypes.func)
+    ]),
 };
 
 TextInput.defaultProps = {


### PR DESCRIPTION
Hi, I think `validation` props is no longer valid, so I've updated docs and input/forms.