### PR TITLE
decode id uri component matched from react router

### DIFF
--- a/src/mui/delete/Delete.js
+++ b/src/mui/delete/Delete.js
@@ -115,8 +115,8 @@ Delete.propTypes = {
 
 function mapStateToProps(state, props) {
     return {
-        id: props.match.params.id,
-        data: state.admin[props.resource].data[props.match.params.id],
+        id: decodeURIComponent(props.match.params.id),
+        data: state.admin[props.resource].data[decodeURIComponent(props.match.params.id)],
         isLoading: state.admin.loading > 0,
     };
 }

--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -141,8 +141,8 @@ Edit.propTypes = {
 
 function mapStateToProps(state, props) {
     return {
-        id: props.match.params.id,
-        data: state.admin[props.resource].data[props.match.params.id],
+        id: decodeURIComponent(props.match.params.id),
+        data: state.admin[props.resource].data[decodeURIComponent(props.match.params.id)],
         isLoading: state.admin.loading > 0,
     };
 }

--- a/src/mui/detail/Show.js
+++ b/src/mui/detail/Show.js
@@ -101,8 +101,8 @@ Show.propTypes = {
 
 function mapStateToProps(state, props) {
     return {
-        id: props.match.params.id,
-        data: state.admin[props.resource].data[props.match.params.id],
+        id: decodeURIComponent(props.match.params.id),
+        data: state.admin[props.resource].data[decodeURIComponent(props.match.params.id)],
         isLoading: state.admin.loading > 0,
     };
 }


### PR DESCRIPTION
This PR fixes decoding id with special chars like "/" in `Show`, `Edit` and `Delete` components.
`react-router` v4 requires manually decoding uris as opposed to previous version.

Without this change id with special chars are broken in v1.0.0.

Related PR: #209 