### PR TITLE
[RFR] Integrate permissions into core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-unit-watch: ## launch unit tests and watch for changes
 		--watch \
 		'./src/**/*.spec.js'
 
-test-e2e: example_install ## launch end-to-end tests
+test-e2e: ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \
 		echo 'Building example code (call "make build=false test-e2e" to skip the build)...'; \
 		cd example && ./node_modules/.bin/webpack; \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-unit-watch: ## launch unit tests and watch for changes
 		--watch \
 		'./src/**/*.spec.js'
 
-test-e2e: ## launch end-to-end tests
+test-e2e: example_install ## launch end-to-end tests
 	@if [ "$(build)" != "false" ]; then \
 		echo 'Building example code (call "make build=false test-e2e" to skip the build)...'; \
 		cd example && ./node_modules/.bin/webpack; \

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -312,4 +312,4 @@ export default withRouter(MyPage);
 ```
 {% endraw %}
 
-The `<Restricted>` component calls the `authClient` function with `AUTH_CHECK` and `authParams`. If the response is a fulfilled promise, the child component is rendered. If the response is a rejected promise, `<Restricted>` redirects to the login form. Upon successful login, the user is redirected to the initial location (that's why it's necessary to get the location from the router). 
+The `<Restricted>` component calls the `authClient` function with `AUTH_CHECK` and `authParams`. If the response is a fulfilled promise, the child component is rendered. If the response is a rejected promise, `<Restricted>` redirects to the login form. Upon successful login, the user is redirected to the initial location (that's why it's necessary to get the location from the router).

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -95,7 +95,7 @@ Note that the function returns an array of React elements. This is required to a
 
 ## Restricting Access To Fields And Inputs
 
-You might want to display some fields, inputs or filters only to users with specific permissions. It's possible to do so the same way you can restrict access to resources.
+You might want to display some fields, inputs or filters only to users with specific permissions. Just like for resources, pass a function as only child of the component, instead of a set of Fields and Inputs.
 
 Here's an example inside a `Create` view with a `SimpleForm` and a custom `Toolbar`:
 

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -132,7 +132,7 @@ export const UserCreate = ({ ...props }) =>
 ```
 {% endraw %}
 
