### PR TITLE
[RFR] Fix SelectInput selection via keyboard

### DIFF
--- a/src/mui/input/SelectInput.js
+++ b/src/mui/input/SelectInput.js
@@ -84,6 +84,17 @@ export class SelectInput extends Component {
         this.setState({ value });
     }
 
+    addAllowEmpty = (choices) => {
+        if (this.props.allowEmpty) {
+            return [
+                <MenuItem value={null} primaryText="" />,
+                ...choices,
+            ];
+        }
+
+        return choices;
+    }
+
     renderMenuItem = (choice) => {
         const {
             optionText,
@@ -128,10 +139,7 @@ export class SelectInput extends Component {
                 errorText={touched && error}
                 {...options}
             >
-                {allowEmpty &&
-                    <MenuItem value={null} primaryText="" />
-                }
-                {choices.map(this.renderMenuItem)}
+                {this.addAllowEmpty(choices.map(this.renderMenuItem))}
             </SelectField>
         );
     }

--- a/src/mui/input/SelectInput.spec.js
+++ b/src/mui/input/SelectInput.spec.js
@@ -58,6 +58,19 @@ describe('<SelectInput />', () => {
         assert.equal(MenuItemElement1.prop('primaryText'), '');
     });
 
+    it('should not add a falsy (null or false) element when allowEmpty is false', () => {
+        const wrapper = shallow(<SelectInput
+            {...defaultProps}
+            choices={[
+                { id: 'M', name: 'Male' },
+                { id: 'F', name: 'Female' },
+            ]}
+        />);
+        const SelectFieldElement = wrapper.find('SelectField').at(0);
+        assert.equal(SelectFieldElement.prop('children').includes(false), false);
+        assert.equal(SelectFieldElement.prop('children').includes(null), false);
+    });
+
     it('should use optionValue as value identifier', () => {
         const wrapper = shallow(<SelectInput
             {...defaultProps}


### PR DESCRIPTION
The problem was that when `allowEmpty` was false, we inserted a `false` element in the `SelectField`. However, there are no check for null or false children inside the MUI component which does some introspection on its children for keyboard navigation: [Menu](https://github.com/callemall/material-ui/blob/master/src/Menu/Menu.js#L386)

Fixes #952