### PR TITLE
Allow embedded resource in reference field

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lodash.debounce": "~4.0.8",
     "lodash.defaultsdeep": "~4.6.0",
     "lodash.get": "~4.4.2",
+    "lodash.isplainobject": "~4.0.6",
     "lodash.set": "~4.3.2",
     "material-ui": "~0.17.4",
     "material-ui-chip-input": "~0.13.5",

--- a/src/mui/field/ReferenceField.js
+++ b/src/mui/field/ReferenceField.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import LinearProgress from 'material-ui/LinearProgress';
 import get from 'lodash.get';
+import isPlainObject from 'lodash.isplainobject';
 import { crudGetManyAccumulate as crudGetManyAccumulateAction } from '../../actions/accumulateActions';
 import linkToRecord from '../../util/linkToRecord';
 
@@ -49,7 +50,7 @@ export class ReferenceField extends Component {
 
     fetchReference(props) {
         const source = get(props.record, props.source);
-        if (source !== null && typeof source !== 'undefined') {
+        if (source !== null && typeof source !== 'undefined' && !isRecord(source)) {
             this.props.crudGetManyAccumulate(props.reference, [source]);
         }
     }
@@ -107,9 +108,14 @@ ReferenceField.defaultProps = {
     linkType: 'edit',
 };
 
+export const isRecord = (reference) => isPlainObject(reference) && reference.id;
+
 function mapStateToProps(state, props) {
+    const source = get(props.record, props.source);
+    const referenceRecord = isRecord(source) ? source : state.admin[props.reference].data[source];
+
     return {
-        referenceRecord: state.admin[props.reference].data[get(props.record, props.source)],
+        referenceRecord,
     };
 }
 

--- a/src/mui/field/ReferenceField.spec.js
+++ b/src/mui/field/ReferenceField.spec.js
@@ -91,4 +91,20 @@ describe('<ReferenceField />', () => {
         const linkElement = wrapper.find('Link');
         assert.equal(linkElement.length, 0);
     });
+    it('should not call crudGetManyAccumulate on componentDidMount if reference source is an embedded resource', () => {
+        const crudGetManyAccumulate = sinon.spy();
+        shallow(
+            <ReferenceField
+                record={{ foo: { id: 123, title: 'foo' } }}
+                source="foo"
+                reference="bar"
+                basePath=""
+              crudGetManyAccumulate={crudGetManyAccumulate}
+            >
+                <TextField source="title" />
+            </ReferenceField>,
+            { lifecycleExperimental: true },
+        );
+        assert(crudGetManyAccumulate.notCalled);
+    });
 });


### PR DESCRIPTION
Hi there,

Here is a quick win to allow embedded resources in the `ReferenceField`.
In case of an embedded resource `crudGetOneReference` must not be called, as the resource has already been fetched with the first call.

> the `next` branch appears to be many commits behind `master` at the moment, but I'll be happy to propose this against `next` instead, once it's synced.