### PR TITLE
fix show(edit) button in edit(show) page

### DIFF
--- a/src/mui/button/EditButton.js
+++ b/src/mui/button/EditButton.js
@@ -25,9 +25,10 @@ EditButton.propTypes = {
 
 const enhance = compose(
     shouldUpdate((props, nextProps) =>
-        props.record
+        (props.record
         && props.record.id !== nextProps.record.id
-        || props.basePath !== nextProps.basePath
+        || props.basePath !== nextProps.basePath)
+        || (props.record == null && nextProps.record != null)
     ),
     translate,
 );

--- a/src/mui/button/ShowButton.js
+++ b/src/mui/button/ShowButton.js
@@ -25,9 +25,10 @@ ShowButton.propTypes = {
 
 const enhance = compose(
     shouldUpdate((props, nextProps) =>
-        props.record
+        (props.record
         && props.record.id !== nextProps.record.id
-        || props.basePath !== nextProps.basePath
+        || props.basePath !== nextProps.basePath)
+        || (props.record == null && nextProps.record != null)
     ),
     translate,
 );


### PR DESCRIPTION
Bug fix for an issue that can be reproduced by the following step:
1. run example app `make run`
2. open `http://localhost:8080/#/posts/13` (and refresh broswer).
3. the show button links to `http://localhost:8080/#/posts/undefined/show` rather than `http://localhost:8080/#/posts/13/show`
