### PR TITLE
[RFR] Fix SelectArrayInput prop types

### DIFF
--- a/src/mui/input/SelectArrayInput.js
+++ b/src/mui/input/SelectArrayInput.js
@@ -184,7 +184,10 @@ SelectArrayInput.propTypes = {
     onFocus: PropTypes.func,
     setFilter: PropTypes.func,
     options: PropTypes.object,
-    optionText: PropTypes.string.isRequired,
+    optionText: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+    ]).isRequired,
     optionValue: PropTypes.string.isRequired,
     resource: PropTypes.string,
     source: PropTypes.string,


### PR DESCRIPTION
Having a function as `optionText` does work on `SelectArrayInput` but gives a console warning:

![image](https://cloud.githubusercontent.com/assets/2562270/26776543/d3cb84b6-49d9-11e7-9f07-84a34b0e0912.png)
