### PR TITLE
[RFR] Fix a redux-form onBlur related issue

### DIFF
--- a/e2e/pages/EditPage.js
+++ b/e2e/pages/EditPage.js
@@ -40,6 +40,12 @@ module.exports = url => driver => ({
         return input.sendKeys(value);
     },
 
+    clickInput(name) {
+        const input = driver.findElement(this.elements.input(name));
+        input.click();
+        return driver.sleep(200);
+    },
+
     gotoTab(index) {
         const tab = driver.findElement(this.elements.tab(index));
         tab.click();

--- a/e2e/tests/edit.js
+++ b/e2e/tests/edit.js
@@ -23,6 +23,13 @@ describe('Edit Page', () => {
         it('should allow to switch tabs', async () => {
             await EditPage.gotoTab(2);
             assert.equal(await EditPage.getInputValue('average_note'), '3');
-        })
+        });
+
+        it('should keep DateInput value after opening datapicker', async () => {
+            await EditPage.gotoTab(3);
+            const valueBeforeClick = (await EditPage.getInputValue('published_at'));
+            await EditPage.clickInput('published_at');
+            assert.equal(await EditPage.getInputValue('published_at'), valueBeforeClick);
+        });
     });
 });

--- a/example/data.js
+++ b/example/data.js
@@ -109,7 +109,7 @@ export default {
             views: 559,
             average_note: 3,
             commentable: true,
-            published_at: new Date('2012-08-24'),
+            published_at: new Date('2012-08-05'),
             tags: [],
             category: 'tech',
             notifications: [12, 31, 42],

--- a/example/posts.js
+++ b/example/posts.js
@@ -144,7 +144,7 @@ export const PostEdit = ({ ...props }) => (
                 <ReferenceArrayInput source="tags" reference="tags" allowEmpty>
                     <SelectArrayInput optionText="name" options={{ fullWidth: true }} />
                 </ReferenceArrayInput>
-                <DateInput source="published_at" />
+                <DateInput source="published_at" options={{ locale: 'pt' }} />
                 <SelectInput source="category" choices={[
                     { name: 'Tech', id: 'tech' },
                     { name: 'Lifestyle', id: 'lifestyle' },

--- a/src/mui/input/DateInput.js
+++ b/src/mui/input/DateInput.js
@@ -17,8 +17,12 @@ export const datify = input => {
 };
 
 class DateInput extends Component {
-    onChange = (_, date) => this.props.input.onChange(date);
-    onBlur = () => this.props.input.onBlur();
+    onChange = (_, date) => {
+        this.props.input.onChange(date);
+        this.props.input.onBlur();
+    };
+    onBlur = () => {};
+    onDismiss = () => this.props.input.onBlur();
 
     render() {
         const { input, isRequired, label, meta: { touched, error }, options, source, elStyle, resource } = this.props;
@@ -33,6 +37,7 @@ class DateInput extends Component {
             value={datify(input.value)}
             onChange={this.onChange}
             onBlur={this.onBlur}
+            onDismiss={this.onDismiss}
             style={elStyle}
             {...options}
         />);

--- a/src/mui/input/DateInput.js
+++ b/src/mui/input/DateInput.js
@@ -18,6 +18,7 @@ export const datify = input => {
 
 class DateInput extends Component {
     onChange = (_, date) => this.props.input.onChange(date);
+    onBlur = () => this.props.input.onBlur();
 
     render() {
         const { input, isRequired, label, meta: { touched, error }, options, source, elStyle, resource } = this.props;
@@ -31,6 +32,7 @@ class DateInput extends Component {
             autoOk
             value={datify(input.value)}
             onChange={this.onChange}
+            onBlur={this.onBlur}
             style={elStyle}
             {...options}
         />);

--- a/src/mui/input/DateInput.js
+++ b/src/mui/input/DateInput.js
@@ -21,7 +21,17 @@ class DateInput extends Component {
         this.props.input.onChange(date);
         this.props.input.onBlur();
     };
+
+    /**
+     * This aims to fix a bug created by the conjunction of
+     * redux-form, which expects onBlur to be triggered after onChange, and
+     * material-ui, which triggers onBlur on <DatePicker> when the user clicks
+     * on the input to bring the focus on the calendar rather than the input.
+     *
+     * @see https://github.com/erikras/redux-form/issues/1218#issuecomment-229072652
+     */
     onBlur = () => {};
+
     onDismiss = () => this.props.input.onBlur();
 
     render() {

--- a/src/mui/input/DateInput.spec.js
+++ b/src/mui/input/DateInput.spec.js
@@ -39,7 +39,7 @@ describe('<DateInput />', () => {
     });
 
     it('should call props `input.onChange` method when changed', () => {
-        const input = { value: null, onChange: sinon.spy() };
+        const input = { value: null, onChange: sinon.spy(), onBlur: () => {} };
         const wrapper = shallow(
             <DateInput source="foo" input={input} meta={{}} locale="de-DE" />
         );


### PR DESCRIPTION
~~issue: onBlur causes redux-form to fetch raw value (for example
12/08/2017) from DatePicker.~~

I checked both redux-form and material-ui. 
Currently, DatePicker's event flow is like this:

1. User click on the input triggers `onBlur`
2. User close the input without  selecting value triggers `onDismiss`
3. User select a value triggers `onChange`

And for redux-form:

1. `onBlur` is used to update value(if event param is provided) and validate the field.
2. `onChange` is used to update value.

#691 