### PR TITLE
Support nested filter object

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash.debounce": "~4.0.8",
     "lodash.defaultsdeep": "~4.6.0",
     "lodash.get": "~4.4.2",
+    "lodash.isequal": "~4.5.0",
     "lodash.set": "~4.3.2",
     "material-ui": "~0.17.4",
     "material-ui-chip-input": "~0.13.5",

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
-import shallowEqual from 'recompose/shallowEqual';
+import isEqual from 'lodash.isequal';
 
 import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
 import defaultTheme from '../defaultTheme';
+import removeEmpty from '../../util/removeEmpty';
 
 class Filter extends Component {
     constructor(props) {
@@ -24,15 +25,9 @@ class Filter extends Component {
     }
 
     setFilters = debounce(filters => {
-        if (!shallowEqual(filters, this.filters)) {
+        if (!isEqual(filters, this.filters)) {
             // fix for redux-form bug with onChange and enableReinitialize
-            const filtersWithoutEmpty = filters;
-            Object.keys(filtersWithoutEmpty).forEach(filterName => {
-                if (filtersWithoutEmpty[filterName] === '') {
-                    // remove empty filter from query
-                    delete filtersWithoutEmpty[filterName];
-                }
-            });
+            const filtersWithoutEmpty = removeEmpty(filters);
             this.props.setFilters(filtersWithoutEmpty);
             this.filters = filtersWithoutEmpty;
         }

--- a/src/rest/jsonServer.js
+++ b/src/rest/jsonServer.js
@@ -1,5 +1,5 @@
 import { stringify } from 'query-string';
-import { fetchJson } from '../util/fetch';
+import { fetchJson, flattenObject } from '../util/fetch';
 import {
     GET_LIST,
     GET_ONE,
@@ -37,7 +37,7 @@ export default (apiUrl, httpClient = fetchJson) => {
                 const { page, perPage } = params.pagination;
                 const { field, order } = params.sort;
                 const query = {
-                    ...params.filter,
+                    ...flattenObject(params.filter),
                     _sort: field,
                     _order: order,
                     _start: (page - 1) * perPage,
@@ -53,7 +53,7 @@ export default (apiUrl, httpClient = fetchJson) => {
                 const { page, perPage } = params.pagination;
                 const { field, order } = params.sort;
                 const query = {
-                    ...params.filter,
+                    ...flattenObject(params.filter),
                     [params.target]: params.id,
                     _sort: field,
                     _order: order,

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -44,3 +44,30 @@ export const fetchJson = (url, options = {}) => {
 };
 
 export const queryParameters = stringify;
+
+const isValidObject = value => {
+    if (!value) {
+        return false;
+    }
+
+    const isArray = Array.isArray(value);
+    const isBuffer = Buffer.isBuffer(value);
+    const isObject =
+        Object.prototype.toString.call(value) === '[object Object]';
+    const hasKeys = !!Object.keys(value).length;
+
+    return !isArray && !isBuffer && isObject && hasKeys;
+};
+
+export const flattenObject = (value, path = []) => {
+    if (isValidObject(value)) {
+        return Object.assign(
+            {},
+            ...Object.keys(value).map(key =>
+                flattenObject(value[key], path.concat([key]))
+            )
+        );
+    } else {
+        return path.length ? { [path.join('.')]: value } : value;
+    }
+};

--- a/src/util/fetch.spec.js
+++ b/src/util/fetch.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { queryParameters } from './fetch';
+import { queryParameters, flattenObject } from './fetch';
 
 describe('queryParameters', () => {
     it('should generate a query parameter', () => {
@@ -26,5 +26,34 @@ describe('queryParameters', () => {
             queryParameters({ [data[0]]: data[1] }),
             data.map(encodeURIComponent).join('=')
         );
+    });
+});
+
+describe('flattenObject', () => {
+    it('should return null with null', () => {
+        assert.strictEqual(flattenObject(null), null);
+    });
+
+    it('should return itself with a string', () => {
+        assert.equal(flattenObject('foo'), 'foo');
+    });
+
+    it('should return itself with an array', () => {
+        assert.deepEqual(flattenObject(['foo']), ['foo']);
+    });
+
+    it('should return a same object with an empty object', () => {
+        assert.deepEqual(flattenObject({}), {});
+    });
+
+    it('should return a same object with a non-nested object', () => {
+        const value = { foo: 'fooval', bar: 'barval' };
+        assert.deepEqual(flattenObject(value), value);
+    });
+
+    it('should return a same object with a nested object', () => {
+        const input = { foo: 'foo', bar: { baz: 'barbaz' } };
+        const expected = { foo: 'foo', 'bar.baz': 'barbaz' };
+        assert.deepEqual(flattenObject(input), expected);
     });
 });

--- a/src/util/removeEmpty.js
+++ b/src/util/removeEmpty.js
@@ -1,0 +1,15 @@
+import { shallowEqual } from 'recompose';
+
+const isObject = obj =>
+    obj && Object.prototype.toString.call(obj) === '[object Object]';
+const isEmpty = obj => obj === '' || obj === null || shallowEqual(obj, {});
+
+const removeEmpty = object =>
+    Object.keys(object).reduce((acc, key) => {
+        const child = isObject(object[key])
+            ? removeEmpty(object[key])
+            : object[key];
+        return isEmpty(child) ? acc : { ...acc, [key]: child };
+    }, {});
+
+export default removeEmpty;

--- a/src/util/removeEmpty.spec.js
+++ b/src/util/removeEmpty.spec.js
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import removeEmpty from './removeEmpty';
+
+describe('removeEmpty', () => {
+    it('should not remove any properties with no empty values', () => {
+        const obj = { foo: 'fooval', bar: 'barval' };
+        assert.deepEqual(removeEmpty({ ...obj }), obj);
+    });
+
+    it('should remove the empty values with empty values', () => {
+        const input = { foo: '', bar: null };
+        assert.deepEqual(removeEmpty(input), {});
+    });
+
+    it('should remove whole empty object with a nested empty value', () => {
+        const input = { foo: 'val', bar: { baz: '' } };
+        assert.deepEqual(removeEmpty(input), { foo: 'val' });
+    });
+});


### PR DESCRIPTION
There are two problems when a deep property is specified in `Filter` like:

```javascript
const MyFilter = props => (
  <Filter {...props}>
    <TextInput source='foo.bar' label='Foo' />
  </Filter>
);


const MyList = props => (
  <List {...props} filters={<MyFilter />}
    ...
  </List>
);
```

* Invalid query string (E.g. `"foo=%5Bobject%20Object%5D"`) is generated for json server. This should b flatten like `"foo.bar=val"`.
* When the text input value is cleared, the filter value is not removed from filter parameters.