### PR TITLE
[fetchJson] check for "Content-Type" already set, before setting automatically

### DIFF
--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -4,7 +4,7 @@ export const fetchJson = (url, options = {}) => {
     const requestHeaders = options.headers || new Headers({
         Accept: 'application/json',
     });
-    if (!(options && options.body && options.body instanceof FormData)) {
+    if (!requestHeaders.has('Content-Type') && !(options && options.body && options.body instanceof FormData)) {
         requestHeaders.set('Content-Type', 'application/json');
     }
     if (options.user && options.user.authenticated && options.user.token) {


### PR DESCRIPTION
..., this way it is possible to use **fetchJson** in own rest clients. In our case we had to fork this, because we use **'application/merge-patch+json'** and **'application/json-patch+json'** in the server, to differentiate between the both formats.