### PR TITLE
list; use flexbox for all the header items

### DIFF
--- a/src/mui/list/Actions.js
+++ b/src/mui/list/Actions.js
@@ -6,8 +6,9 @@ import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
 const cardActionStyle = {
     zIndex: 2,
-    display: 'inline-block',
-    float: 'right',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    flexWrap: 'wrap',
 };
 
 const Actions = ({ resource, filters, displayedFilters, filterValues, hasCreate, basePath, showFilter, refresh }) => (

--- a/src/mui/list/Actions.js
+++ b/src/mui/list/Actions.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { CardActions } from 'material-ui/Card';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import autoprefixer from 'material-ui/utils/autoprefixer';
 import { CreateButton, RefreshButton } from '../button';
 import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
 
@@ -11,12 +13,17 @@ const cardActionStyle = {
     flexWrap: 'wrap',
 };
 
-const Actions = ({ resource, filters, displayedFilters, filterValues, hasCreate, basePath, showFilter, refresh }) => (
-    <CardActions style={cardActionStyle}>
-        {filters && React.cloneElement(filters, { resource, showFilter, displayedFilters, filterValues, context: 'button' }) }
-        {hasCreate && <CreateButton basePath={basePath} />}
-        <RefreshButton refresh={refresh} />
-    </CardActions>
-);
+const Actions = ({ resource, filters, displayedFilters, filterValues, theme, hasCreate, basePath, showFilter, refresh }) => {
+    const muiTheme = getMuiTheme(theme);
+    const prefix = autoprefixer(muiTheme);
 
-export default onlyUpdateForKeys(['resource', 'filters', 'displayedFilters', 'filterValues'])(Actions);
+    return (
+        <CardActions style={prefix(cardActionStyle)}>
+            {filters && React.cloneElement(filters, { resource, showFilter, displayedFilters, filterValues, context: 'button' }) }
+            {hasCreate && <CreateButton basePath={basePath} />}
+            <RefreshButton refresh={refresh} />
+        </CardActions>
+    );
+};
+
+export default onlyUpdateForKeys(['resource', 'filters', 'displayedFilters', 'filterValues', 'theme'])(Actions);

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -5,6 +5,7 @@ import shallowEqual from 'recompose/shallowEqual';
 
 import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
+import defaultTheme from '../defaultTheme';
 
 class Filter extends Component {
     constructor(props) {
@@ -50,7 +51,7 @@ class Filter extends Component {
     }
 
     renderForm() {
-        const { resource, children, hideFilter, displayedFilters, filterValues } = this.props;
+        const { resource, children, hideFilter, displayedFilters, filterValues, theme } = this.props;
         return (
             <FilterForm
                 resource={resource}
@@ -59,6 +60,7 @@ class Filter extends Component {
                 displayedFilters={displayedFilters}
                 initialValues={filterValues}
                 setFilters={this.setFilters}
+                theme={theme}
             />
         );
     }
@@ -78,10 +80,12 @@ Filter.propTypes = {
     setFilters: PropTypes.func,
     showFilter: PropTypes.func,
     resource: PropTypes.string.isRequired,
+    theme: PropTypes.object,
 };
 
 Filter.defaultProps = {
     debounce: 500,
+    theme: defaultTheme,
 };
 
 export default Filter;

--- a/src/mui/list/FilterForm.js
+++ b/src/mui/list/FilterForm.js
@@ -5,8 +5,11 @@ import { CardText } from 'material-ui/Card';
 import IconButton from 'material-ui/IconButton';
 import ActionHide from 'material-ui/svg-icons/action/highlight-off';
 import compose from 'recompose/compose';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import autoprefixer from 'material-ui/utils/autoprefixer';
 
 import translate from '../../i18n/translate';
+import defaultTheme from '../defaultTheme';
 
 const styles = {
     card: { marginTop: '-14px', paddingTop: 0, display: 'flex', justifyContent: 'flex-end', alignItems: 'flex-end', flexWrap: 'wrap' },
@@ -32,20 +35,22 @@ export class FilterForm extends Component {
     handleHide = event => this.props.hideFilter(event.currentTarget.dataset.key);
 
     render() {
-        const { resource, translate } = this.props;
+        const { resource, translate, theme } = this.props;
+        const muiTheme = getMuiTheme(theme);
+        const prefix = autoprefixer(muiTheme);
         return (<div>
-            <CardText style={styles.card}>
+            <CardText style={prefix(styles.card)}>
                 {this.getShownFilters().reverse().map(filterElement =>
                     <div
                         key={filterElement.props.source}
                         data-source={filterElement.props.source}
                         className="filter-field"
-                        style={filterElement.props.style || styles.body}
+                        style={filterElement.props.style || prefix(styles.body)}
                     >
                         {filterElement.props.alwaysOn ?
-                            <div style={styles.spacer}>&nbsp;</div> :
+                            <div style={prefix(styles.spacer)}>&nbsp;</div> :
                             <IconButton
-                                iconStyle={styles.icon}
+                                iconStyle={prefix(styles.icon)}
                                 className="hide-filter"
                                 onTouchTap={this.handleHide}
                                 data-key={filterElement.props.source}
@@ -67,7 +72,7 @@ export class FilterForm extends Component {
                     </div>,
                 )}
             </CardText>
-            <div style={styles.clearFix} />
+            <div style={prefix(styles.clearFix)} />
         </div>);
     }
 }
@@ -79,6 +84,11 @@ FilterForm.propTypes = {
     hideFilter: PropTypes.func.isRequired,
     initialValues: PropTypes.object,
     translate: PropTypes.func.isRequired,
+    theme: PropTypes.object.isRequired,
+};
+
+FilterForm.defaultProps = {
+    theme: defaultTheme,
 };
 
 const enhance = compose(

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -7,6 +7,8 @@ import { Card, CardText } from 'material-ui/Card';
 import compose from 'recompose/compose';
 import { createSelector } from 'reselect';
 import inflection from 'inflection';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import autoprefixer from 'material-ui/utils/autoprefixer';
 import queryReducer, { SET_SORT, SET_PAGE, SET_FILTER, SORT_DESC } from '../../reducer/resource/list/queryReducer';
 import ViewTitle from '../layout/ViewTitle';
 import Title from '../layout/Title';
@@ -16,6 +18,7 @@ import { crudGetList as crudGetListAction } from '../../actions/dataActions';
 import { changeListParams as changeListParamsAction } from '../../actions/listActions';
 import translate from '../../i18n/translate';
 import removeKey from '../../util/removeKey';
+import defaultTheme from '../defaultTheme';
 
 const styles = {
     noResults: { padding: 20 },
@@ -165,7 +168,7 @@ export class List extends Component {
     }
 
     render() {
-        const { filters, pagination = <DefaultPagination />, actions = <DefaultActions />, resource, hasCreate, title, data, ids, total, children, isLoading, translate } = this.props;
+        const { filters, pagination = <DefaultPagination />, actions = <DefaultActions />, resource, hasCreate, title, data, ids, total, children, isLoading, translate, theme } = this.props;
         const { key } = this.state;
         const query = this.getQuery();
         const filterValues = query.filter;
@@ -177,23 +180,26 @@ export class List extends Component {
         });
         const defaultTitle = translate('aor.page.list', { name: `${resourceName}` });
         const titleElement = <Title title={title} defaultTitle={defaultTitle} />;
+        const muiTheme = getMuiTheme(theme);
+        const prefix = autoprefixer(muiTheme);
 
         return (
             <div className="list-page">
                 <Card style={{ opacity: isLoading ? 0.8 : 1 }}>
-		   <div style={styles.header} >
-                      <ViewTitle title={titleElement} />
-                      {actions && React.cloneElement(actions, {
-                          resource,
-                          filters,
-                          filterValues,
-                          basePath,
-                          hasCreate,
-                          displayedFilters: this.state,
-                          showFilter: this.showFilter,
-                          refresh: this.refresh,
-                      })}
-		    </div>
+                    <div style={prefix(styles.header)} >
+                        <ViewTitle title={titleElement} />
+                        {actions && React.cloneElement(actions, {
+                            resource,
+                            filters,
+                            filterValues,
+                            basePath,
+                            hasCreate,
+                            displayedFilters: this.state,
+                            showFilter: this.showFilter,
+                            refresh: this.refresh,
+                            theme,
+                        })}
+                    </div>
                     {filters && React.cloneElement(filters, {
                         resource,
                         hideFilter: this.hideFilter,
@@ -258,6 +264,7 @@ List.propTypes = {
     resource: PropTypes.string.isRequired,
     total: PropTypes.number.isRequired,
     translate: PropTypes.func.isRequired,
+    theme: PropTypes.object.isRequired,
 };
 
 List.defaultProps = {
@@ -268,6 +275,7 @@ List.defaultProps = {
         field: 'id',
         order: SORT_DESC,
     },
+    theme: defaultTheme,
 };
 
 const getLocationSearch = props => props.location.search;

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -19,6 +19,10 @@ import removeKey from '../../util/removeKey';
 
 const styles = {
     noResults: { padding: 20 },
+    header: {
+        display: 'flex',
+        justifyContent: 'space-between',
+    },
 };
 
 /**
@@ -177,17 +181,19 @@ export class List extends Component {
         return (
             <div className="list-page">
                 <Card style={{ opacity: isLoading ? 0.8 : 1 }}>
-                    {actions && React.cloneElement(actions, {
-                        resource,
-                        filters,
-                        filterValues,
-                        basePath,
-                        hasCreate,
-                        displayedFilters: this.state,
-                        showFilter: this.showFilter,
-                        refresh: this.refresh,
-                    })}
-                    <ViewTitle title={titleElement} />
+		   <div style={styles.header} >
+                      <ViewTitle title={titleElement} />
+                      {actions && React.cloneElement(actions, {
+                          resource,
+                          filters,
+                          filterValues,
+                          basePath,
+                          hasCreate,
+                          displayedFilters: this.state,
+                          showFilter: this.showFilter,
+                          refresh: this.refresh,
+                      })}
+		    </div>
                     {filters && React.cloneElement(filters, {
                         resource,
                         hideFilter: this.hideFilter,


### PR DESCRIPTION
The commit efccc73d179 introduced the usage of flexbox to properly align
the filter form. It also introduced a regression with mobile device.

The issue was due to a mixed usage of flexbox and floating div.

This commit add flexbox layout for the whole list header:
* title
* add filter/create/refresh buttons
* filter form.

Some small changes are observed, the main one is the alignement of the
"Refresh" button on the right on mobile.

Closes: #754 