### PR TITLE
[RFR] Layoutless routes

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -320,10 +320,12 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import Foo from './Foo';
 import Bar from './Bar';
+import Baz from './Baz';
 
 export default [
     <Route exact path="/foo" component={Foo} />,
     <Route exact path="/bar" component={Bar} />,
+    <Route exact path="/baz" component={Baz} noLayout />,
 ];
 ```
 
@@ -346,6 +348,8 @@ export default App;
 ```
 
 Now, when a user browses to `/foo` or `/bar`, the components you defined will appear in the main part of the screen.
+When a user browses to `/baz`, the component will appear outside of the defined Layout, leaving you the freedom
+to design the screen the way you want.
 
 **Tip**: It's up to you to create a [custom menu](#applayout) entry, or custom buttons, to lead to your custom pages.
 

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -23,7 +23,7 @@ const Admin = ({
     children,
     customReducers = {},
     customSagas = [],
-    customRoutes,
+    customRoutes = [],
     dashboard,
     history,
     locale,
@@ -74,12 +74,38 @@ const Admin = ({
                                         theme,
                                     })}
                             />
+                            {customRoutes
+                                .filter(route => route.props.noLayout)
+                                .map((route, index) =>
+                                    <Route
+                                        key={index}
+                                        exact={route.props.exact}
+                                        path={route.props.path}
+                                        render={({ location }) => {
+                                            if (route.props.render) {
+                                                return route.props.render({
+                                                    location,
+                                                    title,
+                                                    theme,
+                                                });
+                                            }
+                                            if (route.props.component) {
+                                                return createElement(
+                                                    route.props.component,
+                                                    { location, title, theme }
+                                                );
+                                            }
+                                        }}
+                                    />
+                                )}
                             <Route
                                 path="/"
                                 render={() =>
                                     createElement(appLayout || DefaultLayout, {
                                         dashboard,
-                                        customRoutes,
+                                        customRoutes: customRoutes.filter(
+                                            route => !route.props.noLayout
+                                        ),
                                         menu: createElement(menu || Menu, {
                                             logout,
                                             resources,


### PR DESCRIPTION
At this time, when using the `customRoutes` prop, the routes are rendered in the default Layout.
While this is the expected behavior, a user might need to add routes which are not rendered inside the default layout (i.e: password forgot dance, or user registration). The only way of doing that is to follow the [custom app tutorial](https://marmelab.com/admin-on-rest/CustomApp.html) which comes at other expenses (maintenance, loss of dev speed). 

At a quick glance on the code, it was pretty easy to add a `layoutlessRoutes` props which are rendered outside of the default Layout. This is the purpose of this PR. Feedbacks are welcome :)