### PR TITLE
Changed 'Edition' to Editing or Edit, etc

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -691,6 +691,6 @@ const App = () => (
 
 ## Conclusion
 
-Admin-on-rest was build with customization in mind. You can replace any admin-on-rest component with a component of your own, for instance to display a custom list layout, or a different edit form for a given resource.
+Admin-on-rest was built with customization in mind. You can replace any admin-on-rest component with a component of your own, for instance to display a custom list layout, or a different edit form for a given resource.
 
 Now that you've completed the tutorial, continue reading the [admin-on-rest documentation](http://marmelab.com/admin-on-rest/), and read the [Material UI components documentation](http://www.material-ui.com/#/).

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -222,7 +222,8 @@ When displaying the posts list, the app now fetches related user records, and di
 
 **Tip**: Reference components always pass the data they fetch to a child component, which is responsible for displaying the data.
 
-## Creation and Edition
+## Creation and Editing
+
 
 An admin interface is about displaying remote data, but also about editing and creating. Admin-on-REST provides `<Create>` and `<Edit>` components for that purpose. Add them to the `posts` script:
 
@@ -275,7 +276,7 @@ export const PostCreate = (props) => (
 );
 ```
 
-Notice the additional `<EditButton>` field in the `<PostList>` children: that's what gives access to the post edition page. Also, the `<Edit>` component uses a custom `<PostTitle>` component as title, which shows the way to customize the title for a given page.
+Notice the additional `<EditButton>` field in the `<PostList>` children: that's what gives access to the post editing page. Also, the `<Edit>` component uses a custom `<PostTitle>` component as title, which shows the way to customize the title for a given page.
 
 If you've understood the `<List>` component, the `<Edit>` and `<Create>` components will be no surprise. They are responsible for fetching the record, and displaying the page title. They pass the record down to the `<SimpleForm>` component, which is responsible for the form layout, default values, and validation. Just like `<Datagrid>`, `<SimpleForm>` uses its children to determine the form inputs to display. It expects *input components* as children. `<DisabledInput>`, `<TextInput>`, `<LongTextInput>`, and `<ReferenceInput>` are such inputs.
 
@@ -306,7 +307,7 @@ The form rendered in the create and edit pages is already functional. It issues 
 
 ![post edition form](./img/post-edition.png)
 
-**Note**: JSONPlaceholder is a read-only API; although it seems to accept `POST` and `PUT` requests, it doesn't take into account the creations and editions - that's why, in this particular case, you will see errors after creation, and you won't see your editions after you save them. It's just an artifact of JSONPlaceholder.
+**Note**: JSONPlaceholder is a read-only API; although it seems to accept `POST` and `PUT` requests, it doesn't take into account the creations and edits - that's why, in this particular case, you will see errors after creation, and you won't see your edits after you save them. It's just an artifact of JSONPlaceholder.
 
 ## Deletion
 
@@ -324,7 +325,7 @@ const App = () => (
 );
 ```
 
-In the edition view, a new "delete" button appears. And you can also use the `<DeleteButton>` as a field in the list.
+In the edit view, a new "delete" button appears. And you can also use the `<DeleteButton>` as a field in the list.
 
 ![post deletion view](./img/post-deletion.png)
 
@@ -690,6 +691,6 @@ const App = () => (
 
 ## Conclusion
 
-Admin-on-rest was build with customization in mind. You can replace any admin-on-rest component with a component of your own, for instance to display a custom list layout, or a different edition form for a given resource.
+Admin-on-rest was build with customization in mind. You can replace any admin-on-rest component with a component of your own, for instance to display a custom list layout, or a different edit form for a given resource.
 
 Now that you've completed the tutorial, continue reading the [admin-on-rest documentation](http://marmelab.com/admin-on-rest/), and read the [Material UI components documentation](http://www.material-ui.com/#/).

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,7 +45,7 @@
                                     <a href="#relationships">Relationships</a>
                                 </li>
                                 <li class="chapter">
-                                    <a href="#creation-and-edition">Creation and Edition</a>
+                                    <a href="#creation-and-edition">Creation and Editing</a>
                                 </li>
                                 <li class="chapter">
                                     <a href="#deletion">Deletion</a>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,7 +45,7 @@
                                     <a href="#relationships">Relationships</a>
                                 </li>
                                 <li class="chapter">
-                                    <a href="#creation-and-edition">Creation and Editing</a>
+                                    <a href="#creation-and-editing">Creation and Editing</a>
                                 </li>
                                 <li class="chapter">
                                     <a href="#deletion">Deletion</a>


### PR DESCRIPTION
I just changed a few instances of the word 'edtion' to 'editing' or 'edit', which I think is clearer (I did not change the link to the image with Edition name).