### PR TITLE
Show rejected reason as error message if the type is string

### DIFF
--- a/src/sideEffect/saga/auth.js
+++ b/src/sideEffect/saga/auth.js
@@ -27,7 +27,7 @@ export default (authClient) => {
             } catch (e) {
                 yield put({ type: USER_LOGIN_FAILURE, error: e, meta: { auth: true } });
                 const errorMessage = typeof e === 'string'
-                    ? error
+                    ? e
                     : (typeof e === 'undefined' || !e.message ? 'aor.auth.sign_in_error' : e.message);
                 yield put(showNotification(errorMessage, 'warning'));
             }


### PR DESCRIPTION
Hello again :)
When authclient reject with `string` reason, I think AOR should show that `string` message as error message.