-This also works inside an `Edition` view with a `TabbedForm` and you can hide a `FormTab` completely:
+This also works inside an `Edition` view with a `TabbedForm`, and you can hide a `FormTab` completely:
 
 {% raw %}
 ```jsx

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -91,7 +91,7 @@ It's possible to restrict access to resources or their views inside the `Admin` 
 
 Note that the function returns an array of React elements. This is required to avoid having to wrap them in a container element which would prevent the `Admin` from working.
 
-**Tip** Even if that's possible, be careful when completely excluding a resource (like we did with the `categories` in this example) as it will prevent you to reference them in the other resources views too.
+**Tip** Even if that's possible, be careful when completely excluding a resource (like with the `categories` resource in this example) as it will prevent you to reference them in the other resources views too.
 
 ## Restricting Access To Fields And Inputs
 

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -7,7 +7,7 @@ title: "Authorization"
 
 Some applications may require to determine what level of access a particular authenticated user should have to secured resources. Since there are many different possible strategies (single role, multiple roles or rights, etc.), admin-on-rest simply provides hooks to execute your own authorization code.
 
-By default, an admin-on-rest app doesn't require authorization. However, if needed, it will relies on the `authClient` introduced in the [Authentication](./Authentication.html) section.
+By default, an admin-on-rest app doesn't require authorization. However, if needed, it will rely on the `authClient` introduced in the [Authentication](./Authentication.html) section.
 
 ## Configuring the Auth Client
 

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -91,7 +91,7 @@ It's possible to restrict access to resources or their views inside the `Admin` 
 
 Note that the function returns an array of React elements. This is required to avoid having to wrap them in a container element which would prevent the `Admin` from working.
 
-**Tip** Even if that's possible, be careful when completely excluding a resource (like with the `categories` resource in this example) as it will prevent you to reference them in the other resources views too.
+**Tip** Even if that's possible, be careful when completely excluding a resource (like with the `categories` resource in this example) as it will prevent you to reference them in the other resource views, too.
 
 ## Restricting Access To Fields And Inputs
 

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -13,7 +13,7 @@ By default, an admin-on-rest app doesn't require authorization. However, if need
 
 A call to the `authClient` with the `AUTH_GET_PERMISSIONS` type will be made each time a component requires to check the user's permissions.
 
-Following is an example which store the user's role upon authentication and return it for the permissions check:
+Following is an example where the `authClient` stores the user's role upon authentication, and returns it when called for a permissions check:
 
 ```jsx
 // in src/authClient.js

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -1,0 +1,286 @@
+---
+layout: default
+title: "Authorization"
+---
+
+# Authorization
+
+Some applications may require to determine what level of access a particular authenticated user should have to secured resources. Since there are many different possible strategies (single role, multiple roles or rights, etc.), admin-on-rest simply provides hooks to execute your own authorization code.
+
+By default, an admin-on-rest app doesn't require authorization. However, if needed, it will relies on the `authClient` introduced in the [Authentication](./Authentication.html) section.
+
+## Configuring the Auth Client
+
+A call to the `authClient` with the `AUTH_GET_PERMISSIONS` type will be made each time something requires to check the user's permissions.
+
+Following is an example which store the user's role upon authentication and return it for the permissions check:
+
+```jsx
+// in src/authClient.js
+import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from 'admin-on-rest';
+import decodeJwt from 'jwt-decode';
+
+export default (type, params) => {
+    if (type === AUTH_LOGIN) {
+        const { username, password } = params;
+        const request = new Request('https://mydomain.com/authenticate', {
+            method: 'POST',
+            body: JSON.stringify({ username, password }),
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+        })
+        return fetch(request)
+            .then(response => {
+                if (response.status < 200 || response.status >= 300) {
+                    throw new Error(response.statusText);
+                }
+                return response.json();
+            })
+            .then(({ token }) => {
+                const decodedToken = decodeJwt(token);
+                localStorage.setItem('token', token);
+                localStorage.setItem('role', decodedToken.role);
+            });
+    }
+    if (type === AUTH_LOGOUT) {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
+        return Promise.resolve();
+    }
+    if (type === AUTH_ERROR) {
+        // ...
+    }
+    if (type === AUTH_CHECK) {
+        return localStorage.getItem('token') ? Promise.resolve() : Promise.reject();
+    }
+    if (type === AUTH_GET_PERMISSIONS) {
+        const role = localStorage.getItem('role');
+        return Promise.resolve(role);
+    }
+
+    return Promise.reject('Unkown method');
+};
+```
+
+## Restricting Access To Resources or Views
+
+It's possible to restrict access to resources or their views inside the `Admin` component. To do so, you must specify a function as the `Admin` only child. This function will be called with the permissions returned by the `authClient`.
+
+{% raw %}
+```jsx
+<Admin
+    restClient={restClient}
+    authClient={authClient}
+>
+    {permissions => [
+        // Restrict access to the edit and remove views to admin only
+        <Resource
+            name="customers"
+            list={VisitorList}
+            edit={permissions === 'admin' ? VisitorEdit : null}
+            remove={permissions === 'admin' ? VisitorDelete : null}
+            icon={VisitorIcon}
+        />,
+        // Only include the categories resource for admin users
+        permissions === 'admin'
+            ? <Resource name="categories" list={CategoryList} edit={CategoryEdit} remove={Delete} icon={CategoryIcon} />
+            : null,
+    ]}
+</Admin>
+```
+{% endraw %}
+
+Note that the function returns an array of React elements. This is required to avoid having to wrap them in a container element which would prevent the `Admin` from working.
+
+**Tip** Even if that's possible, be careful when completely excluding a resource (like we did with the `categories` in this example) as it will prevent you to reference them in the other resources views too.
+
+## Restricting Access To Fields And Inputs
+
+You might want to display some fields, inputs or filters only to users with specific permissions. It's possible to do so the same way you can restrict access to resources.
+
+Here's an example inside a `Create` view with a `SimpleForm` and a custom `Toolbar`:
+
+{% raw %}
+```jsx
+const UserCreateToolbar = ({ permissions, ...props }) =>
+    <Toolbar {...props}>
+        <SaveButton
+            label="user.action.save_and_show"
+            redirect="show"
+            submitOnEnter={true}
+        />
+        {permissions === 'admin' &&
+            <SaveButton
+                label="user.action.save_and_add"
+                redirect={false}
+                submitOnEnter={false}
+                raised={false}
+            />}
+    </Toolbar>;
+
+export const UserCreate = ({ ...props }) =>
+    <Create {...props}>
+        {permissions =>
+            <SimpleForm
+                toolbar={<UserCreateToolbar permissions={permissions} />}
+                defaultValue={{ role: 'user' }}
+            >
+                <TextInput source="name" validate={[required]} />
+                {permissions === 'admin' &&
+                    <TextInput source="role" validate={[required]} />}
+            </SimpleForm>}
+    </Create>;
+```
+{% endraw %}
+
+This also works inside an `Edition` view with a `TabbedForm` and you can hide a `FormTab` completely:
+
+{% raw %}
+```jsx
+export const UserEdit = ({ ...props }) =>
+    <Edit title={<UserTitle />} {...props}>
+        {permissions =>
+            <TabbedForm defaultValue={{ role: 'user' }}>
+                <FormTab label="user.form.summary">
+                    {permissions === 'admin' && <DisabledInput source="id" />}
+                    <TextInput source="name" validate={required} />
+                </FormTab>
+                {permissions === 'admin' &&
+                    <FormTab label="user.form.security">
+                        <TextInput source="role" validate={required} />
+                    </FormTab>}
+            </TabbedForm>}
+    </Edit>;
+```
+{% endraw %}
+
+What about the `List` view, the `DataGrid`, `SimpleList` and `Filter` components ?
+
+{% raw %}
+```jsx
+const UserFilter = ({ ...props }) =>
+    <Filter {...props}>
+        {permissions => [
+            <TextInput
+                key="user.list.search"
+                label="user.list.search"
+                source="q"
+                alwaysOn
+            />,
+            <TextInput key="name" source="name" />,
+            permissions === 'admin' ? <TextInput source="role" /> : null,
+        ]}
+    </Filter>;
+
+export const UserList = ({ ...props }) =>
+    <List
+        {...props}
+        filters={<UserFilter />}
+        sort={{ field: 'name', order: 'ASC' }}
+    >
+        {permissions =>
+            <Responsive
+                small={
+                    <SimpleList
+                        primaryText={record => record.name}
+                        secondaryText={record =>
+                            permissions === 'admin' ? record.role : null}
+                    />
+                }
+                medium={
+                    <Datagrid>
+                        <TextField source="id" />
+                        <TextField source="name" />
+                        {permissions === 'admin' && <TextField source="role" />}
+                        {permissions === 'admin' && <EditButton />}
+                        <ShowButton />
+                    </Datagrid>
+                }
+            />}
+    </List>;
+```
+{% endraw %}
+
+Note that for the `Filter` component,  the function returns an array of React elements. This is required to avoid having to wrap them in a container element which would prevent the `Filter` from working.
+
+## Restricting Access To Content In Custom Pages or Menus
+
+What if you want to check the permissions inside a [Dashboard](./Admin.html#dashboard), a [custom page](http://127.0.0.1:4000/Admin.html#customroutes) or a [custom menu](./Admin.html#menu) ? Admin-on-rest provides two components for that: `WithPermissions` and `SwitchPermissions`.
+
+### WithPermissions
+
+The `WithPermissions` component will only display its content if the user has the required permissions. Let's see an example with a custom menu where a custom page link should only be presented to admins:
+
+{% raw %}
+```jsx
+// in src/Menu.js
+import React from 'react';
+import { MenuItemLink, WithPermissions } from 'admin-on-rest';
+
+export default ({ resources, onMenuTap, logout }) => (
+    <div>
+        <MenuItemLink to="/posts" primaryText="Posts" onTouchTap={onMenuTap} />
+        <MenuItemLink to="/comments" primaryText="Comments" onTouchTap={onMenuTap} />
+        <WithPermissions value="admin">
+            <MenuItemLink to="/custom-route" primaryText="Miscellaneous" onTouchTap={onMenuTap} />
+        </WithPermissions>
+        {logout}
+    </div>
+);
+```
+{% endraw %}
+
+The `WithPermission` component requires either a `value` with the permissions to check (could be a role, an array of roles, etc) or a `resolve` function.
+
+An additional `exact` prop may be specified depending on your requirements. It determines whether the user must have **all** the required permissions or only some. If `false`, the default, we'll only check if the user has at least one of the required permissions.
+
+You may bypass the default logic by specifying a function as the `resolve` prop. This function may return `true` or `false` directly or a promise resolving to either `true` or `false`. It will be called with an object having the following properties:
+
+- `permissions`: the result of the `authClient` call.
+- `value`: the value of the `value` prop if specified
+- `exact`: the value of the `exact` prop if specified
+
+An optional `loading` prop may be specified on the `WithPermissions` component to pass a component to display while checking for permissions. It defaults to `null`.
+
+### SwitchPermissions
+
+The `SwitchPermissions` component will display one of its `Permission` children depending on the permissions returned by the `authClient`. It accepts two optional props:
+
+- `loading`: A component to display while checking for permissions. Defaults to `null`.
+- `notFound`: A component to display when no match was found while checking the permissions. Default to `null`.
+
+The `Permission` component requires either a `value` with the permissions to check (could be a role, an array of roles, etc) or a `resolve` function.
+
+An additional `exact` prop may be specified depending on your requirements. It determines whether the user must have **all** the required permissions or only some. If `false`, the default, we'll only check if the user has at least one of the required permissions.
+
+You may bypass the default logic by specifying a function as the `resolve` prop. This function may return `true` or `false` directly or a promise resolving to either `true` or `false`. It will be called with an object having the following properties:
+
+- `permissions`: the result of the `authClient` call.
+- `value`: the value of the `value` prop if specified
+- `exact`: the value of the `exact` prop if specified
+
+If multiple `Permission` match, only the first one will be displayed.
+
+Here's an example inside a `DashBoard`:
+
+```jsx
+// in src/Dashboard.js
+import React from 'react';
+import BenefitsSummary from './BenefitsSummary';
+import BenefitsDetailsWithSensitiveData from './BenefitsDetailsWithSensitiveData';
+import { ViewTitle } from 'admin-on-rest/lib/mui';
+
+export default () => (
+    <Card>
+        <ViewTitle title="Dashboard" />
+
+        <SwitchPermissions>
+            <Permission value="associate">
+                <BenefitsSummary />
+            </Permission>
+            <Permission value="boss">
+                <BenefitsDetailsWithSensitiveData />
+            </Permission>
+        </SwitchPermissions>
+    </Card>
+);
+```

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -11,7 +11,7 @@ By default, an admin-on-rest app doesn't require authorization. However, if need
 
 ## Configuring the Auth Client
 
-A call to the `authClient` with the `AUTH_GET_PERMISSIONS` type will be made each time something requires to check the user's permissions.
+A call to the `authClient` with the `AUTH_GET_PERMISSIONS` type will be made each time a component requires to check the user's permissions.
 
 Following is an example which store the user's role upon authentication and return it for the permissions check:
 

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -153,7 +153,7 @@ export const UserEdit = ({ ...props }) =>
 ```
 {% endraw %}
 
-What about the `List` view, the `DataGrid`, `SimpleList` and `Filter` components ?
+What about the `List` view, the `DataGrid`, `SimpleList` and `Filter` components? It works there, too.
 
 {% raw %}
 ```jsx

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -204,25 +204,25 @@ Note that for the `Filter` component,  the function returns an array of React el
 
 ## Restricting Access To Content In Custom Pages or Menus
 
-What if you want to check the permissions inside a [Dashboard](./Admin.html#dashboard), a [custom page](http://127.0.0.1:4000/Admin.html#customroutes) or a [custom menu](./Admin.html#menu) ? Admin-on-rest provides two components for that: `WithPermissions` and `SwitchPermissions`.
+What if you want to check the permissions inside a [Dashboard](./Admin.html#dashboard), a [custom page](./Admin.html#customroutes) or a [custom menu](./Admin.html#menu) ? Admin-on-rest provides two components for that: `WithPermission` and `SwitchPermissions`.
 
-### WithPermissions
+### WithPermission
 
-The `WithPermissions` component will only display its content if the user has the required permissions. Let's see an example with a custom menu where a custom page link should only be presented to admins:
+The `WithPermission` component will only display its content if the user has the required permissions. Let's see an example with a custom menu where a custom page link should only be presented to admins:
 
 {% raw %}
 ```jsx
 // in src/Menu.js
 import React from 'react';
-import { MenuItemLink, WithPermissions } from 'admin-on-rest';
+import { MenuItemLink, WithPermission } from 'admin-on-rest';
 
 export default ({ resources, onMenuTap, logout }) => (
     <div>
         <MenuItemLink to="/posts" primaryText="Posts" onTouchTap={onMenuTap} />
         <MenuItemLink to="/comments" primaryText="Comments" onTouchTap={onMenuTap} />
-        <WithPermissions value="admin">
+        <WithPermission value="admin">
             <MenuItemLink to="/custom-route" primaryText="Miscellaneous" onTouchTap={onMenuTap} />
-        </WithPermissions>
+        </WithPermission>
         {logout}
     </div>
 );
@@ -239,7 +239,9 @@ You may bypass the default logic by specifying a function as the `resolve` prop.
 - `value`: the value of the `value` prop if specified
 - `exact`: the value of the `exact` prop if specified
 
-An optional `loading` prop may be specified on the `WithPermissions` component to pass a component to display while checking for permissions. It defaults to `null`.
+An optional `loading` prop may be specified on the `WithPermission` component to pass a component to display while checking for permissions. It defaults to `null`.
+
+**Tip**: Do not use the `WithPermission` component inside the others admin-on-rest components. It is only meant to be used in custom pages or components.
 
 ### SwitchPermissions
 
@@ -284,3 +286,6 @@ export default () => (
     </Card>
 );
 ```
+
+**Tip**: Do not use the `SwitchPermissions` component inside the others admin-on-rest components. It is only meant to be used in custom pages or components.
+

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -84,6 +84,7 @@ title: "Reference"
 * [`<SimpleList>`](./List.html#the-simplelist-component)
 * [`<SimpleShowLayout>`](./Show.html#the-simpleshowlayout-component)
 * [`<SingleFieldList>`](./List.html#the-singlefieldlist-component)
+* [`<SwitchPermissions>`](./Authorization.html#switchpermissions)
 * `<Tab>`
 * [`<TabbedForm>`](./CreateEdit.html#the-tabbedform-component)
 * `<TabbedShowLayout>`
@@ -93,5 +94,6 @@ title: "Reference"
 * `<Toolbar>`
 * [`<UrlField>`](./Fields.html#urlfield)
 * `<ViewTitle>`
+* [`<WithPermission>`](./Authorization.html#withpermission)
 
 </div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -403,9 +403,28 @@
                             </li>
                         </ul>
                     </li>
+                    <li class="chapter {% if page.path == 'Authorization.md' %}active{% endif %}">
+                        <a href="./Authorization.html">
+                                <b>12.</b> Authorization
+                            </a>
+                        <ul class="articles" {% if page.path !='Authorization.md' %}style="display:none" {% endif %}>
+                            <li class="chapter">
+                                <a href="#configuring-the-auth-client">Configuring the Auth Client</a>
+                            </li>
+                            <li class="chapter">
+                                <a href="#restricting_access_to_resources_or_views">Restricting Access To Resources or Views</a>
+                            </li>
+                            <li class="chapter">
+                                <a href="#restricting_access_to_fields_and_inputs">Restricting Access To Fields And Inputs</a>
+                            </li>
+                            <li class="chapter">
+                                <a href="#restricting_access_to_content_in_custom_pages_or_menus">Restricting Access To Content In Custom Pages or Menus</a>
+                            </li>
+                        </ul>
+                    </li>
                     <li class="chapter {% if page.path == 'Theming.md' %}active{% endif %}">
                         <a href="./Theming.html">
-                                <b>12.</b> Theming
+                                <b>13.</b> Theming
                             </a>
                         <ul class="articles" {% if page.path !='Theming.md' %}style="display:none" {% endif %}>
                             <li class="chapter">
@@ -431,7 +450,7 @@
 
                     <li class="chapter {% if page.path == 'Actions.md' %}active{% endif %}">
                         <a href="./Actions.html">
-                                <b>13.</b> Writing Actions
+                                <b>14.</b> Writing Actions
                             </a>
                         <ul class="articles" {% if page.path !='Actions.md' %}style="display:none" {% endif %}>
                             <li class="chapter">
@@ -457,7 +476,7 @@
 
                     <li class="chapter {% if page.path == 'Translation.md' %}active{% endif %}">
                         <a href="./Translation.html">
-                                <b>14.</b> Translation
+                                <b>15.</b> Translation
                             </a>
                         <ul class="articles" {% if page.path !='Translation.md' %}style="display:none" {% endif %}>
                             <li class="chapter">
@@ -492,25 +511,25 @@
 
                     <li class="chapter {% if page.path == 'CustomApp.md' %}active{% endif %}">
                         <a href="./CustomApp.html">
-                                <b>15.</b> Including in Another App
+                                <b>16.</b> Including in Another App
                             </a>
                     </li>
 
                     <li class="chapter {% if page.path == 'Reference.md' %}active{% endif %}">
                         <a href="./Reference.html">
-                                <b>16.</b> Reference
+                                <b>17.</b> Reference
                             </a>
                     </li>
 
                     <li class="chapter {% if page.path == 'FAQ.md' %}active{% endif %}">
                         <a href="./FAQ.html">
-                                <b>17.</b> FAQ
+                                <b>18.</b> FAQ
                             </a>
                     </li>
 
                     <li class="chapter {% if page.path == 'Ecosystem.md' %}active{% endif %}">
                         <a href="./Ecosystem.html">
-                                <b>18.</b> Ecosystem
+                                <b>19.</b> Ecosystem
                             </a>
                     </li>
                 </ul>

--- a/e2e/pages/CreatePage.js
+++ b/e2e/pages/CreatePage.js
@@ -5,6 +5,7 @@ export default url => driver => ({
         appLoader: By.css('.app-loader'),
         input: (name, type = 'input') =>
             By.css(`.create-page ${type}[name='${name}']`),
+        inputs: By.css(`.aor-input`),
         submitButton: By.css(".create-page button[type='submit']"),
         submitAndAddButton: By.css(
             ".create-page form>div:last-child button[type='button']"
@@ -65,6 +66,25 @@ export default url => driver => ({
         return driver
             .findElement(this.elements.input(name, type))
             .getAttribute('value');
+    },
+
+    getFields() {
+        return driver
+            .findElements(this.elements.inputs)
+            .then(fields =>
+                Promise.all(
+                    fields.map(field =>
+                        field
+                            .getAttribute('class')
+                            .then(classes =>
+                                classes
+                                    .replace('aor-input-', '')
+                                    .replace('aor-input', '')
+                                    .trim()
+                            )
+                    )
+                )
+            );
     },
 
     submit() {

--- a/e2e/pages/EditPage.js
+++ b/e2e/pages/EditPage.js
@@ -4,6 +4,8 @@ export default url => driver => ({
     elements: {
         appLoader: By.css('.app-loader'),
         input: name => By.css(`.edit-page input[name='${name}']`),
+        inputs: By.css(`.aor-input`),
+        tabs: By.css(`.form-tab`),
         submitButton: By.css(".edit-page button[type='submit']"),
         tab: index => By.css(`button.form-tab:nth-of-type(${index})`),
         title: By.css('.title'),
@@ -40,6 +42,31 @@ export default url => driver => ({
     getInputValue(name) {
         const input = driver.findElement(this.elements.input(name));
         return input.getAttribute('value');
+    },
+
+    getFields() {
+        return driver
+            .findElements(this.elements.inputs)
+            .then(fields =>
+                Promise.all(
+                    fields.map(field =>
+                        field
+                            .getAttribute('class')
+                            .then(classes =>
+                                classes
+                                    .replace('aor-input-', '')
+                                    .replace('aor-input', '')
+                                    .trim()
+                            )
+                    )
+                )
+            );
+    },
+
+    getTabs() {
+        return driver
+            .findElements(this.elements.tabs)
+            .then(tabs => Promise.all(tabs.map(tab => tab.getText())));
     },
 
     setInputValue(name, value, clearPreviousValue = true) {

--- a/e2e/pages/ListPage.js
+++ b/e2e/pages/ListPage.js
@@ -6,6 +6,8 @@ export default url => driver => ({
         appLoader: By.css('.app-loader'),
         displayedRecords: By.css('.displayed-records'),
         filter: name => By.css(`.filter-field[data-source='${name}'] input`),
+        filterMenuItems: By.css(`.new-filter-item`),
+        menuItems: By.css(`[role=menuitem`),
         filterMenuItem: source =>
             By.css(`.new-filter-item[data-key="${source}"]`),
         hideFilterButton: source =>
@@ -14,6 +16,7 @@ export default url => driver => ({
         pageNumber: n => By.css(`.page-number[data-page='${n}']`),
         previousPage: By.css('.previous-page'),
         recordRows: By.css('.datagrid-body tr'),
+        datagridHeaders: By.css('th'),
         title: By.css('.title'),
         logout: By.css('.logout'),
     },
@@ -50,6 +53,35 @@ export default url => driver => ({
         return driver
             .findElements(this.elements.recordRows)
             .then(rows => rows.length);
+    },
+
+    getColumns() {
+        return driver
+            .findElements(this.elements.datagridHeaders)
+            .then(ths => Promise.all(ths.map(th => th.getText())));
+    },
+
+    getResources() {
+        return driver
+            .findElements(this.elements.menuItems)
+            .then(menuItems =>
+                Promise.all(menuItems.map(menuItem => menuItem.getText()))
+            );
+    },
+
+    getAvailableFilters() {
+        const addFilterButton = driver.findElement(
+            this.elements.addFilterButton
+        );
+        addFilterButton.click();
+        driver.sleep(500); // wait until the dropdown animation ends
+        driver.wait(until.elementLocated(this.elements.filterMenuItems));
+
+        return driver
+            .findElements(this.elements.filterMenuItems)
+            .then(filters =>
+                Promise.all(filters.map(filter => filter.getText()))
+            );
     },
 
     getNbPagesText() {

--- a/e2e/pages/ShowPage.js
+++ b/e2e/pages/ShowPage.js
@@ -1,9 +1,10 @@
 import { By, until } from 'selenium-webdriver';
 
-export default url => driver => ({
+export default (url, initialField = 'title') => driver => ({
     elements: {
         appLoader: By.css('.app-loader'),
         field: name => By.css(`.aor-field-${name} > div > span`),
+        fields: By.css(`.aor-field`),
     },
 
     navigate() {
@@ -12,7 +13,9 @@ export default url => driver => ({
     },
 
     waitUntilVisible() {
-        return driver.wait(until.elementLocated(this.elements.field('title')));
+        return driver.wait(
+            until.elementLocated(this.elements.field(initialField))
+        );
     },
 
     waitUntilDataLoaded() {
@@ -36,5 +39,24 @@ export default url => driver => ({
 
     getValue(name) {
         return driver.findElement(this.elements.field(name)).getText();
+    },
+
+    getFields() {
+        return driver
+            .findElements(this.elements.fields)
+            .then(fields =>
+                Promise.all(
+                    fields.map(field =>
+                        field
+                            .getAttribute('class')
+                            .then(classes =>
+                                classes
+                                    .replace('aor-field-', '')
+                                    .replace('aor-field', '')
+                                    .trim()
+                            )
+                    )
+                )
+            );
     },
 });

--- a/e2e/tests/permissions.js
+++ b/e2e/tests/permissions.js
@@ -20,7 +20,7 @@ describe('Permissions', () => {
         'name'
     )(driver);
 
-    it('Hide protected resources depending on permissions', async () => {
+    it('hides protected resources depending on permissions', async () => {
         await LoginPage.navigate();
         await LoginPage.login('login', 'password');
 

--- a/e2e/tests/permissions.js
+++ b/e2e/tests/permissions.js
@@ -31,7 +31,7 @@ describe('Permissions', () => {
         ]);
     });
 
-    it('Show protected resources depending on permissions', async () => {
+    it('shows protected resources depending on permissions', async () => {
         await LoginPage.navigate();
         await LoginPage.login('user', 'password');
 

--- a/e2e/tests/permissions.js
+++ b/e2e/tests/permissions.js
@@ -87,7 +87,7 @@ describe('Permissions', () => {
         });
     });
 
-    describe('show protected data depending on permissions', () => {
+    describe('shows protected data depending on permissions', () => {
         before(async () => {
             await LoginPage.navigate();
             await LoginPage.login('admin', 'password');

--- a/e2e/tests/permissions.js
+++ b/e2e/tests/permissions.js
@@ -43,7 +43,7 @@ describe('Permissions', () => {
         ]);
     });
 
-    describe('hide protected data depending on permissions', () => {
+    describe('hides protected data depending on permissions', () => {
         before(async () => {
             await LoginPage.navigate();
             await LoginPage.login('user', 'password');

--- a/e2e/tests/permissions.js
+++ b/e2e/tests/permissions.js
@@ -1,0 +1,145 @@
+import assert from 'assert';
+import { until } from 'selenium-webdriver';
+import driver from '../chromeDriver';
+
+import createPageFactory from '../pages/CreatePage';
+import editPageFactory from '../pages/EditPage';
+import listPageFactory from '../pages/ListPage';
+import loginPageFactory from '../pages/LoginPage';
+import showPageFactory from '../pages/ShowPage';
+
+describe('Permissions', () => {
+    const CreatePage = createPageFactory(
+        'http://localhost:8083/#/users/create'
+    )(driver);
+    const EditPage = editPageFactory('http://localhost:8083/#/users/1')(driver);
+    const ListPage = listPageFactory('http://localhost:8083/#/users')(driver);
+    const LoginPage = loginPageFactory('http://localhost:8083/#/login')(driver);
+    const ShowPage = showPageFactory(
+        'http://localhost:8083/#/users/1/show',
+        'name'
+    )(driver);
+
+    it('Hide protected resources depending on permissions', async () => {
+        await LoginPage.navigate();
+        await LoginPage.login('login', 'password');
+
+        assert.deepEqual(await ListPage.getResources(), [
+            'Posts',
+            'Comments',
+            'Logout',
+        ]);
+    });
+
+    it('Show protected resources depending on permissions', async () => {
+        await LoginPage.navigate();
+        await LoginPage.login('user', 'password');
+
+        assert.deepEqual(await ListPage.getResources(), [
+            'Posts',
+            'Comments',
+            'Users',
+            'Logout',
+        ]);
+    });
+
+    describe('hide protected data depending on permissions', () => {
+        before(async () => {
+            await LoginPage.navigate();
+            await LoginPage.login('user', 'password');
+            await driver.wait(until.urlIs('http://localhost:8083/#/posts'));
+        });
+
+        it('in List page with DataGrid', async () => {
+            await ListPage.navigate();
+
+            assert.deepEqual(await ListPage.getColumns(), [
+                'ID',
+                'NAME',
+                '',
+                '',
+            ]);
+        });
+
+        it('in List page filters', async () => {
+            await ListPage.navigate();
+
+            assert.deepEqual(await ListPage.getAvailableFilters(), ['Name']);
+        });
+
+        it('in Create page', async () => {
+            await CreatePage.navigate();
+
+            assert.deepEqual(await CreatePage.getFields(), ['name']);
+        });
+
+        it('in Show page', async () => {
+            await ShowPage.navigate();
+
+            assert.deepEqual(await ShowPage.getFields(), ['id', 'name']);
+        });
+
+        it('in Edit page', async () => {
+            await EditPage.navigate();
+
+            assert.deepEqual(await EditPage.getFields(), ['name']);
+            assert.deepEqual(await EditPage.getTabs(), ['SUMMARY']);
+        });
+    });
+
+    describe('show protected data depending on permissions', () => {
+        before(async () => {
+            await LoginPage.navigate();
+            await LoginPage.login('admin', 'password');
+            await driver.wait(until.urlIs('http://localhost:8083/#/posts'));
+        });
+
+        it('in List page with DataGrid', async () => {
+            await ListPage.navigate();
+
+            assert.deepEqual(await ListPage.getColumns(), [
+                'ID',
+                'NAME',
+                'ROLE',
+                '',
+                '',
+            ]);
+        });
+
+        it('in List page filters', async () => {
+            await ListPage.navigate();
+
+            assert.deepEqual(await ListPage.getAvailableFilters(), [
+                'Name',
+                'Role',
+            ]);
+        });
+
+        it('in Create page', async () => {
+            await CreatePage.navigate();
+
+            assert.deepEqual(await CreatePage.getFields(), ['name', 'role']);
+        });
+
+        it('in Show page', async () => {
+            await ShowPage.navigate();
+
+            assert.deepEqual(await ShowPage.getFields(), [
+                'id',
+                'name',
+                'role',
+            ]);
+        });
+
+        it('in Edit page', async () => {
+            await EditPage.navigate();
+
+            assert.deepEqual(await EditPage.getFields(), [
+                'id',
+                'name',
+                'role',
+            ]);
+            assert.deepEqual(await EditPage.getTabs(), ['SUMMARY', 'SECURITY']);
+        });
+    });
+});

--- a/example/app.js
+++ b/example/app.js
@@ -1,3 +1,4 @@
+/* eslint react/jsx-key: off */
 import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
@@ -47,7 +48,6 @@ render(
         {permissions => [
             <Resource
                 name="posts"
-                key="posts"
                 list={PostList}
                 create={PostCreate}
                 edit={PostEdit}
@@ -57,7 +57,6 @@ render(
             />,
             <Resource
                 name="comments"
-                key="comments"
                 list={CommentList}
                 create={CommentCreate}
                 edit={CommentEdit}
@@ -67,7 +66,6 @@ render(
             permissions
                 ? <Resource
                       name="users"
-                      key="users"
                       list={UserList}
                       create={UserCreate}
                       edit={UserEdit}
@@ -76,7 +74,7 @@ render(
                       show={UserShow}
                   />
                 : null,
-            <Resource name="tags" key="tags" />,
+            <Resource name="tags" />,
         ]}
     </Admin>,
     document.getElementById('root')

--- a/example/app.js
+++ b/example/app.js
@@ -44,33 +44,40 @@ render(
         locale="en"
         messages={messages}
     >
-        <Resource
-            name="posts"
-            list={PostList}
-            create={PostCreate}
-            edit={PostEdit}
-            show={PostShow}
-            remove={Delete}
-            icon={PostIcon}
-        />
-        <Resource
-            name="comments"
-            list={CommentList}
-            create={CommentCreate}
-            edit={CommentEdit}
-            remove={Delete}
-            icon={CommentIcon}
-        />
-        <Resource
-            name="users"
-            list={UserList}
-            create={UserCreate}
-            edit={UserEdit}
-            remove={Delete}
-            icon={UserIcon}
-            show={UserShow}
-        />
-        <Resource name="tags" />
+        {permissions => [
+            <Resource
+                name="posts"
+                key="posts"
+                list={PostList}
+                create={PostCreate}
+                edit={PostEdit}
+                show={PostShow}
+                remove={Delete}
+                icon={PostIcon}
+            />,
+            <Resource
+                name="comments"
+                key="comments"
+                list={CommentList}
+                create={CommentCreate}
+                edit={CommentEdit}
+                remove={Delete}
+                icon={CommentIcon}
+            />,
+            permissions
+                ? <Resource
+                      name="users"
+                      key="users"
+                      list={UserList}
+                      create={UserCreate}
+                      edit={UserEdit}
+                      remove={Delete}
+                      icon={UserIcon}
+                      show={UserShow}
+                  />
+                : null,
+            <Resource name="tags" key="tags" />,
+        ]}
     </Admin>,
     document.getElementById('root')
 );

--- a/example/app.js
+++ b/example/app.js
@@ -15,6 +15,7 @@ import {
     CommentCreate,
     CommentIcon,
 } from './comments';
+import { UserList, UserEdit, UserCreate, UserIcon, UserShow } from './users';
 
 import data from './data';
 import * as customMessages from './i18n';
@@ -59,6 +60,15 @@ render(
             edit={CommentEdit}
             remove={Delete}
             icon={CommentIcon}
+        />
+        <Resource
+            name="users"
+            list={UserList}
+            create={UserCreate}
+            edit={UserEdit}
+            remove={Delete}
+            icon={UserIcon}
+            show={UserShow}
         />
         <Resource name="tags" />
     </Admin>,

--- a/example/authClient.js
+++ b/example/authClient.js
@@ -1,10 +1,22 @@
-import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from 'admin-on-rest'; // eslint-disable-line import/no-unresolved
+import {
+    AUTH_GET_PERMISSIONS,
+    AUTH_LOGIN,
+    AUTH_LOGOUT,
+    AUTH_ERROR,
+    AUTH_CHECK,
+} from 'admin-on-rest'; // eslint-disable-line import/no-unresolved
 
 // Authenticatd by default
 export default (type, params) => {
     if (type === AUTH_LOGIN) {
         const { username, password } = params;
         if (username === 'login' && password === 'password') {
+            localStorage.setItem('role', 'user');
+            localStorage.removeItem('not_authenticated');
+            return Promise.resolve();
+        }
+        if (username === 'admin' && password === 'password') {
+            localStorage.setItem('role', 'admin');
             localStorage.removeItem('not_authenticated');
             return Promise.resolve();
         }
@@ -26,5 +38,11 @@ export default (type, params) => {
             ? Promise.reject()
             : Promise.resolve();
     }
+
+    if (type === AUTH_GET_PERMISSIONS) {
+        const role = localStorage.getItem('role');
+        return Promise.resolve(role);
+    }
+
     return Promise.reject('Unknown method');
 };

--- a/example/authClient.js
+++ b/example/authClient.js
@@ -11,6 +11,11 @@ export default (type, params) => {
     if (type === AUTH_LOGIN) {
         const { username, password } = params;
         if (username === 'login' && password === 'password') {
+            localStorage.removeItem('not_authenticated');
+            localStorage.removeItem('role');
+            return Promise.resolve();
+        }
+        if (username === 'user' && password === 'password') {
             localStorage.setItem('role', 'user');
             localStorage.removeItem('not_authenticated');
             return Promise.resolve();
@@ -25,6 +30,7 @@ export default (type, params) => {
     }
     if (type === AUTH_LOGOUT) {
         localStorage.setItem('not_authenticated', true);
+        localStorage.removeItem('role');
         return Promise.resolve();
     }
     if (type === AUTH_ERROR) {

--- a/example/data.js
+++ b/example/data.js
@@ -404,4 +404,21 @@ export default {
             published: 1,
         },
     ],
+    users: [
+        {
+            id: 1,
+            name: 'Logan Schowalter',
+            role: 'admin',
+        },
+        {
+            id: 2,
+            name: 'Breanna Gibson',
+            role: 'user',
+        },
+        {
+            id: 3,
+            name: 'Annamarie Mayer',
+            role: 'user',
+        },
+    ],
 };

--- a/example/i18n/en.js
+++ b/example/i18n/en.js
@@ -32,6 +32,13 @@ export const messages = {
                 },
             },
         },
+        users: {
+            name: 'User |||| Users',
+            fields: {
+                name: 'Name',
+                role: 'Role',
+            },
+        },
     },
     post: {
         list: {
@@ -54,6 +61,22 @@ export const messages = {
     comment: {
         list: {
             about: 'About',
+        },
+    },
+    user: {
+        list: {
+            search: 'Search',
+        },
+        form: {
+            summary: 'Summary',
+            security: 'Security',
+        },
+        edit: {
+            title: 'User "%{title}"',
+        },
+        action: {
+            save_and_add: 'Save and Add',
+            save_and_show: 'Save and Show',
         },
     },
 };

--- a/example/i18n/fr.js
+++ b/example/i18n/fr.js
@@ -31,6 +31,13 @@ export const messages = {
                 },
             },
         },
+        users: {
+            name: 'User |||| Users',
+            fields: {
+                name: 'Name',
+                role: 'Role',
+            },
+        },
     },
     post: {
         list: {
@@ -49,6 +56,18 @@ export const messages = {
     comment: {
         list: {
             about: 'Au sujet de',
+        },
+    },
+    user: {
+        list: {
+            search: 'Recherche',
+        },
+        form: {
+            summary: 'Résumé',
+            security: 'Sécurité',
+        },
+        edit: {
+            title: 'Utilisateur "%{title}"',
         },
     },
 };

--- a/example/posts.js
+++ b/example/posts.js
@@ -222,7 +222,7 @@ export const PostEdit = ({ ...props }) =>
                 />
                 <NumberInput
                     source="average_note"
-                    validate={[number, minValue(0)]}
+                    validate={[required, number, minValue(0)]}
                 />
                 <BooleanInput source="commentable" defaultValue />
                 <DisabledInput source="views" />

--- a/example/users.js
+++ b/example/users.js
@@ -1,0 +1,139 @@
+import React from 'react';
+import {
+    Create,
+    Datagrid,
+    DisabledInput,
+    Edit,
+    EditButton,
+    Filter,
+    FormTab,
+    List,
+    Responsive,
+    SaveButton,
+    Show,
+    ShowButton,
+    SimpleForm,
+    SimpleList,
+    Tab,
+    TabbedForm,
+    TabbedShowLayout,
+    TextField,
+    TextInput,
+    Toolbar,
+    required,
+    translate,
+} from 'admin-on-rest'; // eslint-disable-line import/no-unresolved
+
+export UserIcon from 'material-ui/svg-icons/social/people';
+
+const UserFilter = ({ ...props }) =>
+    <Filter {...props}>
+        {permissions => [
+            <TextInput
+                key="user.list.search"
+                label="user.list.search"
+                source="q"
+                alwaysOn
+            />,
+            <TextInput key="name" source="name" />,
+            permissions ? <TextInput source="role" /> : null,
+        ]}
+    </Filter>;
+
+const titleFieldStyle = {
+    maxWidth: '20em',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+};
+export const UserList = ({ ...props }) =>
+    <List
+        {...props}
+        filters={<UserFilter />}
+        sort={{ field: 'name', order: 'ASC' }}
+    >
+        {permissions =>
+            <Responsive
+                small={
+                    <SimpleList
+                        primaryText={record => record.name}
+                        secondaryText={record =>
+                            permissions === 'admin' ? record.role : null}
+                    />
+                }
+                medium={
+                    <Datagrid>
+                        <TextField source="id" />
+                        <TextField source="name" style={titleFieldStyle} />
+                        {permissions && <TextField source="role" />}
+                        <EditButton />
+                        <ShowButton />
+                    </Datagrid>
+                }
+            />}
+    </List>;
+
+const UserTitle = translate(({ record, translate }) =>
+    <span>
+        {record ? translate('user.edit.title', { title: record.name }) : ''}
+    </span>
+);
+
+const UserCreateToolbar = ({ permissions, ...props }) =>
+    <Toolbar {...props}>
+        <SaveButton
+            label="user.action.save_and_show"
+            redirect="show"
+            submitOnEnter={true}
+        />
+        {permissions === 'admin' &&
+            <SaveButton
+                label="user.action.save_and_add"
+                redirect={false}
+                submitOnEnter={false}
+                raised={false}
+            />}
+    </Toolbar>;
+
+export const UserCreate = ({ ...props }) =>
+    <Create {...props}>
+        {permissions =>
+            <SimpleForm
+                toolbar={<UserCreateToolbar permissions={permissions} />}
+                defaultValue={{ role: 'user' }}
+            >
+                <TextInput source="name" validate={[required]} />
+                {permissions === 'admin' &&
+                    <TextInput source="role" validate={[required]} />}
+            </SimpleForm>}
+    </Create>;
+
+export const UserEdit = ({ ...props }) =>
+    <Edit title={<UserTitle />} {...props}>
+        {permissions =>
+            <TabbedForm defaultValue={{ average_note: 0 }}>
+                <FormTab label="user.form.summary">
+                    <DisabledInput source="id" />
+                    <TextInput source="name" validate={required} />
+                </FormTab>
+                {permissions === 'admin' &&
+                    <FormTab label="user.form.security">
+                        <TextInput source="name" validate={required} />
+                    </FormTab>}
+            </TabbedForm>}
+    </Edit>;
+
+export const UserShow = ({ ...props }) =>
+    <Show title={<UserTitle />} {...props}>
+        {permissions =>
+            <TabbedShowLayout>
+                <Tab label="user.form.summary">
+                    <TextField source="id" />
+                    <TextField source="name" />
+                </Tab>
+                {permissions &&
+                    <Tab label="user.form.security">
+                        <TextField source="role" />
+                    </Tab>}
+            </TabbedShowLayout>}
+    </Show>;

--- a/example/users.js
+++ b/example/users.js
@@ -111,7 +111,7 @@ export const UserCreate = ({ ...props }) =>
 export const UserEdit = ({ ...props }) =>
     <Edit title={<UserTitle />} {...props}>
         {permissions =>
-            <TabbedForm defaultValue={{ average_note: 0 }}>
+            <TabbedForm defaultValue={{ role: 'user' }}>
                 <FormTab label="user.form.summary">
                     {permissions === 'admin' && <DisabledInput source="id" />}
                     <TextInput source="name" validate={required} />

--- a/example/users.js
+++ b/example/users.js
@@ -1,3 +1,4 @@
+/* eslint react/jsx-key: off */
 import React from 'react';
 import {
     Create,
@@ -29,13 +30,8 @@ export UserIcon from 'material-ui/svg-icons/social/people';
 const UserFilter = ({ ...props }) =>
     <Filter {...props}>
         {permissions => [
-            <TextInput
-                key="user.list.search"
-                label="user.list.search"
-                source="q"
-                alwaysOn
-            />,
-            <TextInput key="name" source="name" />,
+            <TextInput label="user.list.search" source="q" alwaysOn />,
+            <TextInput source="name" />,
             permissions === 'admin' ? <TextInput source="role" /> : null,
         ]}
     </Filter>;

--- a/example/users.js
+++ b/example/users.js
@@ -36,7 +36,7 @@ const UserFilter = ({ ...props }) =>
                 alwaysOn
             />,
             <TextInput key="name" source="name" />,
-            permissions ? <TextInput source="role" /> : null,
+            permissions === 'admin' ? <TextInput source="role" /> : null,
         ]}
     </Filter>;
 
@@ -65,7 +65,7 @@ export const UserList = ({ ...props }) =>
                     <Datagrid>
                         <TextField source="id" />
                         <TextField source="name" style={titleFieldStyle} />
-                        {permissions && <TextField source="role" />}
+                        {permissions === 'admin' && <TextField source="role" />}
                         <EditButton />
                         <ShowButton />
                     </Datagrid>
@@ -113,12 +113,12 @@ export const UserEdit = ({ ...props }) =>
         {permissions =>
             <TabbedForm defaultValue={{ average_note: 0 }}>
                 <FormTab label="user.form.summary">
-                    <DisabledInput source="id" />
+                    {permissions === 'admin' && <DisabledInput source="id" />}
                     <TextInput source="name" validate={required} />
                 </FormTab>
                 {permissions === 'admin' &&
                     <FormTab label="user.form.security">
-                        <TextInput source="name" validate={required} />
+                        <TextInput source="role" validate={required} />
                     </FormTab>}
             </TabbedForm>}
     </Edit>;
@@ -131,7 +131,7 @@ export const UserShow = ({ ...props }) =>
                     <TextField source="id" />
                     <TextField source="name" />
                 </Tab>
-                {permissions &&
+                {permissions === 'admin' &&
                     <Tab label="user.form.security">
                         <TextField source="role" />
                     </Tab>}

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -21,6 +21,7 @@ import TranslationProvider from './i18n/TranslationProvider';
 const Admin = ({
     appLayout,
     authClient,
+    children,
     customReducers = {},
     customSagas = [],
     customRoutes = [],
@@ -106,7 +107,7 @@ const Admin = ({
                                 render={() =>
                                     createElement(appLayout || DefaultLayout, {
                                         authClient,
-                                        children: this.props.children,
+                                        children,
                                         dashboard,
                                         customRoutes: customRoutes.filter(
                                             route => !route.props.noLayout

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -1,4 +1,4 @@
-import React, { createElement, Component } from 'react';
+import React, { createElement } from 'react';
 import PropTypes from 'prop-types';
 import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
@@ -18,127 +18,113 @@ import Login from './mui/auth/Login';
 import Logout from './mui/auth/Logout';
 import TranslationProvider from './i18n/TranslationProvider';
 
-class Admin extends Component {
-    render() {
-        const {
-            appLayout,
-            authClient,
-            customReducers = {},
-            customSagas = [],
-            customRoutes = [],
-            dashboard,
-            history,
-            locale,
-            messages = {},
-            menu = Menu,
-            catchAll,
-            restClient,
-            theme,
-            title = 'Admin on REST',
-            loginPage,
-            logoutButton,
-            initialState,
-        } = this.props;
-        const appReducer = createAppReducer(customReducers, locale);
-        const resettableAppReducer = (state, action) =>
-            appReducer(action.type !== USER_LOGOUT ? state : undefined, action);
-        const saga = function* rootSaga() {
-            yield all(
-                [crudSaga(restClient, authClient), ...customSagas].map(fork)
-            );
-        };
-        const sagaMiddleware = createSagaMiddleware();
-        const routerHistory = history || createHistory();
-        const store = createStore(
-            resettableAppReducer,
-            initialState,
-            compose(
-                applyMiddleware(
-                    sagaMiddleware,
-                    routerMiddleware(routerHistory)
-                ),
-                window.devToolsExtension ? window.devToolsExtension() : f => f
-            )
-        );
-        sagaMiddleware.run(saga);
+const Admin = ({
+    appLayout,
+    authClient,
+    customReducers = {},
+    customSagas = [],
+    customRoutes = [],
+    dashboard,
+    history,
+    locale,
+    messages = {},
+    menu = Menu,
+    catchAll,
+    restClient,
+    theme,
+    title = 'Admin on REST',
+    loginPage,
+    logoutButton,
+    initialState,
+}) => {
+    const appReducer = createAppReducer(customReducers, locale);
+    const resettableAppReducer = (state, action) =>
+        appReducer(action.type !== USER_LOGOUT ? state : undefined, action);
+    const saga = function* rootSaga() {
+        yield all([crudSaga(restClient, authClient), ...customSagas].map(fork));
+    };
+    const sagaMiddleware = createSagaMiddleware();
+    const routerHistory = history || createHistory();
+    const store = createStore(
+        resettableAppReducer,
+        initialState,
+        compose(
+            applyMiddleware(sagaMiddleware, routerMiddleware(routerHistory)),
+            window.devToolsExtension ? window.devToolsExtension() : f => f
+        )
+    );
+    sagaMiddleware.run(saga);
 
-        const logout = authClient
-            ? createElement(logoutButton || Logout)
-            : null;
+    const logout = authClient ? createElement(logoutButton || Logout) : null;
 
-        return (
-            <Provider store={store}>
-                <TranslationProvider messages={messages}>
-                    <ConnectedRouter history={routerHistory}>
-                        <div>
-                            <Switch>
-                                <Route
-                                    exact
-                                    path="/login"
-                                    render={({ location }) =>
-                                        createElement(loginPage || Login, {
-                                            location,
-                                            title,
-                                            theme,
-                                        })}
-                                />
-                                {customRoutes
-                                    .filter(route => route.props.noLayout)
-                                    .map((route, index) =>
-                                        <Route
-                                            key={index}
-                                            exact={route.props.exact}
-                                            path={route.props.path}
-                                            render={({ location }) => {
-                                                if (route.props.render) {
-                                                    return route.props.render({
+    return (
+        <Provider store={store}>
+            <TranslationProvider messages={messages}>
+                <ConnectedRouter history={routerHistory}>
+                    <div>
+                        <Switch>
+                            <Route
+                                exact
+                                path="/login"
+                                render={({ location }) =>
+                                    createElement(loginPage || Login, {
+                                        location,
+                                        title,
+                                        theme,
+                                    })}
+                            />
+                            {customRoutes
+                                .filter(route => route.props.noLayout)
+                                .map((route, index) =>
+                                    <Route
+                                        key={index}
+                                        exact={route.props.exact}
+                                        path={route.props.path}
+                                        render={({ location }) => {
+                                            if (route.props.render) {
+                                                return route.props.render({
+                                                    location,
+                                                    title,
+                                                    theme,
+                                                });
+                                            }
+                                            if (route.props.component) {
+                                                return createElement(
+                                                    route.props.component,
+                                                    {
                                                         location,
                                                         title,
                                                         theme,
-                                                    });
-                                                }
-                                                if (route.props.component) {
-                                                    return createElement(
-                                                        route.props.component,
-                                                        {
-                                                            location,
-                                                            title,
-                                                            theme,
-                                                        }
-                                                    );
-                                                }
-                                            }}
-                                        />
-                                    )}
-                                <Route
-                                    path="/"
-                                    render={() =>
-                                        createElement(
-                                            appLayout || DefaultLayout,
-                                            {
-                                                authClient,
-                                                children: this.props.children,
-                                                dashboard,
-                                                customRoutes: customRoutes.filter(
-                                                    route =>
-                                                        !route.props.noLayout
-                                                ),
-                                                logout,
-                                                menu,
-                                                catchAll,
-                                                title,
-                                                theme,
+                                                    }
+                                                );
                                             }
-                                        )}
-                                />
-                            </Switch>
-                        </div>
-                    </ConnectedRouter>
-                </TranslationProvider>
-            </Provider>
-        );
-    }
-}
+                                        }}
+                                    />
+                                )}
+                            <Route
+                                path="/"
+                                render={() =>
+                                    createElement(appLayout || DefaultLayout, {
+                                        authClient,
+                                        children: this.props.children,
+                                        dashboard,
+                                        customRoutes: customRoutes.filter(
+                                            route => !route.props.noLayout
+                                        ),
+                                        logout,
+                                        menu,
+                                        catchAll,
+                                        title,
+                                        theme,
+                                    })}
+                            />
+                        </Switch>
+                    </div>
+                </ConnectedRouter>
+            </TranslationProvider>
+        </Provider>
+    );
+};
 
 const componentPropType = PropTypes.oneOfType([
     PropTypes.func,

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -7,6 +7,7 @@ import { Switch, Route } from 'react-router-dom';
 import { ConnectedRouter, routerMiddleware } from 'react-router-redux';
 import createSagaMiddleware from 'redux-saga';
 import { all, fork } from 'redux-saga/effects';
+import withContext from 'recompose/withContext';
 
 import { USER_LOGOUT } from './actions/authActions';
 
@@ -106,7 +107,6 @@ const Admin = ({
                                 path="/"
                                 render={() =>
                                     createElement(appLayout || DefaultLayout, {
-                                        authClient,
                                         children,
                                         dashboard,
                                         customRoutes: customRoutes.filter(
@@ -153,4 +153,9 @@ Admin.propTypes = {
     initialState: PropTypes.object,
 };
 
-export default Admin;
+export default withContext(
+    {
+        authClient: PropTypes.func,
+    },
+    ({ authClient }) => ({ authClient })
+)(Admin);

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import getContext from 'recompose/getContext';
 
 import CrudRoute from './CrudRoute';
 import NotFound from './mui/layout/NotFound';
@@ -108,6 +110,11 @@ const mapStateToProps = state => ({
     ),
 });
 
-export default connect(mapStateToProps, {
-    declareResources: declareResourcesAction,
-})(AdminRoutes);
+export default compose(
+    getContext({
+        authClient: PropTypes.func,
+    }),
+    connect(mapStateToProps, {
+        declareResources: declareResourcesAction,
+    })
+)(AdminRoutes);

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -19,7 +19,9 @@ export class AdminRoutes extends Component {
     initializeResources(children) {
         if (typeof children === 'function') {
             this.props.authClient(AUTH_GET_PERMISSIONS).then(permissions => {
-                const resources = children(permissions).map(node => node.props);
+                const resources = children(permissions)
+                    .filter(node => node)
+                    .map(node => node.props);
                 this.props.declareResources(resources);
             });
         } else {

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -98,7 +98,8 @@ const componentPropType = PropTypes.oneOfType([
 ]);
 
 AdminRoutes.propTypes = {
-    authClient: PropTypes.func.isRequired,
+    authClient: PropTypes.func,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     catchAll: componentPropType,
     customRoutes: PropTypes.array,
     declareResources: PropTypes.func.isRequired,

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -1,60 +1,92 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Redirect, Route, Switch } from 'react-router-dom';
+import { connect } from 'react-redux';
 
 import CrudRoute from './CrudRoute';
 import NotFound from './mui/layout/NotFound';
 import Restricted from './auth/Restricted';
+import { AUTH_GET_PERMISSIONS } from './auth';
+import { declareResources as declareResourcesAction } from './actions';
 
-const AdminRoutes = ({ customRoutes, resources = [], dashboard, catchAll }) =>
-    <Switch>
-        {customRoutes &&
-            customRoutes.map((route, index) =>
-                <Route
-                    key={index}
-                    exact={route.props.exact}
-                    path={route.props.path}
-                    component={route.props.component}
-                    render={route.props.render}
-                    children={route.props.children} // eslint-disable-line react/no-children-prop
-                />
-            )}
-        {resources.map(resource =>
-            <Route
-                path={`/${resource.name}`}
-                key={resource.name}
-                render={() =>
-                    <CrudRoute
-                        resource={resource.name}
-                        list={resource.list}
-                        create={resource.create}
-                        edit={resource.edit}
-                        show={resource.show}
-                        remove={resource.remove}
-                        options={resource.options}
-                    />}
-            />
-        )}
-        {dashboard
-            ? <Route
-                  exact
-                  path="/"
-                  render={routeProps =>
-                      <Restricted
-                          authParams={{ route: 'dashboard' }}
-                          {...routeProps}
-                      >
-                          {React.createElement(dashboard)}
-                      </Restricted>}
-              />
-            : resources[0] &&
-              <Route
-                  exact
-                  path="/"
-                  render={() => <Redirect to={`/${resources[0].name}`} />}
-              />}
-        <Route component={catchAll || NotFound} />
-    </Switch>;
+export class AdminRoutes extends Component {
+    componentDidMount() {
+        this.initializeResources(this.props.children);
+    }
+
+    initializeResources(children) {
+        if (typeof children === 'function') {
+            this.props.authClient(AUTH_GET_PERMISSIONS).then(permissions => {
+                const resources = children(permissions).map(node => node.props);
+                this.props.declareResources(resources);
+            });
+        } else {
+            const resources =
+                React.Children.map(children, ({ props }) => props) || [];
+            this.props.declareResources(resources);
+        }
+    }
+
+    render() {
+        const {
+            customRoutes,
+            resources = [],
+            dashboard,
+            catchAll,
+        } = this.props;
+        return (
+            <Switch>
+                {customRoutes &&
+                    customRoutes.map((route, index) =>
+                        <Route
+                            key={index}
+                            exact={route.props.exact}
+                            path={route.props.path}
+                            component={route.props.component}
+                            render={route.props.render}
+                            children={route.props.children} // eslint-disable-line react/no-children-prop
+                        />
+                    )}
+                {resources.map(resource =>
+                    <Route
+                        path={`/${resource.name}`}
+                        key={resource.name}
+                        render={() =>
+                            <CrudRoute
+                                resource={resource.name}
+                                list={resource.list}
+                                create={resource.create}
+                                edit={resource.edit}
+                                show={resource.show}
+                                remove={resource.remove}
+                                options={resource.options}
+                            />}
+                    />
+                )}
+                {dashboard
+                    ? <Route
+                          exact
+                          path="/"
+                          render={routeProps =>
+                              <Restricted
+                                  authParams={{ route: 'dashboard' }}
+                                  {...routeProps}
+                              >
+                                  {React.createElement(dashboard)}
+                              </Restricted>}
+                      />
+                    : resources[0] &&
+                      <Route
+                          exact
+                          path="/"
+                          render={() =>
+                              <Redirect to={`/${resources[0].name}`} />}
+                      />}
+                <Route component={catchAll || NotFound} />
+            </Switch>
+        );
+    }
+}
 
 const componentPropType = PropTypes.oneOfType([
     PropTypes.func,
@@ -62,10 +94,20 @@ const componentPropType = PropTypes.oneOfType([
 ]);
 
 AdminRoutes.propTypes = {
+    authClient: PropTypes.func.isRequired,
     catchAll: componentPropType,
     customRoutes: PropTypes.array,
+    declareResources: PropTypes.func.isRequired,
     resources: PropTypes.array,
     dashboard: componentPropType,
 };
 
-export default AdminRoutes;
+const mapStateToProps = state => ({
+    resources: Object.keys(state.admin.resources).map(
+        key => state.admin.resources[key].props
+    ),
+});
+
+export default connect(mapStateToProps, {
+    declareResources: declareResourcesAction,
+})(AdminRoutes);

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -10,6 +10,7 @@ import NotFound from './mui/layout/NotFound';
 import Restricted from './auth/Restricted';
 import { AUTH_GET_PERMISSIONS } from './auth';
 import { declareResources as declareResourcesAction } from './actions';
+import getMissingAuthClientError from './util/getMissingAuthClientError';
 
 export class AdminRoutes extends Component {
     componentDidMount() {
@@ -18,6 +19,10 @@ export class AdminRoutes extends Component {
 
     initializeResources(children) {
         if (typeof children === 'function') {
+            if (!this.props.authClient) {
+                throw new Error(getMissingAuthClientError('Admin'));
+            }
+
             this.props.authClient(AUTH_GET_PERMISSIONS).then(permissions => {
                 const resources = children(permissions)
                     .filter(node => node)

--- a/src/AdminRoutes.spec.js
+++ b/src/AdminRoutes.spec.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { render } from 'enzyme';
 import assert from 'assert';
 
-import AdminRoutes from './AdminRoutes';
+import { AdminRoutes } from './AdminRoutes';
 
 describe('<AdminRoutes>', () => {
     const Dashboard = () => <div>Dashboard</div>;

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -22,7 +22,6 @@ Resource.propTypes = {
     remove: componentPropType,
     icon: componentPropType,
     options: PropTypes.object,
-    checkCredentials: PropTypes.func,
 };
 
 Resource.defaultProps = {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -7,11 +7,5 @@ export * from './formActions';
 export * from './listActions';
 export * from './localeActions';
 export * from './notificationActions';
+export * from './resourcesActions';
 export * from './uiActions';
-
-export const DECLARE_RESOURCES = 'AOR/DECLARE_RESOURCES';
-
-export const declareResources = resources => ({
-    type: DECLARE_RESOURCES,
-    payload: resources,
-});

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,3 +8,10 @@ export * from './listActions';
 export * from './localeActions';
 export * from './notificationActions';
 export * from './uiActions';
+
+export const DECLARE_RESOURCES = 'AOR/DECLARE_RESOURCES';
+
+export const declareResources = resources => ({
+    type: DECLARE_RESOURCES,
+    payload: resources,
+});

--- a/src/actions/resourcesActions.js
+++ b/src/actions/resourcesActions.js
@@ -1,0 +1,6 @@
+export const DECLARE_RESOURCES = 'AOR/DECLARE_RESOURCES';
+
+export const declareResources = resources => ({
+    type: DECLARE_RESOURCES,
+    payload: resources,
+});

--- a/src/auth/Loading.js
+++ b/src/auth/Loading.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import LinearProgress from 'material-ui/LinearProgress';
+
+const LoadingComponent = () => <LinearProgress mode="indeterminate" />;
+
+export default LoadingComponent;

--- a/src/auth/Loading.js
+++ b/src/auth/Loading.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import LinearProgress from 'material-ui/LinearProgress';
-
-const LoadingComponent = () => <LinearProgress mode="indeterminate" />;
-
-export default LoadingComponent;

--- a/src/auth/Permission.js
+++ b/src/auth/Permission.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Permission = () =>
+    <span>
+        &lt;Permission&gt; elements are for configuration only and should not be
+        rendered
+    </span>;
+
+Permission.propTypes = {
+    children: PropTypes.node.isRequired,
+    exact: PropTypes.bool,
+    value: PropTypes.any,
+    resolve: PropTypes.any,
+};
+
+export default Permission;

--- a/src/auth/SwitchPermissions.js
+++ b/src/auth/SwitchPermissions.js
@@ -1,0 +1,124 @@
+import React, { createElement, Component } from 'react';
+import PropTypes from 'prop-types';
+import FormField from '../mui/form/FormField';
+import getContext from 'recompose/getContext';
+
+import DefaultLoading from './Loading';
+import { AUTH_GET_PERMISSIONS } from './types';
+import resolvePermissions from './resolvePermissions';
+
+export class SwitchPermissionsComponent extends Component {
+    static propTypes = {
+        authClient: PropTypes.func,
+        authClientFromContext: PropTypes.func,
+        children: PropTypes.node.isRequired,
+        notFound: PropTypes.func,
+        loading: PropTypes.func,
+        record: PropTypes.object,
+        resource: PropTypes.string,
+    };
+
+    static defaultProps = {
+        notFound: null,
+        loading: DefaultLoading,
+    };
+
+    state = {
+        isNotFound: false,
+        match: undefined,
+        role: undefined,
+    };
+
+    async componentWillMount() {
+        const {
+            authClient,
+            authClientFromContext,
+            children,
+            record,
+            resource,
+        } = this.props;
+        const mappings =
+            React.Children.map(
+                children,
+                ({ props: { value, resolve, children, exact } }) => ({
+                    permissions: value,
+                    resolve,
+                    view: children,
+                    exact,
+                })
+            ) || [];
+
+        const finalAuthClient = authClient || authClientFromContext;
+
+        const permissions = await finalAuthClient(AUTH_GET_PERMISSIONS, {
+            record,
+            resource,
+        });
+        const match = await resolvePermissions({
+            mappings,
+            permissions,
+            record,
+            resource,
+        });
+
+        if (match) {
+            this.setState({ match: match.view });
+        } else {
+            this.setState({ isNotFound: true, permissions });
+        }
+    }
+
+    renderSourceChild = (child, props) =>
+        <div
+            key={child.props.source}
+            style={child.props.style}
+            className={`aor-input-${child.props.source}`}
+        >
+            <FormField input={child} {...props} />
+        </div>;
+
+    render() {
+        const { isNotFound, match, role } = this.state;
+        const {
+            authClient,
+            authClientFromContext,
+            children,
+            notFound,
+            loading,
+            ...props
+        } = this.props;
+
+        if (isNotFound) {
+            if (notFound) {
+                return createElement(notFound, { role });
+            }
+            return null;
+        }
+
+        if (!match) {
+            return createElement(loading);
+        }
+
+        if (Array.isArray(match)) {
+            return (
+                <div>
+                    {React.Children.map(
+                        match,
+                        child =>
+                            child.props.source
+                                ? this.renderSourceChild(child)
+                                : <FormField input={child} {...props} />
+                    )}
+                </div>
+            );
+        }
+
+        return match.props.source
+            ? this.renderSourceChild(match)
+            : <FormField input={match} {...props} />;
+    }
+}
+
+export default getContext({
+    authClientFromContext: PropTypes.func,
+})(SwitchPermissionsComponent);

--- a/src/auth/SwitchPermissions.js
+++ b/src/auth/SwitchPermissions.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import FormField from '../mui/form/FormField';
 import getContext from 'recompose/getContext';
 
-import DefaultLoading from './Loading';
 import { AUTH_GET_PERMISSIONS } from './types';
 import resolvePermissions from './resolvePermissions';
 
@@ -20,7 +19,7 @@ export class SwitchPermissionsComponent extends Component {
 
     static defaultProps = {
         notFound: null,
-        loading: DefaultLoading,
+        loading: null,
     };
 
     state = {
@@ -95,7 +94,7 @@ export class SwitchPermissionsComponent extends Component {
             return null;
         }
 
-        if (!match) {
+        if (!match && loading) {
             return createElement(loading);
         }
 

--- a/src/auth/SwitchPermissions.js
+++ b/src/auth/SwitchPermissions.js
@@ -72,7 +72,7 @@ export class SwitchPermissionsComponent extends Component {
         <div
             key={child.props.source}
             style={child.props.style}
-            className={`aor-input-${child.props.source}`}
+            className={`aor-input aor-input-${child.props.source}`}
         >
             <FormField input={child} {...props} />
         </div>;

--- a/src/auth/SwitchPermissions.js
+++ b/src/auth/SwitchPermissions.js
@@ -9,7 +9,6 @@ import resolvePermissions from './resolvePermissions';
 export class SwitchPermissionsComponent extends Component {
     static propTypes = {
         authClient: PropTypes.func,
-        authClientFromContext: PropTypes.func,
         children: PropTypes.node.isRequired,
         notFound: PropTypes.func,
         loading: PropTypes.func,
@@ -29,13 +28,7 @@ export class SwitchPermissionsComponent extends Component {
     };
 
     async componentWillMount() {
-        const {
-            authClient,
-            authClientFromContext,
-            children,
-            record,
-            resource,
-        } = this.props;
+        const { authClient, children, record, resource } = this.props;
         const mappings =
             React.Children.map(
                 children,
@@ -47,9 +40,7 @@ export class SwitchPermissionsComponent extends Component {
                 })
             ) || [];
 
-        const finalAuthClient = authClient || authClientFromContext;
-
-        const permissions = await finalAuthClient(AUTH_GET_PERMISSIONS, {
+        const permissions = await authClient(AUTH_GET_PERMISSIONS, {
             record,
             resource,
         });
@@ -80,7 +71,6 @@ export class SwitchPermissionsComponent extends Component {
         const { isNotFound, match, role } = this.state;
         const {
             authClient,
-            authClientFromContext,
             children,
             notFound,
             loading,
@@ -119,5 +109,5 @@ export class SwitchPermissionsComponent extends Component {
 }
 
 export default getContext({
-    authClientFromContext: PropTypes.func,
+    authClient: PropTypes.func,
 })(SwitchPermissionsComponent);

--- a/src/auth/WithPermission.js
+++ b/src/auth/WithPermission.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import FormField from '../mui/form/FormField';
 import getContext from 'recompose/getContext';
 
-import DefaultLoading from './Loading';
 import { AUTH_GET_PERMISSIONS } from './types';
 import { resolvePermission } from './resolvePermissions';
 
@@ -22,7 +21,7 @@ export class WithPermissionComponent extends Component {
     };
 
     static defaultProps = {
-        loading: DefaultLoading,
+        loading: null,
     };
 
     state = {
@@ -95,7 +94,7 @@ export class WithPermissionComponent extends Component {
             return null;
         }
 
-        if (!match) {
+        if (!match && loading) {
             return createElement(loading);
         }
 

--- a/src/auth/WithPermission.js
+++ b/src/auth/WithPermission.js
@@ -67,7 +67,7 @@ export class WithPermissionComponent extends Component {
         <div
             key={child.props.source}
             style={child.props.style}
-            className={`aor-input-${child.props.source}`}
+            className={`aor-input aor-input-${child.props.source}`}
         >
             <FormField input={child} {...props} />
         </div>;

--- a/src/auth/WithPermission.js
+++ b/src/auth/WithPermission.js
@@ -9,7 +9,6 @@ import { resolvePermission } from './resolvePermissions';
 export class WithPermissionComponent extends Component {
     static propTypes = {
         authClient: PropTypes.func,
-        authClientFromContext: PropTypes.func,
         children: PropTypes.node.isRequired,
         exact: PropTypes.bool,
         loading: PropTypes.func,

--- a/src/auth/WithPermission.js
+++ b/src/auth/WithPermission.js
@@ -1,0 +1,124 @@
+import React, { createElement, Component } from 'react';
+import PropTypes from 'prop-types';
+import FormField from '../mui/form/FormField';
+import getContext from 'recompose/getContext';
+
+import DefaultLoading from './Loading';
+import { AUTH_GET_PERMISSIONS } from './types';
+import { resolvePermission } from './resolvePermissions';
+
+export class WithPermissionComponent extends Component {
+    static propTypes = {
+        authClient: PropTypes.func,
+        authClientFromContext: PropTypes.func,
+        children: PropTypes.node.isRequired,
+        exact: PropTypes.bool,
+        loading: PropTypes.func,
+        notFound: PropTypes.func,
+        record: PropTypes.object,
+        resource: PropTypes.string,
+        value: PropTypes.any,
+        resolve: PropTypes.func,
+    };
+
+    static defaultProps = {
+        loading: DefaultLoading,
+    };
+
+    state = {
+        isNotFound: false,
+        match: undefined,
+        role: undefined,
+    };
+
+    async componentWillMount() {
+        const {
+            authClient,
+            children,
+            record,
+            resolve,
+            resource,
+            value: requiredPermissions,
+            exact,
+        } = this.props;
+        const permissions = await authClient(AUTH_GET_PERMISSIONS, {
+            record,
+            resource,
+        });
+        const match = await resolvePermission({
+            permissions,
+            record,
+            resource,
+        })({
+            exact,
+            permissions: requiredPermissions,
+            resolve,
+            view: children,
+        });
+
+        if (match && match.matched) {
+            this.setState({ match: match.view });
+        } else {
+            this.setState({ isNotFound: true, permissions });
+        }
+    }
+
+    renderSourceChild = (child, props) =>
+        <div
+            key={child.props.source}
+            style={child.props.style}
+            className={`aor-input-${child.props.source}`}
+        >
+            <FormField input={child} {...props} />
+        </div>;
+
+    render() {
+        const { isNotFound, match, role } = this.state;
+        const {
+            authClient,
+            children,
+            notFound,
+            loading,
+            resource,
+            record,
+            resolve,
+            value,
+            exact,
+            ...props
+        } = this.props;
+
+        if (isNotFound) {
+            if (notFound) {
+                return createElement(notFound, { role });
+            }
+
+            return null;
+        }
+
+        if (!match) {
+            return createElement(loading);
+        }
+
+        if (Array.isArray(children)) {
+            return (
+                <div>
+                    {React.Children.map(
+                        children,
+                        child =>
+                            child.props.source
+                                ? this.renderSourceChild(child, props)
+                                : <FormField input={child} {...props} />
+                    )}
+                </div>
+            );
+        }
+
+        return children.props.source
+            ? this.renderSourceChild(children, props)
+            : <FormField input={children} {...props} />;
+    }
+}
+
+export default getContext({
+    authClient: PropTypes.func,
+})(WithPermissionComponent);

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -1,2 +1,5 @@
 export * from './types';
 export Restricted from './Restricted';
+export Permission from './Permission';
+export SwitchPermissions from './SwitchPermissions';
+export WithPermission from './WithPermission';

--- a/src/auth/resolvePermissions.js
+++ b/src/auth/resolvePermissions.js
@@ -1,0 +1,63 @@
+export const resolvePermission = ({
+    permissions,
+    record,
+    resource,
+}) => mapping => {
+    if (typeof mapping.resolve === 'function') {
+        const result = mapping.resolve({
+            record,
+            resource,
+            permissions,
+            exact: mapping.exact,
+            value: mapping.permissions,
+        });
+
+        if (typeof result.then === 'function') {
+            return result.then(matched => ({ matched, view: mapping.view }));
+        }
+
+        return Promise.resolve({ matched: result, view: mapping.view });
+    }
+
+    if (Array.isArray(mapping.permissions) && Array.isArray(permissions)) {
+        if (mapping.exact) {
+            return Promise.resolve({
+                matched: mapping.permissions.every(mp =>
+                    permissions.includes(mp)
+                ),
+                view: mapping.view,
+            });
+        }
+
+        return Promise.resolve({
+            matched: mapping.permissions.some(mp => permissions.includes(mp)),
+            view: mapping.view,
+        });
+    }
+
+    if (Array.isArray(mapping.permissions)) {
+        return Promise.resolve({
+            matched: mapping.permissions.includes(permissions),
+            view: mapping.view,
+        });
+    }
+
+    if (Array.isArray(permissions)) {
+        return Promise.resolve({
+            matched: permissions.includes(mapping.permissions),
+            view: mapping.view,
+        });
+    }
+
+    return Promise.resolve({
+        matched: mapping.permissions === permissions,
+        view: mapping.view,
+    });
+};
+
+export default ({ mappings, permissions, record, resource }) => {
+    const promise = resolvePermission({ permissions, record, resource });
+    return Promise.all(mappings.map(promise)).then(matchers =>
+        matchers.find(match => match.matched)
+    );
+};

--- a/src/auth/resolvePermissions.spec.js
+++ b/src/auth/resolvePermissions.spec.js
@@ -1,0 +1,94 @@
+import assert from 'assert';
+import { stub } from 'sinon';
+import resolvePermissions from './resolvePermissions';
+
+describe('resolvePermissions', () => {
+    const checker = stub().callsFake(params =>
+        Promise.resolve(params.permissions === 'function')
+    );
+    const parameters = {
+        mappings: [
+            { permissions: 'admin', view: 'SingleValue' },
+            {
+                permissions: ['ignored_role', 'array_value'],
+                view: 'ArrayValue',
+            },
+            {
+                permissions: ['array_value_exact_1', 'array_value_exact_2'],
+                exact: true,
+                view: 'ArrayValueExactMatch',
+            },
+            {
+                resolve: checker,
+                view: 'FunctionValue',
+                exact: true,
+                permissions: 'foo',
+            },
+        ],
+        resource: 'products',
+        record: { category: 'announcements' },
+    };
+
+    it('returns a match with mapping having a single value permissions and available permissions is a single value', async () => {
+        const match = await resolvePermissions({
+            ...parameters,
+            permissions: 'admin',
+        });
+
+        assert.equal(match.view, 'SingleValue');
+    });
+
+    it('returns a match with mapping having an array of permissions and available permissions is a single value', async () => {
+        const match = await resolvePermissions({
+            ...parameters,
+            permissions: 'array_value',
+        });
+
+        assert.equal(match.view, 'ArrayValue');
+    });
+
+    it('returns a match with mapping having an array of permissions, available permissions is an array and exact is falsy', async () => {
+        const match = await resolvePermissions({
+            ...parameters,
+            permissions: ['array_value', 'foo'],
+        });
+
+        assert.equal(match.view, 'ArrayValue');
+    });
+
+    it('returns a match with mapping having an array of permissions, available permissions is a single value and exact match requested', async () => {
+        const match = await resolvePermissions({
+            ...parameters,
+            permissions: ['array_value_exact_1', 'array_value_exact_2'],
+        });
+
+        assert.equal(match.view, 'ArrayValueExactMatch');
+    });
+
+    it('returns a match with resolve being a function', async () => {
+        const match = await resolvePermissions({
+            ...parameters,
+            permissions: 'function',
+        });
+
+        assert.equal(match.view, 'FunctionValue');
+        assert(
+            checker.calledWith({
+                permissions: 'function',
+                resource: 'products',
+                record: { category: 'announcements' },
+                exact: true,
+                value: 'foo',
+            })
+        );
+    });
+
+    it('returns undefined if no match found', async () => {
+        const match = await resolvePermissions({
+            ...parameters,
+            permissions: 'an_unknown_permission',
+        });
+
+        assert.equal(match, undefined);
+    });
+});

--- a/src/auth/types.js
+++ b/src/auth/types.js
@@ -2,3 +2,4 @@ export const AUTH_LOGIN = 'AUTH_LOGIN';
 export const AUTH_CHECK = 'AUTH_CHECK';
 export const AUTH_ERROR = 'AUTH_ERROR';
 export const AUTH_LOGOUT = 'AUTH_LOGOUT';
+export const AUTH_GET_PERMISSIONS = 'AUTH_GET_PERMISSIONS';

--- a/src/auth/withPermissionsFilteredChildren.js
+++ b/src/auth/withPermissionsFilteredChildren.js
@@ -1,4 +1,4 @@
-import React, { cloneElement, Children, Component } from 'react';
+import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import getContext from 'recompose/getContext';
 import { AUTH_GET_PERMISSIONS } from './types';

--- a/src/auth/withPermissionsFilteredChildren.js
+++ b/src/auth/withPermissionsFilteredChildren.js
@@ -2,6 +2,7 @@ import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import getContext from 'recompose/getContext';
 import { AUTH_GET_PERMISSIONS } from './types';
+import getMissingAuthClientError from '../util/getMissingAuthClientError';
 
 export default BaseComponent => {
     class WithPermissionsFilteredChildren extends Component {
@@ -19,6 +20,12 @@ export default BaseComponent => {
 
         initializeChildren(children) {
             if (typeof children === 'function') {
+                if (!this.props.authClient) {
+                    throw new Error(
+                        getMissingAuthClientError(BaseComponent.name)
+                    );
+                }
+
                 this.props
                     .authClient(AUTH_GET_PERMISSIONS)
                     .then(permissions => {
@@ -41,7 +48,7 @@ export default BaseComponent => {
                                   child
                                       ? cloneElement(child, {
                                             key:
-                                                child.props.key ||
+                                                child.props.name ||
                                                 child.props.source ||
                                                 child.props.label,
                                         })

--- a/src/auth/withPermissionsFilteredChildren.js
+++ b/src/auth/withPermissionsFilteredChildren.js
@@ -26,7 +26,7 @@ export default BaseComponent => {
                         this.setState({ children: allowedChildren });
                     });
             } else {
-                this.setState({ children: Children.toArray(children) });
+                this.setState({ children });
             }
         }
 

--- a/src/auth/withPermissionsFilteredChildren.js
+++ b/src/auth/withPermissionsFilteredChildren.js
@@ -1,0 +1,48 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import getContext from 'recompose/getContext';
+import { AUTH_GET_PERMISSIONS } from './types';
+
+export default BaseComponent => {
+    class WithPermissionsFilteredChildren extends Component {
+        state = { children: null };
+
+        static propTypes = {
+            authClient: PropTypes.func,
+            children: PropTypes.oneOfType([PropTypes.node, PropTypes.func])
+                .isRequired,
+        };
+
+        componentDidMount() {
+            this.initializeChildren(this.props.children);
+        }
+
+        initializeChildren(children) {
+            if (typeof children === 'function') {
+                this.props
+                    .authClient(AUTH_GET_PERMISSIONS)
+                    .then(permissions => {
+                        const allowedChildren = children(permissions);
+                        this.setState({ children: allowedChildren });
+                    });
+            } else {
+                this.setState({ children });
+            }
+        }
+
+        render() {
+            const { children } = this.state;
+            const { authClient, ...props } = this.props;
+
+            return (
+                <BaseComponent {...props}>
+                    {children}
+                </BaseComponent>
+            );
+        }
+    }
+
+    return getContext({
+        authClient: PropTypes.func,
+    })(WithPermissionsFilteredChildren);
+};

--- a/src/auth/withPermissionsFilteredChildren.js
+++ b/src/auth/withPermissionsFilteredChildren.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { cloneElement, Children, Component } from 'react';
 import PropTypes from 'prop-types';
 import getContext from 'recompose/getContext';
 import { AUTH_GET_PERMISSIONS } from './types';
@@ -26,17 +26,28 @@ export default BaseComponent => {
                         this.setState({ children: allowedChildren });
                     });
             } else {
-                this.setState({ children });
+                this.setState({ children: Children.toArray(children) });
             }
         }
 
         render() {
             const { children } = this.state;
             const { authClient, ...props } = this.props;
-
             return (
                 <BaseComponent {...props}>
-                    {children}
+                    {children && Array.isArray(children)
+                        ? children.map(
+                              child =>
+                                  child
+                                      ? cloneElement(child, {
+                                            key:
+                                                child.props.key ||
+                                                child.props.source ||
+                                                child.props.label,
+                                        })
+                                      : null
+                          )
+                        : children}
                 </BaseComponent>
             );
         }

--- a/src/mui/detail/Create.js
+++ b/src/mui/detail/Create.js
@@ -105,9 +105,9 @@ function mapStateToProps(state) {
 }
 
 const enhance = compose(
-    withPermissionsFilteredChildren,
     connect(mapStateToProps, { crudCreate: crudCreateAction }),
-    translate
+    translate,
+    withPermissionsFilteredChildren
 );
 
 export default enhance(Create);

--- a/src/mui/detail/Create.js
+++ b/src/mui/detail/Create.js
@@ -9,6 +9,7 @@ import Title from '../layout/Title';
 import { crudCreate as crudCreateAction } from '../../actions/dataActions';
 import DefaultActions from './CreateActions';
 import translate from '../../i18n/translate';
+import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
 
 class Create extends Component {
     getBasePath() {
@@ -41,6 +42,8 @@ class Create extends Component {
             title,
             translate,
         } = this.props;
+
+        if (!children) return null;
         const basePath = this.getBasePath();
 
         const resourceName = translate(`resources.${resource}.name`, {
@@ -102,6 +105,7 @@ function mapStateToProps(state) {
 }
 
 const enhance = compose(
+    withPermissionsFilteredChildren,
     connect(mapStateToProps, { crudCreate: crudCreateAction }),
     translate
 );

--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -12,6 +12,7 @@ import {
 } from '../../actions/dataActions';
 import DefaultActions from './EditActions';
 import translate from '../../i18n/translate';
+import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
 
 export class Edit extends Component {
     constructor(props) {
@@ -80,6 +81,9 @@ export class Edit extends Component {
             title,
             translate,
         } = this.props;
+
+        if (!children) return null;
+
         const basePath = this.getBasePath();
 
         const resourceName = translate(`resources.${resource}.name`, {
@@ -128,7 +132,7 @@ export class Edit extends Component {
 
 Edit.propTypes = {
     actions: PropTypes.element,
-    children: PropTypes.element.isRequired,
+    children: PropTypes.node,
     crudGetOne: PropTypes.func.isRequired,
     crudUpdate: PropTypes.func.isRequired,
     data: PropTypes.object,
@@ -147,16 +151,18 @@ Edit.propTypes = {
 function mapStateToProps(state, props) {
     return {
         id: decodeURIComponent(props.match.params.id),
-        data:
-            state.admin.resources[props.resource].data[
-                decodeURIComponent(props.match.params.id)
-            ],
+        data: state.admin.resources[props.resource]
+            ? state.admin.resources[props.resource].data[
+                  decodeURIComponent(props.match.params.id)
+              ]
+            : null,
         isLoading: state.admin.loading > 0,
         version: state.admin.ui.viewVersion,
     };
 }
 
 const enhance = compose(
+    withPermissionsFilteredChildren,
     connect(mapStateToProps, {
         crudGetOne: crudGetOneAction,
         crudUpdate: crudUpdateAction,

--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -162,12 +162,12 @@ function mapStateToProps(state, props) {
 }
 
 const enhance = compose(
-    withPermissionsFilteredChildren,
     connect(mapStateToProps, {
         crudGetOne: crudGetOneAction,
         crudUpdate: crudUpdateAction,
     }),
-    translate
+    translate,
+    withPermissionsFilteredChildren
 );
 
 export default enhance(Edit);

--- a/src/mui/detail/Show.js
+++ b/src/mui/detail/Show.js
@@ -47,6 +47,8 @@ export class Show extends Component {
             hasEdit,
             translate,
         } = this.props;
+
+        if (!children) return null;
         const basePath = this.getBasePath();
 
         const resourceName = translate(`resources.${resource}.name`, {

--- a/src/mui/detail/Show.js
+++ b/src/mui/detail/Show.js
@@ -120,9 +120,9 @@ function mapStateToProps(state, props) {
 }
 
 const enhance = compose(
-    withPermissionsFilteredChildren,
     connect(mapStateToProps, { crudGetOne: crudGetOneAction }),
-    translate
+    translate,
+    withPermissionsFilteredChildren
 );
 
 export default enhance(Show);

--- a/src/mui/detail/Show.js
+++ b/src/mui/detail/Show.js
@@ -9,6 +9,7 @@ import Title from '../layout/Title';
 import { crudGetOne as crudGetOneAction } from '../../actions/dataActions';
 import DefaultActions from './ShowActions';
 import translate from '../../i18n/translate';
+import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
 
 export class Show extends Component {
     componentDidMount() {
@@ -106,16 +107,18 @@ Show.propTypes = {
 function mapStateToProps(state, props) {
     return {
         id: decodeURIComponent(props.match.params.id),
-        data:
-            state.admin.resources[props.resource].data[
-                decodeURIComponent(props.match.params.id)
-            ],
+        data: state.admin.resources[props.resource]
+            ? state.admin.resources[props.resource].data[
+                  decodeURIComponent(props.match.params.id)
+              ]
+            : null,
         isLoading: state.admin.loading > 0,
         version: state.admin.ui.viewVersion,
     };
 }
 
 const enhance = compose(
+    withPermissionsFilteredChildren,
     connect(mapStateToProps, { crudGetOne: crudGetOneAction }),
     translate
 );

--- a/src/mui/detail/SimpleShowLayout.js
+++ b/src/mui/detail/SimpleShowLayout.js
@@ -15,7 +15,7 @@ export const SimpleShowLayout = ({
             <div
                 key={field.props.source}
                 style={field.props.style}
-                className={`aor-field-${field.props.source}`}
+                className={`aor-field aor-field-${field.props.source}`}
             >
                 {field.props.addLabel
                     ? <Labeled

--- a/src/mui/detail/Tab.js
+++ b/src/mui/detail/Tab.js
@@ -10,7 +10,7 @@ const Tab = ({ label, icon, children, ...rest }) =>
                 <div
                     key={field.props.source}
                     style={field.props.style}
-                    className={`aor-field-${field.props.source}`}
+                    className={`aor-field aor-field-${field.props.source}`}
                 >
                     {field.props.addLabel
                         ? <Labeled

--- a/src/mui/detail/TabbedShowLayout.js
+++ b/src/mui/detail/TabbedShowLayout.js
@@ -34,19 +34,23 @@ export class TabbedShowLayout extends Component {
                     onChange={this.handleChange}
                     contentContainerStyle={contentContainerStyle}
                 >
-                    {React.Children.map(children, (tab, index) =>
-                        <Tab
-                            key={tab.props.value}
-                            label={translate(tab.props.label)}
-                            value={index}
-                            icon={tab.props.icon}
-                        >
-                            {React.cloneElement(tab, {
-                                resource,
-                                record,
-                                basePath,
-                            })}
-                        </Tab>
+                    {React.Children.map(
+                        children,
+                        (tab, index) =>
+                            tab
+                                ? <Tab
+                                      key={tab.props.value}
+                                      label={translate(tab.props.label)}
+                                      value={index}
+                                      icon={tab.props.icon}
+                                  >
+                                      {React.cloneElement(tab, {
+                                          resource,
+                                          record,
+                                          basePath,
+                                      })}
+                                  </Tab>
+                                : null
                     )}
                 </Tabs>
             </div>

--- a/src/mui/form/FormInput.js
+++ b/src/mui/form/FormInput.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import FormField from './FormField';
+
+const FormInput = ({ input, ...rest }) =>
+    input
+        ? <div
+              className={`aor-input aor-input-${input.props.source}`}
+              style={input.props.style}
+          >
+              <FormField input={input} {...rest} />
+          </div>
+        : null;
+
+export default FormInput;

--- a/src/mui/form/FormTab.js
+++ b/src/mui/form/FormTab.js
@@ -10,7 +10,7 @@ const FormTab = ({ label, icon, children, ...rest }) =>
                 <div
                     key={input.props.source}
                     style={input.props.style}
-                    className={`aor-input-${input.props.source}`}
+                    className={`aor-input aor-input-${input.props.source}`}
                 >
                     <FormField input={input} {...rest} />
                 </div>

--- a/src/mui/form/FormTab.js
+++ b/src/mui/form/FormTab.js
@@ -1,19 +1,11 @@
 import React from 'react';
-import FormField from './FormField';
+import FormInput from './FormInput';
 
 const FormTab = ({ label, icon, children, ...rest }) =>
     <span>
         {React.Children.map(
             children,
-            input =>
-                input &&
-                <div
-                    key={input.props.source}
-                    style={input.props.style}
-                    className={`aor-input aor-input-${input.props.source}`}
-                >
-                    <FormField input={input} {...rest} />
-                </div>
+            input => input && <FormInput input={input} {...rest} />
         )}
     </span>;
 

--- a/src/mui/form/SimpleForm.js
+++ b/src/mui/form/SimpleForm.js
@@ -4,7 +4,7 @@ import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import getDefaultValues from './getDefaultValues';
-import FormField from './FormField';
+import FormInput from './FormInput';
 import Toolbar from './Toolbar';
 
 const formStyle = { padding: '0 1em 1em 1em' };
@@ -15,34 +15,25 @@ export class SimpleForm extends Component {
 
     render() {
         const {
+            basePath,
             children,
             invalid,
             record,
             resource,
-            basePath,
             submitOnEnter,
             toolbar,
         } = this.props;
+
         return (
             <form className="simple-form">
                 <div style={formStyle}>
-                    {Children.map(
-                        children,
-                        input =>
-                            input &&
-                            <div
-                                key={input.props.source}
-                                className={`aor-input aor-input-${input.props
-                                    .source}`}
-                                style={input.props.style}
-                            >
-                                <FormField
-                                    input={input}
-                                    resource={resource}
-                                    record={record}
-                                    basePath={basePath}
-                                />
-                            </div>
+                    {Children.map(children, input =>
+                        <FormInput
+                            basePath={basePath}
+                            input={input}
+                            record={record}
+                            resource={resource}
+                        />
                     )}
                 </div>
                 {toolbar &&

--- a/src/mui/form/SimpleForm.js
+++ b/src/mui/form/SimpleForm.js
@@ -32,7 +32,8 @@ export class SimpleForm extends Component {
                             input &&
                             <div
                                 key={input.props.source}
-                                className={`aor-input-${input.props.source}`}
+                                className={`aor-input aor-input-${input.props
+                                    .source}`}
                                 style={input.props.style}
                             >
                                 <FormField

--- a/src/mui/form/SimpleForm.spec.js
+++ b/src/mui/form/SimpleForm.spec.js
@@ -13,7 +13,7 @@ describe('<SimpleForm />', () => {
                 <TextInput source="city" />
             </SimpleForm>
         );
-        const inputs = wrapper.find('FormField');
+        const inputs = wrapper.find('FormInput');
         assert.deepEqual(inputs.map(i => i.prop('input').props.source), [
             'name',
             'city',

--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -44,22 +44,26 @@ export class TabbedForm extends Component {
                         onChange={this.handleChange}
                         contentContainerStyle={contentContainerStyle}
                     >
-                        {React.Children.map(children, (tab, index) =>
-                            <Tab
-                                key={tab.props.value}
-                                className="form-tab"
-                                label={translate(tab.props.label, {
-                                    _: tab.props.label,
-                                })}
-                                value={index}
-                                icon={tab.props.icon}
-                            >
-                                {React.cloneElement(tab, {
-                                    resource,
-                                    record,
-                                    basePath,
-                                })}
-                            </Tab>
+                        {React.Children.map(
+                            children,
+                            (tab, index) =>
+                                tab
+                                    ? <Tab
+                                          key={tab.props.value}
+                                          className="form-tab"
+                                          label={translate(tab.props.label, {
+                                              _: tab.props.label,
+                                          })}
+                                          value={index}
+                                          icon={tab.props.icon}
+                                      >
+                                          {React.cloneElement(tab, {
+                                              resource,
+                                              record,
+                                              basePath,
+                                          })}
+                                      </Tab>
+                                    : null
                         )}
                     </Tabs>
                 </div>

--- a/src/mui/form/Toolbar.js
+++ b/src/mui/form/Toolbar.js
@@ -37,16 +37,20 @@ const Toolbar = ({
                               raised={false}
                               submitOnEnter={submitOnEnter}
                           />
-                        : Children.map(children, button =>
-                              React.cloneElement(button, {
-                                  invalid,
-                                  handleSubmitWithRedirect,
-                                  raised: false,
-                                  submitOnEnter: valueOrDefault(
-                                      button.props.submitOnEnter,
-                                      submitOnEnter
-                                  ),
-                              })
+                        : Children.map(
+                              children,
+                              button =>
+                                  button
+                                      ? React.cloneElement(button, {
+                                            invalid,
+                                            handleSubmitWithRedirect,
+                                            raised: false,
+                                            submitOnEnter: valueOrDefault(
+                                                button.props.submitOnEnter,
+                                                submitOnEnter
+                                            ),
+                                        })
+                                      : null
                           )}
                 </ToolbarGroup>
             </MuiToolbar>
@@ -62,15 +66,19 @@ const Toolbar = ({
                               invalid={invalid}
                               submitOnEnter={submitOnEnter}
                           />
-                        : Children.map(children, button =>
-                              React.cloneElement(button, {
-                                  handleSubmitWithRedirect,
-                                  invalid,
-                                  submitOnEnter: valueOrDefault(
-                                      button.props.submitOnEnter,
-                                      submitOnEnter
-                                  ),
-                              })
+                        : Children.map(
+                              children,
+                              button =>
+                                  button
+                                      ? React.cloneElement(button, {
+                                            handleSubmitWithRedirect,
+                                            invalid,
+                                            submitOnEnter: valueOrDefault(
+                                                button.props.submitOnEnter,
+                                                submitOnEnter
+                                            ),
+                                        })
+                                      : null
                           )}
                 </ToolbarGroup>
             </MuiToolbar>

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { createElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -12,6 +12,7 @@ import injectTapEventPlugin from 'react-tap-event-plugin';
 import AdminRoutes from '../../AdminRoutes';
 import AppBar from './AppBar';
 import Sidebar from './Sidebar';
+import Menu from './Menu';
 import Notification from './Notification';
 import defaultTheme from '../defaultTheme';
 import { setSidebarVisibility as setSidebarVisibilityAction } from '../../actions';
@@ -52,7 +53,7 @@ const styles = {
         top: 0,
         right: 0,
         margin: 16,
-        zIndex: 1200,
+        zInœdex: 1200,
     },
 };
 
@@ -68,16 +69,18 @@ class Layout extends Component {
     render() {
         const {
             authClient,
+            children,
             customRoutes,
             dashboard,
             isLoading,
+            logout,
             menu,
             catchAll,
-            resources,
             theme,
             title,
             width,
         } = this.props;
+
         const muiTheme = getMuiTheme(theme);
         if (!prefixedStyles.main) {
             // do this once because user agent never changes
@@ -111,14 +114,18 @@ class Layout extends Component {
                             >
                                 <AdminRoutes
                                     customRoutes={customRoutes}
-                                    resources={resources}
                                     authClient={authClient}
                                     dashboard={dashboard}
                                     catchAll={catchAll}
-                                />
+                                >
+                                    {children}
+                                </AdminRoutes>
                             </div>
                             <Sidebar theme={theme}>
-                                {menu}
+                                {createElement(menu || Menu, {
+                                    logout,
+                                    hasDashboard: !!dashboard,
+                                })}
                             </Sidebar>
                         </div>
                         <Notification />
@@ -144,12 +151,17 @@ const componentPropType = PropTypes.oneOfType([
 
 Layout.propTypes = {
     authClient: PropTypes.func,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     catchAll: componentPropType,
     customRoutes: PropTypes.array,
     dashboard: componentPropType,
     isLoading: PropTypes.bool.isRequired,
-    menu: PropTypes.element,
-    resources: PropTypes.array,
+    logout: PropTypes.oneOfType([
+        PropTypes.node,
+        PropTypes.func,
+        PropTypes.string,
+    ]),
+    menu: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     setSidebarVisibility: PropTypes.func.isRequired,
     title: PropTypes.node.isRequired,
     theme: PropTypes.object.isRequired,

--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -68,7 +68,6 @@ class Layout extends Component {
 
     render() {
         const {
-            authClient,
             children,
             customRoutes,
             dashboard,
@@ -114,7 +113,6 @@ class Layout extends Component {
                             >
                                 <AdminRoutes
                                     customRoutes={customRoutes}
-                                    authClient={authClient}
                                     dashboard={dashboard}
                                     catchAll={catchAll}
                                 >
@@ -150,7 +148,6 @@ const componentPropType = PropTypes.oneOfType([
 ]);
 
 Layout.propTypes = {
-    authClient: PropTypes.func,
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     catchAll: componentPropType,
     customRoutes: PropTypes.array,

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import inflection from 'inflection';
-import pure from 'recompose/pure';
 import compose from 'recompose/compose';
 import DashboardMenuItem from './DashboardMenuItem';
 import MenuItemLink from './MenuItemLink';
 import translate from '../../i18n/translate';
+import withResources from './withResources';
 
 const styles = {
     main: {
@@ -57,6 +57,6 @@ Menu.defaultProps = {
     onMenuTap: () => null,
 };
 
-const enhance = compose(pure, translate);
+const enhance = compose(translate, withResources);
 
 export default enhance(Menu);

--- a/src/mui/layout/Menu.js
+++ b/src/mui/layout/Menu.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import inflection from 'inflection';
 import compose from 'recompose/compose';
 import DashboardMenuItem from './DashboardMenuItem';
 import MenuItemLink from './MenuItemLink';
 import translate from '../../i18n/translate';
-import withResources from './withResources';
+import { getResources } from '../../reducer';
 
 const styles = {
     main: {
@@ -57,6 +58,10 @@ Menu.defaultProps = {
     onMenuTap: () => null,
 };
 
-const enhance = compose(translate, withResources);
+const mapStateToProps = state => ({
+    resources: getResources(state),
+});
+
+const enhance = compose(translate, connect(mapStateToProps));
 
 export default enhance(Menu);

--- a/src/mui/layout/withResources.js
+++ b/src/mui/layout/withResources.js
@@ -1,9 +1,0 @@
-import { connect } from 'react-redux';
-
-const mapStateToProps = state => ({
-    resources: Object.keys(state.admin.resources).map(
-        key => state.admin.resources[key].props
-    ),
-});
-
-export default connect(mapStateToProps);

--- a/src/mui/layout/withResources.js
+++ b/src/mui/layout/withResources.js
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+
+const mapStateToProps = state => ({
+    resources: Object.keys(state.admin.resources).map(
+        key => state.admin.resources[key].props
+    ),
+});
+
+export default connect(mapStateToProps);

--- a/src/mui/list/Datagrid.js
+++ b/src/mui/list/Datagrid.js
@@ -104,22 +104,29 @@ class Datagrid extends Component {
                     {...headerOptions}
                 >
                     <TableRow style={muiTheme.tableRow}>
-                        {React.Children.map(children, (field, index) =>
-                            <DatagridHeaderCell
-                                key={field.props.source || index}
-                                field={field}
-                                defaultStyle={
-                                    index === 0
-                                        ? styles.header['th:first-child']
-                                        : styles.header.th
-                                }
-                                currentSort={currentSort}
-                                isSorting={
-                                    field.props.source === currentSort.field
-                                }
-                                updateSort={this.updateSort}
-                                resource={resource}
-                            />
+                        {React.Children.map(
+                            children,
+                            (field, index) =>
+                                field
+                                    ? <DatagridHeaderCell
+                                          key={field.props.source || index}
+                                          field={field}
+                                          defaultStyle={
+                                              index === 0
+                                                  ? styles.header[
+                                                        'th:first-child'
+                                                    ]
+                                                  : styles.header.th
+                                          }
+                                          currentSort={currentSort}
+                                          isSorting={
+                                              field.props.source ===
+                                              currentSort.field
+                                          }
+                                          updateSort={this.updateSort}
+                                          resource={resource}
+                                      />
+                                    : null
                         )}
                     </TableRow>
                 </TableHeader>

--- a/src/mui/list/DatagridBody.js
+++ b/src/mui/list/DatagridBody.js
@@ -29,18 +29,22 @@ const DatagridBody = ({
                 selectable={false}
                 {...rowOptions}
             >
-                {React.Children.map(children, (field, index) =>
-                    <DatagridCell
-                        key={`${id}-${field.props.source || index}`}
-                        className={`column-${field.props.source}`}
-                        record={data[id]}
-                        defaultStyle={
-                            index === 0
-                                ? styles.cell['td:first-child']
-                                : styles.cell.td
-                        }
-                        {...{ field, basePath, resource }}
-                    />
+                {React.Children.map(
+                    children,
+                    (field, index) =>
+                        field
+                            ? <DatagridCell
+                                  key={`${id}-${field.props.source || index}`}
+                                  className={`column-${field.props.source}`}
+                                  record={data[id]}
+                                  defaultStyle={
+                                      index === 0
+                                          ? styles.cell['td:first-child']
+                                          : styles.cell.td
+                                  }
+                                  {...{ field, basePath, resource }}
+                              />
+                            : null
                 )}
             </TableRow>
         )}

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -7,8 +7,9 @@ import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
 import defaultTheme from '../defaultTheme';
 import removeEmpty from '../../util/removeEmpty';
+import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
 
-class Filter extends Component {
+export class Filter extends Component {
     constructor(props) {
         super(props);
         this.filters = this.props.filterValues;
@@ -99,4 +100,4 @@ Filter.defaultProps = {
     theme: defaultTheme,
 };
 
-export default Filter;
+export default withPermissionsFilteredChildren(Filter);

--- a/src/mui/list/Filter.spec.js
+++ b/src/mui/list/Filter.spec.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Filter from './Filter';
+import { Filter } from './Filter';
 
 describe('<Filter />', () => {
     describe('With form context', () => {

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -24,6 +24,7 @@ import { changeListParams as changeListParamsAction } from '../../actions/listAc
 import translate from '../../i18n/translate';
 import removeKey from '../../util/removeKey';
 import defaultTheme from '../defaultTheme';
+import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
 
 const styles = {
     noResults: { padding: 20 },
@@ -75,10 +76,7 @@ const styles = {
  *     );
  */
 export class List extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {};
-    }
+    state = {};
 
     componentDidMount() {
         this.updateData();
@@ -196,6 +194,7 @@ export class List extends Component {
 
     render() {
         const {
+            children,
             filters,
             pagination = <DefaultPagination />,
             actions = <DefaultActions />,
@@ -205,7 +204,6 @@ export class List extends Component {
             data,
             ids,
             total,
-            children,
             isLoading,
             translate,
             theme,
@@ -298,8 +296,9 @@ List.propTypes = {
         field: PropTypes.string,
         order: PropTypes.string,
     }),
-    children: PropTypes.element.isRequired,
+    children: PropTypes.node,
     // the props managed by admin-on-rest
+    authClient: PropTypes.func,
     changeListParams: PropTypes.func.isRequired,
     crudGetList: PropTypes.func.isRequired,
     data: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -359,7 +358,8 @@ const enhance = compose(
         changeListParams: changeListParamsAction,
         push: pushAction,
     }),
-    translate
+    translate,
+    withPermissionsFilteredChildren
 );
 
 export default enhance(List);

--- a/src/reducer/admin/index.js
+++ b/src/reducer/admin/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import resources from './resource';
+import resources, { getResources as innerGetResources } from './resource';
 import loading from './loading';
 import notification from './notification';
 import record from './record';
@@ -16,3 +16,5 @@ export default combineReducers({
     saving,
     ui,
 });
+
+export const getResources = state => innerGetResources(state.resources);

--- a/src/reducer/admin/index.js
+++ b/src/reducer/admin/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import resourceReducer from './resource';
+import resources from './resource';
 import loading from './loading';
 import notification from './notification';
 import record from './record';
@@ -7,21 +7,12 @@ import references from './references';
 import saving from './saving';
 import ui from './ui';
 
-export default resources => {
-    const resourceReducers = {};
-    resources.forEach(resource => {
-        resourceReducers[resource.name] = resourceReducer(
-            resource.name,
-            resource.options
-        );
-    });
-    return combineReducers({
-        resources: combineReducers(resourceReducers),
-        loading,
-        notification,
-        record,
-        references,
-        saving,
-        ui,
-    });
-};
+export default combineReducers({
+    resources,
+    loading,
+    notification,
+    record,
+    references,
+    saving,
+    ui,
+});

--- a/src/reducer/admin/resource/index.js
+++ b/src/reducer/admin/resource/index.js
@@ -4,15 +4,20 @@ import data from './data';
 import list from './list';
 
 const initialState = {};
-export default (previousState = initialState, action) => {
+export default (
+    previousState = initialState,
+    action,
+    dataReducer = data,
+    listReducer = list
+) => {
     if (action.type === DECLARE_RESOURCES) {
         const newState = action.payload.reduce(
             (acc, resource) => ({
                 ...acc,
                 [resource.name]: {
                     props: resource,
-                    data: data(resource.name)(undefined, action),
-                    list: list(resource.name)(undefined, action),
+                    data: dataReducer(resource.name)(undefined, action),
+                    list: listReducer(resource.name)(undefined, action),
                 },
             }),
             {}
@@ -20,15 +25,32 @@ export default (previousState = initialState, action) => {
         return newState;
     }
 
+    if (!action.meta || !action.meta.resource) {
+        return previousState;
+    }
+
     const resources = Object.keys(previousState);
     const newState = resources.reduce(
         (acc, resource) => ({
             ...acc,
-            [resource]: {
-                props: previousState[resource].props,
-                data: data(resource)(previousState[resource].data, action),
-                list: list(resource)(previousState[resource].list, action),
-            },
+            [resource]:
+                action.meta.resource === resource
+                    ? {
+                          props: previousState[resource].props,
+                          data: dataReducer(resource)(
+                              previousState[resource].data,
+                              action
+                          ),
+                          list: listReducer(resource)(
+                              previousState[resource].list,
+                              action
+                          ),
+                      }
+                    : {
+                          props: previousState[resource].props,
+                          data: previousState[resource].data,
+                          list: previousState[resource].list,
+                      },
         }),
         {}
     );

--- a/src/reducer/admin/resource/index.js
+++ b/src/reducer/admin/resource/index.js
@@ -35,3 +35,6 @@ export default (previousState = initialState, action) => {
 
     return newState;
 };
+
+export const getResources = state =>
+    Object.keys(state).map(key => state[key].props);

--- a/src/reducer/admin/resource/index.js
+++ b/src/reducer/admin/resource/index.js
@@ -1,9 +1,37 @@
-import { combineReducers } from 'redux';
+import { DECLARE_RESOURCES } from '../../../actions';
+
 import data from './data';
 import list from './list';
 
-export default resource =>
-    combineReducers({
-        data: data(resource),
-        list: list(resource),
-    });
+const initialState = {};
+export default (previousState = initialState, action) => {
+    if (action.type === DECLARE_RESOURCES) {
+        const newState = action.payload.reduce(
+            (acc, resource) => ({
+                ...acc,
+                [resource.name]: {
+                    props: resource,
+                    data: data(resource.name)(undefined, action),
+                    list: list(resource.name)(undefined, action),
+                },
+            }),
+            {}
+        );
+        return newState;
+    }
+
+    const resources = Object.keys(previousState);
+    const newState = resources.reduce(
+        (acc, resource) => ({
+            ...acc,
+            [resource]: {
+                props: previousState[resource].props,
+                data: data(resource)(previousState[resource].data, action),
+                list: list(resource)(previousState[resource].list, action),
+            },
+        }),
+        {}
+    );
+
+    return newState;
+};

--- a/src/reducer/admin/resource/index.spec.js
+++ b/src/reducer/admin/resource/index.spec.js
@@ -1,0 +1,97 @@
+import assert from 'assert';
+import { stub } from 'sinon';
+import reducer from './index';
+import { DECLARE_RESOURCES } from '../../../actions';
+
+describe('Resources Reducer', () => {
+    it('should return previous state if the action has no resource meta and is not DECLARE_RESOURCES', () => {
+        const previousState = { previous: true };
+        assert.deepEqual(
+            reducer(previousState, { type: 'A_TYPE', meta: { foo: 'bar' } }),
+            previousState
+        );
+    });
+
+    it('should initialize resources upon DECLARE_RESOURCES', () => {
+        const postsList = () => {};
+        const commentsCreate = () => {};
+        const usersEdit = () => {};
+        const resources = [
+            { name: 'posts', list: postsList },
+            { name: 'comments', create: commentsCreate },
+            { name: 'users', edit: usersEdit },
+        ];
+
+        const dataReducer = () => () => 'data_data';
+        const listReducer = () => () => 'list_data';
+
+        assert.deepEqual(
+            reducer(
+                { oldResource: {} },
+                { type: DECLARE_RESOURCES, payload: resources },
+                dataReducer,
+                listReducer
+            ),
+            {
+                posts: {
+                    data: 'data_data',
+                    list: 'list_data',
+                    props: { name: 'posts', list: postsList },
+                },
+                comments: {
+                    data: 'data_data',
+                    list: 'list_data',
+                    props: { name: 'comments', create: commentsCreate },
+                },
+                users: {
+                    data: 'data_data',
+                    list: 'list_data',
+                    props: { name: 'users', edit: usersEdit },
+                },
+            }
+        );
+    });
+
+    it('should call inner reducers for each resource when action has a resource meta', () => {
+        const innerReducer = state => state;
+        const dataReducer = stub().callsFake(() => innerReducer);
+        const listReducer = stub().callsFake(() => innerReducer);
+
+        assert.deepEqual(
+            reducer(
+                {
+                    posts: {
+                        data: 'data_data',
+                        list: 'list_data',
+                        props: { name: 'posts' },
+                    },
+                    comments: {
+                        data: 'data_data',
+                        list: 'list_data',
+                        props: { name: 'comments' },
+                    },
+                },
+                { type: 'A_RESOURCE_ACTION', meta: { resource: 'posts' } },
+                dataReducer,
+                listReducer
+            ),
+            {
+                posts: {
+                    data: 'data_data',
+                    list: 'list_data',
+                    props: { name: 'posts' },
+                },
+                comments: {
+                    data: 'data_data',
+                    list: 'list_data',
+                    props: { name: 'comments' },
+                },
+            }
+        );
+
+        assert(dataReducer.calledWith('posts'));
+        assert(listReducer.calledWith('posts'));
+        assert(dataReducer.neverCalledWith('comments'));
+        assert(listReducer.neverCalledWith('comments'));
+    });
+});

--- a/src/reducer/index.js
+++ b/src/reducer/index.js
@@ -1,12 +1,12 @@
 import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { routerReducer } from 'react-router-redux';
-import adminReducer from './admin';
+import admin from './admin';
 import localeReducer from './locale';
 
-export default (resources, customReducers, locale) =>
+export default (customReducers, locale) =>
     combineReducers({
-        admin: adminReducer(resources),
+        admin,
         locale: localeReducer(locale),
         form: formReducer,
         routing: routerReducer,

--- a/src/reducer/index.js
+++ b/src/reducer/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { routerReducer } from 'react-router-redux';
-import admin from './admin';
+import admin, { getResources as getAdminResources } from './admin';
 import localeReducer from './locale';
 
 export default (customReducers, locale) =>
@@ -12,3 +12,5 @@ export default (customReducers, locale) =>
         routing: routerReducer,
         ...customReducers,
     });
+
+export const getResources = state => getAdminResources(state.admin);

--- a/src/util/getMissingAuthClientError.js
+++ b/src/util/getMissingAuthClientError.js
@@ -1,0 +1,7 @@
+const errorMessage = component => `
+    You specified a function as the child of the ${component} component. 
+    This requires you to set up an authClient as well.
+    See the documentation: https://marmelab.com/admin-on-rest/Authorization.html
+`;
+
+export default errorMessage;


### PR DESCRIPTION
Proposal for resources permissions check:

```jsx
<Admin
    restClient={restClient}
    authClient={authClient}
>
    {permissions => [
        <Resource name="customers" list={permissions === 'admin' ? VisitorList : null} edit={VisitorEdit} remove={VisitorDelete} icon={VisitorIcon} />,
        <Resource name="commands" list={CommandList} edit={CommandEdit} remove={Delete} icon={CommandIcon} options={{ label: 'Orders' }} />,
        <Resource name="products" list={ProductList} create={ProductCreate} edit={ProductEdit} remove={Delete} icon={ProductIcon} />,
        <Resource name="categories" list={CategoryList} edit={CategoryEdit} remove={Delete} icon={CategoryIcon} />,
        <Resource name="reviews" list={ReviewList} edit={ReviewEdit} icon={ReviewIcon} />,
    ]}
</Admin>
```

In a nutshell, specify a function instead of nodes as the Admin children. This function will be called with the results of the call to the `authClient` with type `AUTH_GET_PERMISSIONS`. Then do whatever you want with it. The `authClient` has to return a promise as usual but it can resolves to whatever you need: single role, multiple roles or even the user itself.

Note that in the example, we return an array of components to avoid React warning about having to wrap them in a container element.

I updated the `List`, `Create`, `Edit`, `Show` and `Filter` components to allow this too. For example:

- List
```jsx
export const PostList = ({ ...props }) =>
    <List
        {...props}
        filters={<PostFilter />}
        sort={{ field: 'published_at', order: 'DESC' }}
    >
        {permissions =>
            <Responsive
                small={
                    <SimpleList
                        primaryText={record => record.title}
                        secondaryText={
                            permissions === 'admin'
                                ? record => `${record.views} views`
                                : null
                        }
                    />
                }
                medium={
                    <Datagrid>
                        {permissions === 'admin'
                            ? <TextField source="id" />
                            : null}
                        {permissions === 'admin' && <TextField source="title" style={titleFieldStyle} />}
                        <DateField
                            source="published_at"
                            style={{ fontStyle: 'italic' }}
                        />
                    </Datagrid>
                }
            />}
    </List>;
```

- Filter
```jsx
const CommandFilter = props => (
    <Filter {...props}>
        {permissions => [
            <TextInput label="pos.search" source="q" alwaysOn />,
            permissions === 'admin' && <NullableBooleanInput source="returned" />,
        ]}
    </Filter>
);
```

I tested with the demo app and it works fine :)

I also kept the other components as well (`WithPermissions` and `SwitchPermissions`) for usage inside custom menu, custom pages and dashboard.

### TODO:
- [x] Ability to apply permissions on resources
- [x] Use context from `Admin` to inject the `authClient`
- [x] Integration of aor-permissions components for other use cases (`WithPermissions`, `SwitchPermissions`
- [x] Updated `List`, `Create`, `Edit`, `Show` and `Filter` so they accept either nodes or a function as their children like `Admin` does
- [x] More tests
- [x] Documentation