### PR TITLE
[RFR] Remove warning for "non-string" title prop

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -106,7 +106,7 @@ Admin.propTypes = {
     menu: componentPropType,
     restClient: PropTypes.func,
     theme: PropTypes.object,
-    title: PropTypes.string,
+    title: PropTypes.node,
     locale: PropTypes.string,
     messages: PropTypes.object,
     initialState: PropTypes.object,

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -129,7 +129,7 @@ Layout.propTypes = {
     menu: PropTypes.element,
     resources: PropTypes.array,
     setSidebarVisibility: PropTypes.func.isRequired,
-    title: PropTypes.string.isRequired,
+    title: PropTypes.node.isRequired,
     theme: PropTypes.object.isRequired,
     width: PropTypes.number,
 };


### PR DESCRIPTION
Given that MUI accept "node" proptype for "title" props on the AppBar. We should change it in AOR to avoid warnings.

https://github.com/callemall/material-ui/blob/master/src/AppBar/AppBar.js#L134