### PR TITLE
Handle deep paths for optionText and optionValue

### DIFF
--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash.get';
 import AutoComplete from 'material-ui/AutoComplete';
 
 import FieldTitle from '../../util/FieldTitle';
@@ -81,7 +82,7 @@ export class AutocompleteInput extends Component {
 
     getSuggestion(choice) {
         const { optionText, optionValue, translate, translateChoice } = this.props;
-        const choiceName = typeof optionText === 'function' ? optionText(choice) : choice[optionText];
+        const choiceName = typeof optionText === 'function' ? optionText(choice) : get(choice, optionText);
         return translateChoice ? translate(choiceName, { _: choiceName }) : choiceName;
     }
 
@@ -101,9 +102,9 @@ export class AutocompleteInput extends Component {
             source,
         } = this.props;
 
-        const selectedSource = choices.find(choice => choice[optionValue] === input.value);
+        const selectedSource = choices.find(choice => get(choice, optionValue) === input.value);
         const dataSource = choices.map(choice => ({
-            value: choice[optionValue],
+            value: get(choice, optionValue),
             text: this.getSuggestion(choice),
         }));
         return (

--- a/src/mui/input/AutocompleteInput.spec.js
+++ b/src/mui/input/AutocompleteInput.spec.js
@@ -58,12 +58,40 @@ describe('<AutocompleteInput />', () => {
         ]);
     });
 
