### PR TITLE
[RFR] Fix TabbedForm errors are hidden for inactive tabs

### DIFF
--- a/src/mui/form/TabbedForm.js
+++ b/src/mui/form/TabbedForm.js
@@ -1,13 +1,19 @@
 import React, { Children, Component } from 'react';
 import PropTypes from 'prop-types';
-import { reduxForm } from 'redux-form';
+import { reduxForm, getFormAsyncErrors, getFormSyncErrors, getFormSubmitErrors } from 'redux-form';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import { Tabs, Tab } from 'material-ui/Tabs';
+import muiThemeable from 'material-ui/styles/muiThemeable';
+
 import Toolbar from './Toolbar';
 import getDefaultValues from './getDefaultValues';
 
-const formStyle = { padding: '0 1em 1em 1em' };
+const getStyles = theme => ({
+    form: { padding: '0 1em 1em 1em' },
+    // TODO: The color will be taken from another property in MUI 0.19 and later
+    errorTabButton: { color: theme.textField.errorColor },
+});
 
 export class TabbedForm extends Component {
     constructor(props) {
@@ -24,10 +30,11 @@ export class TabbedForm extends Component {
     handleSubmitWithRedirect = (redirect = this.props.redirect) => this.props.handleSubmit(values => this.props.save(values, redirect));
 
     render() {
-        const { children, contentContainerStyle, invalid, record, resource, basePath, translate, submitOnEnter, toolbar } = this.props;
+        const { basePath, children, contentContainerStyle, invalid, muiTheme, record, resource, submitOnEnter, tabsWithErrors, toolbar, translate } = this.props;
+        const styles = getStyles(muiTheme);
         return (
             <form className="tabbed-form">
-                <div style={formStyle}>
+                <div style={styles.form}>
                     <Tabs
                         value={this.state.value}
                         onChange={this.handleChange}
@@ -35,11 +42,12 @@ export class TabbedForm extends Component {
                     >
                         {React.Children.map(children, (tab, index) =>
                             <Tab
-                                key={tab.props.value}
+                                key={tab.props.label}
                                 className="form-tab"
                                 label={translate(tab.props.label, { _: tab.props.label })}
                                 value={index}
                                 icon={tab.props.icon}
+                                buttonStyle={tabsWithErrors.includes(tab.props.label) && this.state.value !== index ? styles.errorTabButton : null}
                             >
                                 {React.cloneElement(tab, { resource, record, basePath })}
                             </Tab>,
@@ -66,6 +74,7 @@ TabbedForm.propTypes = {
     ]),
     handleSubmit: PropTypes.func, // passed by redux-form
     invalid: PropTypes.bool,
+    muiTheme: PropTypes.object.isRequired,
     record: PropTypes.object,
     redirect: PropTypes.oneOfType([
         PropTypes.string,
@@ -74,6 +83,7 @@ TabbedForm.propTypes = {
     resource: PropTypes.string,
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     submitOnEnter: PropTypes.bool,
+    tabsWithErrors: PropTypes.arrayOf(PropTypes.string),
     toolbar: PropTypes.element,
     translate: PropTypes.func,
     validate: PropTypes.func,
@@ -85,6 +95,32 @@ TabbedForm.defaultProps = {
     toolbar: <Toolbar />,
 };
 
+const collectErrors = (state) => {
+    const syncErrors = getFormSyncErrors('record-form')(state);
+    const asyncErrors = getFormAsyncErrors('record-form')(state);
+    const submitErrors = getFormSubmitErrors('record-form')(state);
+
+    return {
+        ...syncErrors,
+        ...asyncErrors,
+        ...submitErrors,
+    };
+};
+
+export const findTabsWithErrors = (state, props, collectErrorsImpl = collectErrors) => {
+    const errors = collectErrorsImpl(state);
+
+    return Children.toArray(props.children).reduce((acc, child) => {
+        const inputs = Children.toArray(child.props.children);
+
+        if (inputs.some(input => errors[input.props.source])) {
+            return [...acc, child.props.label];
+        }
+
+        return acc;
+    }, []);
+};
+
 const enhance = compose(
     connect((state, props) => {
         const children = Children.toArray(props.children).reduce((acc, child) => [
@@ -93,6 +129,7 @@ const enhance = compose(
         ], []);
 
         return {
+            tabsWithErrors: findTabsWithErrors(state, props),
             initialValues: getDefaultValues(state, { ...props, children }),
         };
     }),
@@ -100,6 +137,7 @@ const enhance = compose(
         form: 'record-form',
         enableReinitialize: true,
     }),
+    muiThemeable(),
 );
 
 export default enhance(TabbedForm);

--- a/src/mui/form/TabbedForm.spec.js
+++ b/src/mui/form/TabbedForm.spec.js
@@ -1,19 +1,20 @@
 import assert from 'assert';
 import { shallow } from 'enzyme';
-import React from 'react';
+import React, { createElement } from 'react';
 
-import { TabbedForm } from './TabbedForm';
+import { TabbedForm, findTabsWithErrors } from './TabbedForm';
 import FormTab from './FormTab';
 
-const translate = (label) => label;
+const translate = label => label;
+const muiTheme = { textField: { errorColor: 'red' } };
 
 describe('<TabbedForm />', () => {
     it('should render tabs', () => {
         const wrapper = shallow(
-            <TabbedForm translate={translate}>
-              <FormTab />
-              <FormTab />
-            </TabbedForm>
+            <TabbedForm translate={translate} muiTheme={muiTheme} tabsWithErrors={[]}>
+                <FormTab />
+                <FormTab />
+            </TabbedForm>,
         );
         const tabsContainer = wrapper.find('Tabs');
         assert.equal(tabsContainer.length, 1);
@@ -23,8 +24,7 @@ describe('<TabbedForm />', () => {
 
     it('should display <Toolbar />', () => {
         const wrapper = shallow(
-            <TabbedForm translate={translate}>
-            </TabbedForm>
+            <TabbedForm translate={translate} muiTheme={muiTheme} tabsWithErrors={[]} />,
         );
         const button = wrapper.find('Toolbar');
         assert.equal(button.length, 1);
@@ -33,17 +33,77 @@ describe('<TabbedForm />', () => {
     it('should pass submitOnEnter to <Toolbar />', () => {
         const handleSubmit = () => {};
         const wrapper1 = shallow(
-            <TabbedForm translate={translate} submitOnEnter={false} handleSubmit={handleSubmit}>
-            </TabbedForm>
+            <TabbedForm translate={translate} submitOnEnter={false} handleSubmit={handleSubmit} muiTheme={muiTheme} tabsWithErrors={[]} />,
         );
         const button1 = wrapper1.find('Toolbar');
         assert.equal(button1.prop('submitOnEnter'), false);
 
         const wrapper2 = shallow(
-            <TabbedForm translate={translate} submitOnEnter={true} handleSubmit={handleSubmit}>
-            </TabbedForm>
+            <TabbedForm translate={translate} submitOnEnter handleSubmit={handleSubmit} muiTheme={muiTheme} tabsWithErrors={[]} />,
         );
         const button2 = wrapper2.find('Toolbar');
         assert.strictEqual(button2.prop('submitOnEnter'), true);
+    });
+
+    it('should set the style of an inactive Tab button with errors', () => {
+        const wrapper = shallow(
+            <TabbedForm translate={translate} muiTheme={muiTheme} tabsWithErrors={['tab2']}>
+                <FormTab label="tab1" />
+                <FormTab label="tab2" />
+            </TabbedForm>,
+        );
+        const tabs = wrapper.find('Tab');
+        const tab1 = tabs.at(0);
+        const tab2 = tabs.at(1);
+
+        assert.deepEqual(tab1.prop('buttonStyle'), null);
+        assert.deepEqual(tab2.prop('buttonStyle'), { color: muiTheme.textField.errorColor });
+    });
+
+    it('should not set the style of an active Tab button with errors', () => {
+        const wrapper = shallow(
+            <TabbedForm translate={translate} muiTheme={muiTheme} tabsWithErrors={['tab1']}>
+                <FormTab label="tab1" />
+                <FormTab label="tab2" />
+            </TabbedForm>,
+        );
+        const tabs = wrapper.find('Tab');
+        const tab1 = tabs.at(0);
+        const tab2 = tabs.at(1);
+
+        assert.deepEqual(tab1.prop('buttonStyle'), null);
+        assert.deepEqual(tab2.prop('buttonStyle'), null);
+    });
+
+    describe('findTabsWithErrors', () => {
+        it('should find the tabs containing errors', () => {
+            const collectErrors = () => ({ field1: 'required', field5: 'required' });
+            const state = {};
+            const props = {
+                children: [
+                    createElement(
+                        FormTab,
+                        { label: 'tab1' },
+                        createElement('input', { source: 'field1' }),
+                        createElement('input', { source: 'field2' }),
+                    ),
+                    createElement(
+                        FormTab,
+                        { label: 'tab2' },
+                        createElement('input', { source: 'field3' }),
+                        createElement('input', { source: 'field4' }),
+                    ),
+                    createElement(
+                        FormTab,
+                        { label: 'tab3' },
+                        createElement('input', { source: 'field5' }),
+                        createElement('input', { source: 'field6' }),
+                    ),
+                ],
+            };
+
+            const tabs = findTabsWithErrors(state, props, collectErrors);
+            assert.deepEqual(tabs, ['tab1', 'tab3']);
+        });
     });
 });


### PR DESCRIPTION
Fixes #960

When the tab with errors is inactive:
![screen](http://i.imgur.com/3fB2c4V.png)

When the tab with errors is active:
![screen](http://i.imgur.com/3R4OtaV.png)

We don't apply the error style on active tab to avoid displaying errors on non yet dirty fields