### PR TITLE
relax empty filter check in Filter component to include all falsy values

### DIFF
--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -26,7 +26,7 @@ class Filter extends Component {
         if (!shallowEqual(filters, this.filters)) { // fix for redux-form bug with onChange and enableReinitialize
             const filtersWithoutEmpty = filters;
             Object.keys(filtersWithoutEmpty).forEach((filterName) => {
-                if (filtersWithoutEmpty[filterName] === '') {
+                if (!filtersWithoutEmpty[filterName]) {
                     // remove empty filter from query
                     delete filtersWithoutEmpty[filterName];
                 }


### PR DESCRIPTION
Hi again.

I think that all falsy values should be treated as empty in the `Filter` component and removed from query.

This allows you for example to use `ReferenceInput` with a `SelectInput` for filtering without treating the empty value (`null` in `SelectInput`) as an actual filter for some remote endpoints.

What do you think?