### PR TITLE
[RFR] Replace "Cannot read property 'touched' of undefined" error by a more meaningful one

### DIFF
--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -94,13 +94,17 @@ export class AutocompleteInput extends Component {
             input,
             isRequired,
             label,
-            meta: { touched, error },
+            meta,
             options,
             optionValue,
             resource,
             setFilter,
             source,
         } = this.props;
+        if (typeof meta === 'undefined') {
+            throw new Error('The AutocompleteInput component wasn\'t called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/admin-on-rest/Inputs.html#writing-your-own-input-component for details.');
+        }
+        const { touched, error } = meta;
 
         const selectedSource = choices.find(choice => get(choice, optionValue) === input.value);
         const dataSource = choices.map(choice => ({

--- a/src/mui/input/DateInput.js
+++ b/src/mui/input/DateInput.js
@@ -35,7 +35,11 @@ class DateInput extends Component {
     onDismiss = () => this.props.input.onBlur();
 
     render() {
-        const { input, isRequired, label, meta: { touched, error }, options, source, elStyle, resource } = this.props;
+        const { input, isRequired, label, meta, options, source, elStyle, resource } = this.props;
+        if (typeof meta === 'undefined') {
+            throw new Error('The DateInput component wasn\'t called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/admin-on-rest/Inputs.html#writing-your-own-input-component for details.');
+        }
+        const { touched, error } = meta;
 
         return (<DatePicker
             {...input}

--- a/src/mui/input/Labeled.js
+++ b/src/mui/input/Labeled.js
@@ -25,7 +25,7 @@ const defaultLabelStyle = {
  */
 class Labeled extends Component {
     render() {
-        const { input, isRequired, label, resource, record, onChange, basePath, children, source, disabled = true, labelStyle = defaultLabelStyle } = this.props;
+        const { input, isRequired, label, resource, children, source, disabled = true, labelStyle = defaultLabelStyle, ...rest } = this.props;
         if (!label && !source) {
             throw new Error(`Cannot create label for component <${children && children.type && children.type.name}>: You must set either the label or source props. You can also disable automated label insertion by setting 'addLabel: false' in the component default props`);
         }
@@ -39,7 +39,7 @@ class Labeled extends Component {
                 style={labelStyle}
             >
                 {children && typeof children.type !== 'string' ?
-                    React.cloneElement(children, { input, record, resource, onChange, basePath }) :
+                    React.cloneElement(children, { input, resource, ...rest }) :
                     children
                 }
             </TextField>

--- a/src/mui/input/LongTextInput.js
+++ b/src/mui/input/LongTextInput.js
@@ -3,17 +3,24 @@ import PropTypes from 'prop-types';
 import TextField from 'material-ui/TextField';
 import FieldTitle from '../../util/FieldTitle';
 
-const LongTextInput = ({ input, isRequired, label, meta: { touched, error }, options, source, elStyle, resource }) => (
-    <TextField
-        {...input}
-        multiLine
-        fullWidth
-        floatingLabelText={<FieldTitle label={label} source={source} resource={resource} isRequired={isRequired} />}
-        errorText={touched && error}
-        style={elStyle}
-        {...options}
-    />
-);
+const LongTextInput = ({ input, isRequired, label, meta, options, source, elStyle, resource }) => {
+    if (typeof meta === 'undefined') {
+        throw new Error('The LongTextInput component wasn\'t called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/admin-on-rest/Inputs.html#writing-your-own-input-component for details.');
+    }
+    const { touched, error } = meta;
+
+    return (
+        <TextField
+            {...input}
+            multiLine
+            fullWidth
+            floatingLabelText={<FieldTitle label={label} source={source} resource={resource} isRequired={isRequired} />}
+            errorText={touched && error}
+            style={elStyle}
+            {...options}
+        />
+    );
+}
 
 LongTextInput.propTypes = {
     addField: PropTypes.bool.isRequired,

--- a/src/mui/input/NumberInput.js
+++ b/src/mui/input/NumberInput.js
@@ -39,7 +39,12 @@ class NumberInput extends Component {
     }
 
     render() {
-        const { elStyle, input, isRequired, label, meta: { touched, error }, options, source, step, resource } = this.props;
+        const { elStyle, input, isRequired, label, meta, options, source, step, resource } = this.props;
+        if (typeof meta === 'undefined') {
+            throw new Error('The NumberInput component wasn\'t called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/admin-on-rest/Inputs.html#writing-your-own-input-component for details.');
+        }
+        const { touched, error } = meta;
+
         return (
             <TextField
                 {...input}

--- a/src/mui/input/SelectArrayInput.js
+++ b/src/mui/input/SelectArrayInput.js
@@ -138,7 +138,7 @@ export class SelectArrayInput extends Component {
             isRequired,
             choices,
             label,
-            meta: { touched, error },
+            meta,
             options,
             optionText,
             optionValue,
@@ -148,6 +148,10 @@ export class SelectArrayInput extends Component {
             translate,
             translateChoice,
         } = this.props;
+        if (typeof meta === 'undefined') {
+            throw new Error('The SelectArrayInput component wasn\'t called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/admin-on-rest/Inputs.html#writing-your-own-input-component for details.');
+        }
+        const { touched, error } = meta;
 
         return (
             <ChipInput

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -108,11 +108,16 @@ export class SelectInput extends Component {
             input,
             isRequired,
             label,
-            meta: { touched, error },
+            meta,
             options,
             resource,
             source,
         } = this.props;
+        if (typeof meta === 'undefined') {
+            throw new Error('The SelectInput component wasn\'t called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/admin-on-rest/Inputs.html#writing-your-own-input-component for details.');
+        }
+        const { touched, error } = meta;
+
         return (
             <SelectField
                 value={this.state.value}

--- a/src/mui/input/TextInput.js
+++ b/src/mui/input/TextInput.js
@@ -39,12 +39,16 @@ export class TextInput extends Component {
             input,
             isRequired,
             label,
-            meta: { touched, error },
+            meta,
             options,
             resource,
             source,
             type,
         } = this.props;
+        if (typeof meta === 'undefined') {
+            throw new Error('The TextInput component wasn\'t called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/admin-on-rest/Inputs.html#writing-your-own-input-component for details.');
+        }
+        const { touched, error } = meta;
 
         return (
             <TextField


### PR DESCRIPTION
Decorating an aor `Input` component invariably leads to a very frustrating error:

> Cannot read property 'touched' of undefined

`undefined` in that case refers to the `meta` prop, which is supposed to be passed to the component by a redux-form `<Field>` component. The reason is that all aor `<Input>` components must be embedded inside a `<Field>`. To avoid repetition, we chose to let `<SimpleForm>` and `<TabbedForm>` do the `<Field>` decoration whenever they see an `Input` components with the `addField` prop set to `true`. But this doesn't work for decorated inputs:

```js
const MyInput = props => <LongTextInput source="teaser" validate={required} {...props} />;
```

This input has no `addField` default prop, and therefore will not be decorated by a `<Field>`. To fix that, the developer should add the following line:

```js
MyInput.defaultProps = { addField: true };
``` 

This PR tries to make that more obvious to the developer.

Before:

![image](https://user-images.githubusercontent.com/99944/27787244-68f864f8-5fe4-11e7-8c9e-4199a6116966.png)


After: 

![image](https://user-images.githubusercontent.com/99944/27787215-50ec2a8e-5fe4-11e7-97cf-c71930235d27.png)