+    it('should use optionValue including "." as value identifier', () => {
+        const wrapper = shallow(<AutocompleteInput
+            {...defaultProps}
+            optionValue="foobar.id"
+            choices={[
+                { foobar: { id: 'M' }, name: 'Male' },
+            ]}
+        />);
+        const AutoCompleteElement = wrapper.find('AutoComplete').first();
+        assert.deepEqual(AutoCompleteElement.prop('dataSource'), [
+            { value: 'M', text: 'Male' },
+        ]);
+    });
+
     it('should use optionText with a string value as text identifier', () => {
         const wrapper = shallow(<AutocompleteInput
             {...defaultProps}
             optionText="foobar"
             choices={[
                 { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const AutoCompleteElement = wrapper.find('AutoComplete').first();
+        assert.deepEqual(AutoCompleteElement.prop('dataSource'), [
+            { value: 'M', text: 'Male' },
+        ]);
+    });
+
+    it('should use optionText with a string value including "." as text identifier', () => {
+        const wrapper = shallow(<AutocompleteInput
+            {...defaultProps}
+            optionText="foobar.name"
+            choices={[
+                { id: 'M', foobar: { name: 'Male' } },
             ]}
         />);
         const AutoCompleteElement = wrapper.find('AutoComplete').first();

--- a/src/mui/input/CheckboxGroupInput.js
+++ b/src/mui/input/CheckboxGroupInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash.get';
 import Checkbox from 'material-ui/Checkbox';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import compose from 'recompose/compose';
@@ -125,14 +126,14 @@ export class CheckboxGroupInputComponent extends Component {
             React.cloneElement(optionText, { record: choice }) :
             (typeof optionText === 'function' ?
                 optionText(choice) :
-                choice[optionText]
+                get(choice, optionText)
             );
         return (
             <Checkbox
-                key={choice[optionValue]}
-                checked={value ? value.find(v => (v == choice[optionValue])) !== undefined : false}
+                key={get(choice, optionValue)}
+                checked={value ? value.find(v => (v == get(choice, optionValue))) !== undefined : false}
                 onCheck={this.handleCheck}
-                value={choice[optionValue]}
+                value={get(choice, optionValue)}
                 label={translateChoice ? translate(choiceName, { _: choiceName }) : choiceName}
                 {...options}
             />

--- a/src/mui/input/CheckboxGroupInput.spec.js
+++ b/src/mui/input/CheckboxGroupInput.spec.js
@@ -67,12 +67,40 @@ describe('<CheckboxGroupInput />', () => {
         assert.equal(CheckboxElement1.prop('label'), 'Bar');
     });
 
+    it('should use optionValue including "." as value identifier', () => {
+        const wrapper = shallow(<CheckboxGroupInput
+            {...defaultProps}
+            optionValue="foobar.id"
+            choices={[
+                { foobar: { id: 'foo' }, name: 'Bar' },
+            ]}
+        />);
+        const CheckboxElements = wrapper.find('Checkbox');
+        const CheckboxElement1 = CheckboxElements.first();
+        assert.equal(CheckboxElement1.prop('value'), 'foo');
+        assert.equal(CheckboxElement1.prop('label'), 'Bar');
+    });
+
     it('should use optionText with a string value as text identifier', () => {
         const wrapper = shallow(<CheckboxGroupInput
             {...defaultProps}
             optionText="foobar"
             choices={[
                 { id: 'foo', foobar: 'Bar' },
+            ]}
+        />);
+        const CheckboxElements = wrapper.find('Checkbox');
+        const CheckboxElement1 = CheckboxElements.first();
+        assert.equal(CheckboxElement1.prop('value'), 'foo');
+        assert.equal(CheckboxElement1.prop('label'), 'Bar');
+    });
+
+    it('should use optionText with a string value including "." as text identifier', () => {
+        const wrapper = shallow(<CheckboxGroupInput
+            {...defaultProps}
+            optionText="foobar.name"
+            choices={[
+                { id: 'foo', foobar: { name: 'Bar' } },
             ]}
         />);
         const CheckboxElements = wrapper.find('Checkbox');

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash.get';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 
 import Labeled from './Labeled';
@@ -78,13 +79,13 @@ export class RadioButtonGroupInput extends Component {
             React.cloneElement(optionText, { record: choice }) :
             (typeof optionText === 'function' ?
                 optionText(choice) :
-                choice[optionText]
+                get(choice, optionText)
             );
         return (
             <RadioButton
-                key={choice[optionValue]}
+                key={get(choice, optionValue)}
                 label={translateChoice ? translate(choiceName, { _: choiceName }) : choiceName}
-                value={choice[optionValue]}
+                value={get(choice, optionValue)}
             />
         );
     }

--- a/src/mui/input/RadioButtonGroupInput.spec.js
+++ b/src/mui/input/RadioButtonGroupInput.spec.js
@@ -55,12 +55,40 @@ describe('<RadioButtonGroupInput />', () => {
         assert.equal(RadioButtonElement1.prop('label'), 'Male');
     });
 
+    it('should use optionValue including "." as value identifier', () => {
+        const wrapper = shallow(<RadioButtonGroupInput
+            {...defaultProps}
+            optionValue="foobar.id"
+            choices={[
+                { foobar: { id: 'M' }, name: 'Male' },
+            ]}
+        />);
+        const RadioButtonElements = wrapper.find('RadioButton');
+        const RadioButtonElement1 = RadioButtonElements.first();
+        assert.equal(RadioButtonElement1.prop('value'), 'M');
+        assert.equal(RadioButtonElement1.prop('label'), 'Male');
+    });
+
     it('should use optionText with a string value as text identifier', () => {
         const wrapper = shallow(<RadioButtonGroupInput
             {...defaultProps}
             optionText="foobar"
             choices={[
                 { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const RadioButtonElements = wrapper.find('RadioButton');
+        const RadioButtonElement1 = RadioButtonElements.first();
+        assert.equal(RadioButtonElement1.prop('value'), 'M');
+        assert.equal(RadioButtonElement1.prop('label'), 'Male');
+    });
+
+    it('should use optionText with a string value including "." as text identifier', () => {
+        const wrapper = shallow(<RadioButtonGroupInput
+            {...defaultProps}
+            optionText="foobar.name"
+            choices={[
+                { id: 'M', foobar: { name: 'Male' } },
             ]}
         />);
         const RadioButtonElements = wrapper.find('RadioButton');

--- a/src/mui/input/SelectArrayInput.js
+++ b/src/mui/input/SelectArrayInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash.get';
 import ChipInput from 'material-ui-chip-input';
 
 import translate from '../../i18n/translate';
@@ -123,9 +124,9 @@ export class SelectArrayInput extends Component {
 
     formatChoice = (choice) => {
         const { optionText, optionValue, translateChoice, translate } = this.props;
-        const choiceText = typeof optionText === 'function' ? optionText(choice) : choice[optionText];
+        const choiceText = typeof optionText === 'function' ? optionText(choice) : get(choice, optionText);
         return {
-            value: choice[optionValue],
+            value: get(choice, optionValue),
             text: translateChoice ? translate(choiceText, { _: choiceText }) : choiceText,
         };
     }

--- a/src/mui/input/SelectArrayInput.spec.js
+++ b/src/mui/input/SelectArrayInput.spec.js
@@ -93,12 +93,40 @@ describe('<SelectArrayInput />', () => {
         ]);
     });
 
+    it('should use optionValue including as value identifier', () => {
+        const wrapper = shallow(<SelectArrayInput
+            {...defaultProps}
+            optionValue="foobar.id"
+            choices={[
+                { foobar: { id: 'B' }, name: 'Book' },
+            ]}
+        />);
+        const ChipInputElement = wrapper.find('ChipInput').first();
+        assert.deepEqual(ChipInputElement.prop('dataSource'), [
+            { value: 'B', text: 'Book' },
+        ]);
+    });
+
     it('should use optionText with a string value as text identifier', () => {
         const wrapper = shallow(<SelectArrayInput
             {...defaultProps}
             optionText="foobar"
             choices={[
                 { id: 'B', foobar: 'Book' },
+            ]}
+        />);
+        const ChipInputElement = wrapper.find('ChipInput').first();
+        assert.deepEqual(ChipInputElement.prop('dataSource'), [
+            { value: 'B', text: 'Book' },
+        ]);
+    });
+
+    it('should use optionText with a string value including "." as text identifier', () => {
+        const wrapper = shallow(<SelectArrayInput
+            {...defaultProps}
+            optionText="foobar.name"
+            choices={[
+                { id: 'B', foobar: { name: 'Book' } },
             ]}
         />);
         const ChipInputElement = wrapper.find('ChipInput').first();

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash.get';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 
@@ -88,13 +89,13 @@ export class SelectInput extends Component {
             React.cloneElement(optionText, { record: choice }) :
             (typeof optionText === 'function' ?
                 optionText(choice) :
-                choice[optionText]
+                get(choice, optionText)
             );
         return (
             <MenuItem
-                key={choice[optionValue]}
+                key={get(choice, optionValue)}
                 primaryText={translateChoice ? translate(choiceName, { _: choiceName }) : choiceName}
-                value={choice[optionValue]}
+                value={get(choice, optionValue)}
             />
         );
     }

--- a/src/mui/input/SelectInput.spec.js
+++ b/src/mui/input/SelectInput.spec.js
@@ -72,12 +72,40 @@ describe('<SelectInput />', () => {
         assert.equal(MenuItemElement1.prop('primaryText'), 'Male');
     });
 
+    it('should use optionValue including "." as value identifier', () => {
+        const wrapper = shallow(<SelectInput
+            {...defaultProps}
+            optionValue="foobar.id"
+            choices={[
+                { foobar: { id: 'M' }, name: 'Male' },
+            ]}
+        />);
+        const MenuItemElements = wrapper.find('MenuItem');
+        const MenuItemElement1 = MenuItemElements.first();
+        assert.equal(MenuItemElement1.prop('value'), 'M');
+        assert.equal(MenuItemElement1.prop('primaryText'), 'Male');
+    });
+
     it('should use optionText with a string value as text identifier', () => {
         const wrapper = shallow(<SelectInput
             {...defaultProps}
             optionText="foobar"
             choices={[
                 { id: 'M', foobar: 'Male' },
+            ]}
+        />);
+        const MenuItemElements = wrapper.find('MenuItem');
+        const MenuItemElement1 = MenuItemElements.first();
+        assert.equal(MenuItemElement1.prop('value'), 'M');
+        assert.equal(MenuItemElement1.prop('primaryText'), 'Male');
+    });
+
+    it('should use optionText with a string value including "." as text identifier', () => {
+        const wrapper = shallow(<SelectInput
+            {...defaultProps}
+            optionText="foobar.name"
+            choices={[
+                { id: 'M', foobar: { name: 'Male' } },
             ]}
         />);
         const MenuItemElements = wrapper.find('MenuItem');


### PR DESCRIPTION
Our REST server returns JSON with nested fields like:

```javascript
[
    { "id": "M", "foobar": { "name": "Male" } },
    { "id": "F", "foobar": { "name": "Female" } }
]
```

I'd like to use the "name" value in "foobar" as `optionText` of `SelectInput` within `ReferenceInput`. Although we can specify a function as `optionText` in this case, I'd like to specify a string "foobar.name" for simplicity.