### PR TITLE
Fix edge case in RichTextField when string is falsey value

### DIFF
--- a/src/mui/field/RichTextField.js
+++ b/src/mui/field/RichTextField.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import get from 'lodash.get';
 import pure from 'recompose/pure';
 
-export const removeTags = input => input.replace(/<[^>]+>/gm, '');
+export const removeTags = input => input ? input.replace(/<[^>]+>/gm, '') : '';
 
 const RichTextField = ({ source, record = {}, stripTags, elStyle }) => {
     const value = get(record, source);


### PR DESCRIPTION
If you don't enter anything in a `RichTextInput`, the sent string is `undefined` and will break `removeTags`. I fix it by returning an empty string for any falsey value.

Obviously, a robust form will avoid this by validating against such values, but this doesn't hurt either and is probably the expected behavior.