### PR TITLE
[WIP] Do not send notification when user is logged out

### DIFF
--- a/src/sideEffect/saga/auth.js
+++ b/src/sideEffect/saga/auth.js
@@ -56,7 +56,6 @@ export default (authClient) => {
             } catch (e) {
                 yield call(authClient, AUTH_LOGOUT);
                 yield put(push('/login'));
-                yield put(hideNotification());
             }
             break;
         }

--- a/src/sideEffect/saga/crudResponse.js
+++ b/src/sideEffect/saga/crudResponse.js
@@ -52,9 +52,13 @@ function* handleResponse({ type, requestPayload, error, payload }) {
         const errorMessage = typeof error === 'string'
             ? error
             : (error.message || 'aor.notification.http_error');
-        return yield [
-            put(showNotification(errorMessage, 'warning')),
-        ];
+
+        const sideActions = [];
+        if (error !== 'Unauthorized') { // redirect to login form if user credentials are no more valid
+            sideActions.push(put(showNotification(errorMessage, 'warning')));
+        }
+
+        return yield sideActions;
     }
     default:
         return yield [];


### PR DESCRIPTION
This PR attempts to fix following scenario:

* Connect on root application URL,
* Application redirects to first resource screen,
* API returns a 401 response (it requires authentication)
* A "Unauthorized" notification is sent
* User is redirected on login page
* "Unauthorized" is still displayed as a notification

Probably related to https://github.com/marmelab/admin-on-rest/pull/526/files, but it doesn't seem to work.