### PR TITLE
Use stringify to generate a query string

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -573,6 +573,7 @@ import {
     DELETE,
     fetchUtils,
 } from 'admin-on-rest';
+import { stringify } from 'query-string';
 
 const API_URL = 'my.api.url';
 
@@ -584,7 +585,6 @@ const API_URL = 'my.api.url';
  */
 const convertRESTRequestToHTTP = (type, resource, params) => {
     let url = '';
-    const { queryParameters } = fetchUtils;
     const options = {};
     switch (type) {
     case GET_LIST: {
@@ -595,7 +595,7 @@ const convertRESTRequestToHTTP = (type, resource, params) => {
             range: JSON.stringify([(page - 1) * perPage, page * perPage - 1]),
             filter: JSON.stringify(params.filter),
         };
-        url = `${API_URL}/${resource}?${queryParameters(query)}`;
+        url = `${API_URL}/${resource}?${stringify(query)}`;
         break;
     }
     case GET_ONE:
@@ -605,7 +605,7 @@ const convertRESTRequestToHTTP = (type, resource, params) => {
         const query = {
             filter: JSON.stringify({ id: params.ids }),
         };
-        url = `${API_URL}/${resource}?${queryParameters(query)}`;
+        url = `${API_URL}/${resource}?${stringify(query)}`;
         break;
     }
     case GET_MANY_REFERENCE: {
@@ -616,7 +616,7 @@ const convertRESTRequestToHTTP = (type, resource, params) => {
             range: JSON.stringify([(page - 1) * perPage, (page * perPage) - 1]),
             filter: JSON.stringify({ ...params.filter, [params.target]: params.id }),
         };
-        url = `${API_URL}/${resource}?${queryParameters(query)}`;
+        url = `${API_URL}/${resource}?${stringify(query)}`;
         break;
     }
     case UPDATE:

--- a/src/rest/jsonServer.js
+++ b/src/rest/jsonServer.js
@@ -1,4 +1,5 @@
-import { queryParameters, fetchJson } from '../util/fetch';
+import { stringify } from 'query-string';
+import { fetchJson } from '../util/fetch';
 import {
     GET_LIST,
     GET_ONE,
@@ -42,7 +43,7 @@ export default (apiUrl, httpClient = fetchJson) => {
                 _start: (page - 1) * perPage,
                 _end: page * perPage,
             };
-            url = `${apiUrl}/${resource}?${queryParameters(query)}`;
+            url = `${apiUrl}/${resource}?${stringify(query)}`;
             break;
         }
         case GET_ONE:
@@ -59,7 +60,7 @@ export default (apiUrl, httpClient = fetchJson) => {
                 _start: (page - 1) * perPage,
                 _end: page * perPage,
             };
-            url = `${apiUrl}/${resource}?${queryParameters(query)}`;
+            url = `${apiUrl}/${resource}?${stringify(query)}`;
             break;
         }
         case UPDATE:

--- a/src/rest/simple.js
+++ b/src/rest/simple.js
@@ -1,4 +1,5 @@
-import { queryParameters, fetchJson } from '../util/fetch';
+import { stringify } from 'query-string';
+import { fetchJson } from '../util/fetch';
 import {
     GET_LIST,
     GET_ONE,
@@ -41,7 +42,7 @@ export default (apiUrl, httpClient = fetchJson) => {
                 range: JSON.stringify([(page - 1) * perPage, (page * perPage) - 1]),
                 filter: JSON.stringify(params.filter),
             };
-            url = `${apiUrl}/${resource}?${queryParameters(query)}`;
+            url = `${apiUrl}/${resource}?${stringify(query)}`;
             break;
         }
         case GET_ONE:
@@ -51,7 +52,7 @@ export default (apiUrl, httpClient = fetchJson) => {
             const query = {
                 filter: JSON.stringify({ id: params.ids }),
             };
-            url = `${apiUrl}/${resource}?${queryParameters(query)}`;
+            url = `${apiUrl}/${resource}?${stringify(query)}`;
             break;
         }
         case GET_MANY_REFERENCE: {
@@ -62,7 +63,7 @@ export default (apiUrl, httpClient = fetchJson) => {
                 range: JSON.stringify([(page - 1) * perPage, (page * perPage) - 1]),
                 filter: JSON.stringify({ ...params.filter, [params.target]: params.id }),
             };
-            url = `${apiUrl}/${resource}?${queryParameters(query)}`;
+            url = `${apiUrl}/${resource}?${stringify(query)}`;
             break;
         }
         case UPDATE:

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,4 +1,5 @@
 import HttpError from './HttpError';
+import { stringify } from 'query-string';
 
 export const fetchJson = (url, options = {}) => {
     const requestHeaders = options.headers || new Headers({
@@ -32,6 +33,4 @@ export const fetchJson = (url, options = {}) => {
         });
 };
 
-export const queryParameters = data => Object.keys(data)
-    .map(key => [key, data[key]].map(encodeURIComponent).join('='))
-    .join('&');
+export const queryParameters = stringify;

--- a/src/util/fetch.spec.js
+++ b/src/util/fetch.spec.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { queryParameters } from './fetch';
+
+describe('queryParameters', () => {
+    it('should generate a query parameter', () => {
+        const data = { foo: 'bar' };
+        assert.equal(queryParameters(data), 'foo=bar');
+    });
+
+    it('should generate multiple query parameters', () => {
+        const data = { foo: 'fooval', bar: 'barval' };
+        const actual = queryParameters(data);
+        assert(['foo=fooval&bar=barval', 'bar=barval&foo=fooval'].includes(actual));
+    });
+
+    it('should generate multiple query parameters with a same name', () => {
+        const data = { foo: ['bar', 'baz'] };
+        assert.equal(queryParameters(data), 'foo=bar&foo=baz');
+    });
+
+    it('should generate an encoded query parameter', () => {
+        const data = ['foo=bar', 'foo?bar&baz'];
+        assert.equal(queryParameters({ [data[0]]: data[1] }), data.map(encodeURIComponent).join('='));
+    });
+});


### PR DESCRIPTION
According to [json-server's README](https://github.com/typicode/json-server#filter), it supports multiple query parameters with a same name (e.q. `GET /posts?id=1&id=2`). However, current `queryParameters({ foo: ['bar', 'bar'] })` returns a string `"foo=bar%2Cbaz"`, not `"foo=bar&foo=baz"`.

Note that I might be a good idea to replace `queryParameters` to `stringify` directory and remove the `queryParameters` function.