### PR TITLE
[RFR] Fix RadioButtonGroupInput label translation

### DIFF
--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -129,15 +129,9 @@ RadioButtonGroupInput.propTypes = {
 RadioButtonGroupInput.defaultProps = {
     addField: true,
     choices: [],
-    elStyle: {},
-    input: {},
-    isRequired: false,
-    label: undefined,
     options: {},
     optionText: 'name',
     optionValue: 'id',
-    resource: undefined,
-    source: undefined,
     translateChoice: true,
 };
 

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -91,9 +91,9 @@ export class RadioButtonGroupInput extends Component {
     }
 
     render() {
-        const { label, source, input, isRequired, choices, options, elStyle } = this.props;
+        const { label, resource, source, input, isRequired, choices, options, elStyle } = this.props;
         return (
-            <Labeled label={label} onChange={this.handleChange} source={source} isRequired={isRequired}>
+            <Labeled label={label} onChange={this.handleChange} resource={resource} source={source} isRequired={isRequired}>
                 <RadioButtonGroup
                     name={source}
                     defaultSelected={input.value}
@@ -120,6 +120,7 @@ RadioButtonGroupInput.propTypes = {
         PropTypes.element,
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
+    resource: PropTypes.string,
     source: PropTypes.string,
     translate: PropTypes.func.isRequired,
     translateChoice: PropTypes.bool.isRequired,
@@ -135,6 +136,7 @@ RadioButtonGroupInput.defaultProps = {
     options: {},
     optionText: 'name',
     optionValue: 'id',
+    resource: undefined,
     source: undefined,
     translateChoice: true,
 };

--- a/src/mui/input/RadioButtonGroupInput.js
+++ b/src/mui/input/RadioButtonGroupInput.js
@@ -73,7 +73,7 @@ export class RadioButtonGroupInput extends Component {
             optionText,
             optionValue,
             translate,
-            translateChoice
+            translateChoice,
         } = this.props;
         const choiceName = React.isValidElement(optionText) ? // eslint-disable-line no-nested-ternary
             React.cloneElement(optionText, { record: choice }) :
@@ -108,12 +108,11 @@ export class RadioButtonGroupInput extends Component {
 }
 
 RadioButtonGroupInput.propTypes = {
-    addField: PropTypes.bool.isRequired,
     choices: PropTypes.arrayOf(PropTypes.object),
+    elStyle: PropTypes.object,
     input: PropTypes.object,
     isRequired: PropTypes.bool,
     label: PropTypes.string,
-    onChange: PropTypes.func,
     options: PropTypes.object,
     optionText: PropTypes.oneOfType([
         PropTypes.string,
@@ -122,7 +121,6 @@ RadioButtonGroupInput.propTypes = {
     ]).isRequired,
     optionValue: PropTypes.string.isRequired,
     source: PropTypes.string,
-    style: PropTypes.object,
     translate: PropTypes.func.isRequired,
     translateChoice: PropTypes.bool.isRequired,
 };
@@ -130,9 +128,14 @@ RadioButtonGroupInput.propTypes = {
 RadioButtonGroupInput.defaultProps = {
     addField: true,
     choices: [],
+    elStyle: {},
+    input: {},
+    isRequired: false,
+    label: undefined,
     options: {},
     optionText: 'name',
     optionValue: 'id',
+    source: undefined,
     translateChoice: true,
 };
 


### PR DESCRIPTION
The **RadioButtonGroupInput** wasn't translating its label, and I've found out why. The `resource` prop was undefined, so it would never find the correct translation. I think this also fix #454.