### PR TITLE
[RFR] Pass options to BooleanInput for Toggle

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -166,6 +166,18 @@ import { BooleanInput } from 'admin-on-rest';
 
 This input does not handle `null` values. You would need the `<NullableBooleanInput />` component if you have to handle non-set booleans.
 
+You can use the `options` prop to pass any option supported by the Material UI `Toggle` components.
+
+{% raw %}
+```jsx
+<BooleanInput source="finished" options={{
+    labelPosition: 'right'
+}} />
+```
+{% endraw %}
+
+Refer to [Material UI Toggle documentation](http://www.material-ui.com/#/components/toggle) for more details.
+
 `<NullableBooleanInput />` renders as a dropdown list, allowing to choose between true, false, and null values.
 
 ```jsx

--- a/src/mui/input/BooleanInput.js
+++ b/src/mui/input/BooleanInput.js
@@ -16,7 +16,7 @@ const styles = {
     },
 };
 
-const BooleanInput = ({ input, isRequired, label, source, elStyle, resource }) => (
+const BooleanInput = ({ input, isRequired, label, source, elStyle, resource, options }) => (
     <div style={elStyle || styles.block}>
         <Toggle
             defaultToggled={!!input.value}
@@ -24,6 +24,7 @@ const BooleanInput = ({ input, isRequired, label, source, elStyle, resource }) =
             labelStyle={styles.label}
             style={styles.toggle}
             label={<FieldTitle label={label} source={source} resource={resource} isRequired={isRequired} />}
+            {...options}
         />
     </div>
 );
@@ -36,10 +37,12 @@ BooleanInput.propTypes = {
     label: PropTypes.string,
     resource: PropTypes.string,
     source: PropTypes.string,
+    options: PropTypes.object,
 };
 
 BooleanInput.defaultProps = {
     addField: true,
+    options: {},
 };
 
 export default BooleanInput;


### PR DESCRIPTION
I need to set right position for label for BooleanInput and find that there is not properties which responsible for it. I think that this commit will be useful.
Thanks for chance to take participating in this project.