### PR TITLE
[WIP] Update full-icu to 1.1.3 to support yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "express": "~4.15.2",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-api": "~0.10.4",
-    "full-icu": "~1.0.3",
+    "full-icu": "~1.1.3",
     "ignore-styles": "~5.0.1",
     "mocha": "~3.2.0",
     "react-addons-test-utils": "~15.5.1",


### PR DESCRIPTION
The current version `full-icu@1.0.3` fails to install with `yarn`. This rendered me and perhaps other people unable to use yarn for admin-on-rest. `full-icu@1.1.3` fixes this.

This time without updating `selenium-webdriver` and `chromedriver`.