### PR TITLE
[RFR] Fix login form-lock and loader after saga refactoring

### DIFF
--- a/src/mui/auth/Login.js
+++ b/src/mui/auth/Login.js
@@ -67,7 +67,7 @@ class Login extends Component {
     login = (auth) => this.props.userLogin(auth, this.props.location.state ? this.props.location.state.nextPathname : '/');
 
     render() {
-        const { handleSubmit, submitting, theme, translate } = this.props;
+        const { handleSubmit, isLoading, theme, translate } = this.props;
         const muiTheme = getMuiTheme(theme);
         const { primary1Color, accent1Color } = getColorsFromTheme(muiTheme);
         return (
@@ -84,7 +84,7 @@ class Login extends Component {
                                         name="username"
                                         component={renderInput}
                                         floatingLabelText={translate('aor.auth.username')}
-                                        disabled={submitting}
+                                        disabled={isLoading}
                                     />
                                 </div>
                                 <div style={styles.input}>
@@ -93,7 +93,7 @@ class Login extends Component {
                                         component={renderInput}
                                         floatingLabelText={translate('aor.auth.password')}
                                         type="password"
-                                        disabled={submitting}
+                                        disabled={isLoading}
                                     />
                                 </div>
                             </div>
@@ -101,8 +101,8 @@ class Login extends Component {
                                 <RaisedButton
                                     type="submit"
                                     primary
-                                    disabled={submitting}
-                                    icon={submitting && <CircularProgress size={25} thickness={2} />}
+                                    disabled={isLoading}
+                                    icon={isLoading && <CircularProgress size={25} thickness={2} />}
                                     label={translate('aor.auth.sign_in')}
                                     fullWidth
                                 />
@@ -129,6 +129,8 @@ Login.defaultProps = {
     theme: defaultTheme,
 };
 
+const mapStateToProps = state => ({ isLoading: state.admin.loading > 0 })
+
 const enhance = compose(
     translate,
     reduxForm({
@@ -141,7 +143,7 @@ const enhance = compose(
             return errors;
         },
     }),
-    connect(null, { userLogin: userLoginAction }),
+    connect(mapStateToProps, { userLogin: userLoginAction }),
 );
 
 export default enhance(Login);

--- a/src/reducer/loading.js
+++ b/src/reducer/loading.js
@@ -1,12 +1,16 @@
 import { FETCH_START, FETCH_END, FETCH_ERROR, FETCH_CANCEL } from '../actions/fetchActions';
+import { USER_LOGIN_LOADING, USER_LOGIN_SUCCESS, USER_LOGIN_FAILURE } from '../actions/authActions';
 
 export default (previousState = 0, { type }) => {
     switch (type) {
     case FETCH_START:
+    case USER_LOGIN_LOADING:
         return previousState + 1;
     case FETCH_END:
     case FETCH_ERROR:
     case FETCH_CANCEL:
+    case USER_LOGIN_SUCCESS:
+    case USER_LOGIN_FAILURE:
         return Math.max(previousState - 1, 0);
     default:
         return previousState;

--- a/src/reducer/loading.spec.js
+++ b/src/reducer/loading.spec.js
@@ -1,17 +1,21 @@
 import assert from 'assert';
 import { FETCH_START, FETCH_END, FETCH_ERROR, FETCH_CANCEL } from '../actions/fetchActions';
+import { USER_LOGIN_LOADING, USER_LOGIN_SUCCESS, USER_LOGIN_FAILURE } from '../actions/authActions';
 import reducer from './loading';
 
 describe('loading reducer', () => {
     it('should return 0 by default', () => {
         assert.equal(0, reducer(undefined, {}));
     });
-    it('should increase with fetch actions', () => {
+    it('should increase with fetch or auth actions', () => {
         assert.equal(1, reducer(0, { type: FETCH_START }));
+        assert.equal(1, reducer(0, { type: USER_LOGIN_LOADING }));
     });
-    it('should decrease with fetch actions success or failure', () => {
+    it('should decrease with fetch or auth actions success or failure', () => {
         assert.equal(0, reducer(1, { type: FETCH_END }));
         assert.equal(0, reducer(1, { type: FETCH_ERROR }));
         assert.equal(0, reducer(1, { type: FETCH_CANCEL }));
+        assert.equal(0, reducer(1, { type: USER_LOGIN_SUCCESS }));
+        assert.equal(0, reducer(1, { type: USER_LOGIN_FAILURE }));
     });
 });


### PR DESCRIPTION
#394 added functionality for locking the login form and showing a spinner when the user presses *Sign In*. But as you can see [here](https://github.com/marmelab/admin-on-rest/pull/394#discussion_r104874927) this requires the `onSubmit` function to return a `Promise`. This is not the case after using saga for auth side-effects.

So in this PR I attempt to change to `loading reducer` to also work for `auth actions` (not sure if this is appropriate if a separate reducer should be used) and use `loading` instead of redux-form's `submitting` as an indicator.