### PR TITLE
Add response body to HttpError

### DIFF
--- a/src/sideEffect/saga/crudFetch.js
+++ b/src/sideEffect/saga/crudFetch.js
@@ -43,6 +43,7 @@ const crudFetch = restClient => {
             yield put({
                 type: `${type}_FAILURE`,
                 error: error.message ? error.message : error,
+                payload: error.body ? error.body : null,
                 requestPayload: payload,
                 meta: {
                     ...meta,

--- a/src/util/HttpError.js
+++ b/src/util/HttpError.js
@@ -1,8 +1,9 @@
 class HttpError extends Error {
-    constructor(message, status) {
+    constructor(message, status, body = null) {
         super(message);
         this.message = message;
         this.status = status;
+        this.body = body;
         this.name = this.constructor.name;
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, this.constructor);

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -32,7 +32,11 @@ export const fetchJson = (url, options = {}) => {
             }
             if (status < 200 || status >= 300) {
                 return Promise.reject(
-                    new HttpError((json && json.message) || statusText, status)
+                    new HttpError(
+                        (json && json.message) || statusText,
+                        status,
+                        json
+                    )
                 );
             }
             return { status, headers, body, json };


### PR DESCRIPTION
This PR adds the possibility to pass the response body to a HttpError instance. This response body is then passed in `*_FAILURE` actions so it can be used elsewhere in the app.

I coded this because I needed to get server validations errors (which are in the response) in my app. 