### PR TITLE
[RFR] Move webpack to example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install: package.json ## install dependencies
 	@npm install
 
 run: example_install ## run the example
-	@cd example && ../node_modules/.bin/webpack-dev-server --hot --inline --config ./webpack.config.js
+	@cd example && ./node_modules/.bin/webpack-dev-server --hot --inline --config ./webpack.config.js
 
 example_install: example/package.json
 	@cd example && npm install
@@ -47,7 +47,7 @@ test-unit-watch: ## launch unit tests and watch for changes
 test-e2e: ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \
 		echo 'Building example code (call "make build=false test-e2e" to skip the build)...'; \
-		cd example && ../node_modules/.bin/webpack; \
+		cd example && ./node_modules/.bin/webpack; \
 	fi
 	@echo 'Launching e2e tests...'
 	@NODE_ENV=test node_modules/.bin/mocha \

--- a/example/package.json
+++ b/example/package.json
@@ -12,12 +12,14 @@
     "aor-json-rest-client": "~2.0.0",
     "aor-language-french": "~1.8.0",
     "aor-rich-text-input": "~1.0.0",
-    "babel-core": "^6.25.0",
+    "babel-core": "~6.25.0",
     "babel-loader": "~7.1.1",
     "babel-plugin-transform-react-jsx": "~6.8.0",
     "babel-polyfill": "~6.9.1",
     "babel-preset-react": "~6.11.1",
+    "css-loader": "~0.28.4",
     "extract-text-webpack-plugin": "~2.1.2",
+    "style-loader": "~0.18.2",
     "webpack": "~3.0.0",
     "webpack-dev-server": "~2.5.0"
   }

--- a/example/package.json
+++ b/example/package.json
@@ -9,11 +9,16 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "aor-json-rest-client": "2.0.0",
+    "aor-json-rest-client": "~2.0.0",
     "aor-language-french": "~1.8.0",
     "aor-rich-text-input": "~1.0.0",
-    "babel-plugin-transform-react-jsx": "^6.8.0",
-    "babel-polyfill": "^6.9.1",
-    "babel-preset-react": "^6.11.1"
+    "babel-core": "^6.25.0",
+    "babel-loader": "~7.1.1",
+    "babel-plugin-transform-react-jsx": "~6.8.0",
+    "babel-polyfill": "~6.9.1",
+    "babel-preset-react": "~6.11.1",
+    "extract-text-webpack-plugin": "~2.1.2",
+    "webpack": "~3.0.0",
+    "webpack-dev-server": "~2.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "babel-preset-stage-0": "~6.24.1",
     "babel-register": "~6.24.1",
     "chromedriver": "~2.26.1",
-    "css-loader": "~0.28.0",
     "enzyme": "~2.9.1",
     "eslint": "~4.1.0",
     "eslint-config-prettier": "~2.3.0",
@@ -49,8 +48,7 @@
     "react-addons-test-utils": "~15.5.1",
     "react-test-renderer": "~15.5.1",
     "selenium-webdriver": "~3.3.0",
-    "sinon": "~2.1.0",
-    "style-loader": "~0.16.0"
+    "sinon": "~2.1.0"
   },
   "dependencies": {
     "babel-runtime": "~6.18.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "babel-cli": "~6.24.1",
     "babel-core": "~6.24.1",
     "babel-eslint": "~7.2.2",
-    "babel-loader": "~6.4.1",
     "babel-plugin-add-module-exports": "~0.2.1",
     "babel-plugin-transform-builtin-extend": "~1.1.2",
     "babel-plugin-transform-react-jsx": "~6.24.1",
@@ -41,7 +40,6 @@
     "eslint-plugin-prettier": "~2.1.2",
     "eslint-plugin-react": "~7.1.0",
     "express": "~4.15.2",
-    "extract-text-webpack-plugin": "~1.0.1",
     "file-api": "~0.10.4",
     "full-icu": "~1.0.3",
     "ignore-styles": "~5.0.1",
@@ -52,9 +50,7 @@
     "react-test-renderer": "~15.5.1",
     "selenium-webdriver": "~3.3.0",
     "sinon": "~2.1.0",
-    "style-loader": "~0.16.0",
-    "webpack": "~1.13.2",
-    "webpack-dev-server": "~1.16.2"
+    "style-loader": "~0.16.0"
   },
   "dependencies": {
     "babel-runtime": "~6.18.0",


### PR DESCRIPTION
We don't need webpack in the main project, only in the example. Moving the related dependencies to emphasize that admin-on-rest is bundle agnostic.