### PR TITLE
[RFR] [BC Break] Review FileInput handling when allowing only a single file

### DIFF
--- a/src/mui/input/FileInput.js
+++ b/src/mui/input/FileInput.js
@@ -76,7 +76,12 @@ export class FileInput extends Component {
             : [...files.map(this.transformFile)];
 
         this.setState({ files: updatedFiles });
-        this.props.input.onChange(updatedFiles);
+
+        if (this.props.multiple) {
+            this.props.input.onChange(updatedFiles);
+        } else {
+            this.props.input.onChange(updatedFiles[0]);
+        }
     };
 
     onRemove = file => () => {
@@ -85,7 +90,12 @@ export class FileInput extends Component {
         );
 
         this.setState({ files: filteredFiles });
-        this.props.input.onChange(filteredFiles);
+
+        if (this.props.multiple) {
+            this.props.input.onChange(filteredFiles);
+        } else {
+            this.props.input.onChange(null);
+        }
     };
 
     // turn a browser dropped file structure into expected structure

--- a/src/mui/input/FileInput.spec.js
+++ b/src/mui/input/FileInput.spec.js
@@ -29,52 +29,6 @@ describe('<FileInput />', () => {
         assert.equal(wrapper.find('Dropzone').length, 1);
     });
 
-    it('should display correct label depending multiple property', () => {
-        const test = (multiple, expectedLabel) => {
-            const wrapper = shallow(
-                <FileInput
-                    multiple={multiple}
-                    input={{
-                        value: {
-                            picture: null,
-                        },
-                    }}
-                    translate={x => x}
-                    source="picture"
-                />
-            );
-
-            assert.equal(wrapper.find('Dropzone p').text(), expectedLabel);
-        };
-
-        test(false, 'aor.input.file.upload_single');
-        test(true, 'aor.input.file.upload_several');
-    });
-
-    it('should display correct custom label', () => {
-        const test = expectedLabel => {
-            const wrapper = shallow(
-                <FileInput
-                    placeholder={expectedLabel}
-                    input={{
-                        value: {
-                            picture: null,
-                        },
-                    }}
-                    translate={x => x}
-                    source="picture"
-                />
-            );
-
-            assert.ok(wrapper.find('Dropzone').contains(expectedLabel));
-        };
-        const CustomLabel = () => <div>Custom label</div>;
-
-        test('custom label');
-        test(<h1>Custom label</h1>);
-        test(<CustomLabel />);
-    });
-
     it('should correctly update upon drop when allowing a single file', () => {
         const onChange = spy();
 
@@ -93,7 +47,9 @@ describe('<FileInput />', () => {
 
         wrapper.instance().onDrop([{ preview: 'new_b64_picture' }]);
 
-        assert.deepEqual(onChange.args[0][0], [{ preview: 'new_b64_picture' }]);
+        assert.deepEqual(onChange.args[0][0], {
+            preview: 'new_b64_picture',
+        });
     });
 
     it('should correctly update upon removal when allowing a single file', () => {
@@ -113,7 +69,7 @@ describe('<FileInput />', () => {
         );
 
         wrapper.instance().onRemove({ src: 'b64_picture' })();
-        assert.deepEqual(onChange.args[0][0], []);
+        assert.deepEqual(onChange.args[0][0], null);
     });
 
     it('should correctly update upon drop when allowing multiple files', () => {
@@ -164,6 +120,52 @@ describe('<FileInput />', () => {
         wrapper.instance().onRemove({ src: 'another_b64_picture' })();
 
         assert.deepEqual(onChange.args[0][0], [{ src: 'b64_picture' }]);
+    });
+
+    it('should display correct label depending multiple property', () => {
+        const test = (multiple, expectedLabel) => {
+            const wrapper = shallow(
+                <FileInput
+                    multiple={multiple}
+                    input={{
+                        value: {
+                            picture: null,
+                        },
+                    }}
+                    translate={x => x}
+                    source="picture"
+                />
+            );
+
+            assert.equal(wrapper.find('Dropzone p').text(), expectedLabel);
+        };
+
+        test(false, 'aor.input.file.upload_single');
+        test(true, 'aor.input.file.upload_several');
+    });
+
+    it('should display correct custom label', () => {
+        const test = expectedLabel => {
+            const wrapper = shallow(
+                <FileInput
+                    placeholder={expectedLabel}
+                    input={{
+                        value: {
+                            picture: null,
+                        },
+                    }}
+                    translate={x => x}
+                    source="picture"
+                />
+            );
+
+            assert.ok(wrapper.find('Dropzone').contains(expectedLabel));
+        };
+        const CustomLabel = () => <div>Custom label</div>;
+
+        test('custom label');
+        test(<h1>Custom label</h1>);
+        test(<CustomLabel />);
     });
 
     describe('Image Preview', () => {


### PR DESCRIPTION
This PR introduces a breaking change:

When allowing only a single file, `onChange` will be called with a single file (instead of an array containing a single file).