### PR TITLE
[RFR] Alternative to #925 – Fix SelectInput initial value when an object is passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash.debounce": "~4.0.8",
     "lodash.defaultsdeep": "~4.6.0",
     "lodash.get": "~4.4.2",
+    "lodash.isplainobject": "^4.0.6",
     "lodash.set": "~4.3.2",
     "material-ui": "~0.17.4",
     "material-ui-chip-input": "~0.13.5",

--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -6,6 +6,7 @@ import MenuItem from 'material-ui/MenuItem';
 
 import translate from '../../i18n/translate';
 import FieldTitle from '../../util/FieldTitle';
+import isPlainObject from 'lodash.isplainobject';
 
 /**
  * An Input component for a select box, using an array of objects for the options
@@ -65,13 +66,19 @@ import FieldTitle from '../../util/FieldTitle';
  * The object passed as `options` props is passed to the material-ui <SelectField> component
  */
 export class SelectInput extends Component {
-    /*
-     * Using state to bypass a redux-form comparison but which prevents re-rendering
-     * @see https://github.com/erikras/redux-form/issues/2456
-     */
-    state = {
-        value: this.props.input.value,
-    };
+    constructor(props) {
+        super(props);
+
+        /*
+         * Using state to bypass a redux-form comparison but which prevents re-rendering
+         * @see https://github.com/erikras/redux-form/issues/2456
+         */
+        this.state = {
+            value: isPlainObject(props.input.value)
+                ? get(props.input.value, props.optionValue)
+                : props.input.value,
+        };
+    }
 
     handleChange = (event, index, value) => {
         this.props.input.onChange(value);


### PR DESCRIPTION
This fix uses the `optionValue` property to access the object passed to `SelectInput` **if and only if** the value is an object (which I think is often the case when dealing with reference).

This is another way to fix the problem I describe in #925. I think this is the best solution of the two. What do you think?
