### PR TITLE
[RFR] Ensure DateField tests can pass on all systems

### DIFF
--- a/src/mui/field/DateField.spec.js
+++ b/src/mui/field/DateField.spec.js
@@ -16,36 +16,42 @@ describe('<DateField />', () => {
 
     it('should render a date', () => assert.equal(
         shallow(<DateField record={{ foo: new Date('2017-04-23') }} source="foo" locales="en-US" />).html(),
-        '<span>4/23/2017</span>',
+        `<span>${new Date('2017-04-23').toLocaleDateString('en-US')}</span>`,
     ));
 
     it('should render a date and time when the showtime prop is passed', () => assert.equal(
         shallow(<DateField record={{ foo: new Date('2017-04-23 23:05') }} showTime source="foo" locales="en-US" />).html(),
-        '<span>4/23/2017, 11:05:00 PM</span>',
+        `<span>${new Date('2017-04-23 23:05').toLocaleString('en-US')}</span>`,
     ));
 
-    it('should pass the options prop to Intl.DateTimeFormat', () => assert.equal(
-        shallow(<DateField record={{ foo: new Date('2017-04-23') }} source="foo" locales="en-US" options={{
+    it('should pass the options prop to toLocaleString', () => {
+        const date = new Date('2017-04-23');
+        const options = {
             weekday: 'long',
             year: 'numeric',
             month: 'long',
             day: 'numeric',
-        }} />).html(),
-        '<span>Sunday, April 23, 2017</span>',
-    ));
+        };
+        return assert.equal(
+            shallow(<DateField
+                record={{ foo: date }} source="foo" locales="en-US" options={options}
+            />).html(),
+            `<span>${date.toLocaleDateString('en-US', options)}</span>`,
+        );
+    });
 
-    it('should use the locales props as an argument to Intl.DateTimeFormat', () => assert.equal(
+    it('should use the locales props as an argument to toLocaleString', () => assert.equal(
         shallow(<DateField record={{ foo: new Date('2017-04-23') }} source="foo" locales="fr-FR" />).html(),
-        '<span>23/04/2017</span>',
+        `<span>${new Date('2017-04-23').toLocaleDateString('fr-FR')}</span>`,
     ));
 
     it('should use custom styles passed as an elStyle prop', () => assert.equal(
         shallow(<DateField record={{ foo: new Date('01/01/2016') }} source="foo" locales="en-US" elStyle={{ margin: 1 }} />).html(),
-        '<span style="margin:1px;">1/1/2016</span>',
+        `<span style="margin:1px;">${new Date('1/1/2016').toLocaleDateString('en-US')}</span>`,
     ));
 
     it('should handle deep fields', () => assert.equal(
         shallow(<DateField record={{ foo: { bar: new Date('01/01/2016') } }} source="foo.bar" locales="en-US" />).html(),
-        '<span>1/1/2016</span>',
+        `<span>${new Date('1/1/2016').toLocaleDateString('en-US')}</span>`,
     ));
 });


### PR DESCRIPTION
Fixes #614

Not fan of the logic duplication but I can't think of another way to ensure those tests pass on all systems.