### PR TITLE
[RFC] Add transformValue on SelectInput

### DIFF
--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -65,13 +65,17 @@ import FieldTitle from '../../util/FieldTitle';
  * The object passed as `options` props is passed to the material-ui <SelectField> component
  */
 export class SelectInput extends Component {
-    /*
-     * Using state to bypass a redux-form comparison but which prevents re-rendering
-     * @see https://github.com/erikras/redux-form/issues/2456
-     */
-    state = {
-        value: this.props.input.value,
-    };
+    constructor(props) {
+        super(props);
+
+        /*
+         * Using state to bypass a redux-form comparison but which prevents re-rendering
+         * @see https://github.com/erikras/redux-form/issues/2456
+         */
+        this.state = {
+            value: props.transformValue(props.input.value),
+        };
+    }
 
     handleChange = (event, index, value) => {
         this.props.input.onChange(value);
@@ -166,6 +170,7 @@ SelectInput.propTypes = {
     source: PropTypes.string,
     translate: PropTypes.func.isRequired,
     translateChoice: PropTypes.bool.isRequired,
+    transformValue: PropTypes.func.isRequired,
 };
 
 SelectInput.defaultProps = {
@@ -176,6 +181,7 @@ SelectInput.defaultProps = {
     optionText: 'name',
     optionValue: 'id',
     translateChoice: true,
+    transformValue: value => value,
 };
 
 export default translate(SelectInput);


### PR DESCRIPTION
Please consider this PR as an RFC as I am quite unsure of the proposed feature (maybe there's another way of achieving what I need) and if this is the correct solution, it needs to be expanded to other components before getting merged. 

In order to understand why I propose this change, you need to understand the format of my API. Here is a quick explanation.

In the project I work on, documents are received this way on a GET request: 
```json
{ 
   "@id": "/books/1",
   "title": "My Book title",
   "author": {
     "@id": "/author/3",
     "name": "John Doe"
   }
}
```

When received, documents are processed in order to be compatible with the AOR format (and to be able to have nice urls). After processing, the document looks like that:

```json
{ 
   "@id": "/books/1",
   "id": 1,
   "title": "My Book title",
   "author": {
     "@id": "/authors/3",
     "id": 3,
     "name": "John Doe"
   }
}
```

When creating or editing a resource, the document needs to be look like that:

```json
{ 
   "title": "My Book title",
   "author": "/authors/5"
}
```

`/authors/5` and `/books/1/` are IRIs and are needed by the backend in order to deserialize and populate data correctly (The backend is an https://github.com/api-platform/core one).

## 1. The create operation

The Create operation works well, I just need to create and use this AOR form.

```jsx
<Create {...props}
<SimpleForm>
   <TextInput source="title" />
   <ReferenceInput allowEmpty={true} source="author" reference="authors" label="Author">
       <SelectInput optionValue="@id" />
   </ReferenceInput>
</SimpleForm>
</Create>
```

In this Form, the `ReferenceInput` works as intended.

## 2. The Edit operation

This is where there is a catch. If I use the same form as the Create operation, my `ReferenceInput.SelectInput` is **not** populated. Why? Because the initial value is an object instead of a scalar value (See the first JSON document). I need to transform the object value into the correct format in order for the SelectInput to be populated with the correct value. With the quick fix I propose, here is what my Edit form looks like:

```jsx
import isPlainObject from 'lodash.isplainobject';
<Edit>
<SimpleForm>
     <TextInput source="title" />
     <ReferenceInput allowEmpty={true} source="author" reference="authors" label="Author">
         <SelectInput optionValue="@id" transformValue={(value) => {return isPlainObject(value) ? value['@id'] : value}} />
      </ReferenceInput>
</SimpleForm>
</Edit>
```

Is that the right solution to this problem? Am I missing something? 