### PR TITLE
AUTH_LOGIN's resolve's result goes as payload on USER_LOGIN_SUCCESS

### DIFF
--- a/src/mui/auth/Logout.js
+++ b/src/mui/auth/Logout.js
@@ -23,9 +23,13 @@ Logout.propTypes = {
     userLogout: PropTypes.func,
 };
 
+const mapStateToProps = state => ({
+    theme: state.theme,
+});
+
 const enhance = compose(
     translate,
-    connect(null, { userLogout: userLogoutAction }),
+    connect(mapStateToProps, { userLogout: userLogoutAction }),
 );
 
 export default enhance(Logout);

--- a/src/sideEffect/saga/auth.js
+++ b/src/sideEffect/saga/auth.js
@@ -22,7 +22,7 @@ export default (authClient) => {
             try {
                 yield put({ type: USER_LOGIN_LOADING });
                 yield call(authClient, AUTH_LOGIN, payload);
-                yield put({ type: USER_LOGIN_SUCCESS });
+                yield put({ type: USER_LOGIN_SUCCESS, payload });
                 yield put(push(meta.pathName || '/'));
             } catch (e) {
                 yield put({ type: USER_LOGIN_FAILURE, error: e, meta: { auth: true } });


### PR DESCRIPTION
Based on #582, this small change will send the result of `AUTH_LOGIN`'s resolve as a payload on `USER_LOGIN_SUCCESS`. This way we can integrate, in a simple way, integrate the login with redux.
In my case I just wanted to save user's profile on the store.
Based on the discussion seem that there are some more complex ideas around but this change is enough for what I need and this is my suggestion.