### PR TITLE
[RFR] Function as children without permissions

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -428,6 +428,7 @@ const App = () => (
 ```
 
 ## `initialState`
+
 The `initialState` prop lets you pass preloaded state to Redux. See the [Redux Documentation](http://redux.js.org/docs/api/createStore.html#createstorereducer-preloadedstate-enhancer) for more details.
 
 ## `history`
@@ -451,6 +452,43 @@ const App = () => (
 ## Internationalization
 
 The `locale` and `messages` props let you translate the GUI. The [Translation Documentation](./Translation.md) details this process.
+
+## Declaring resources at runtime
+
+You might want to dynamically define the resources when the app starts. The `<Admin>` component accepts a function as its child and this function can return a Promise. If you also defined an `authClient`, the function will receive the result of a call to `authClient` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+
+For instance, getting the resource from an API might look like:
+
+```js
+import React from 'react';
+
+import { simpleRestClient, Admin, Resource } from 'admin-on-rest';
+
+import { PostList } from './posts';
+import { CommentList } from './comments';
+
+const knownResources = [
+    <Resource name="posts" list={PostList} />,
+    <Resource name="comments" list={CommentList} />,
+];
+
+const fetchResources = permissions =>
+    fetch('https://myapi/resources', {
+        method: 'POST,
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(permissions),
+    })
+    .then(response => response.json())
+    .then(json => knownResources.filter(resource => json.resources.includes(resource.props.name)));
+
+const App = () => (
+    <Admin restClient={simpleRestClient('http://path.to.my.api')}>
+        {fetchResources}
+    </Admin>
+);
+```
 
 ## Using admin-on-rest without `<Admin>` and `<Resource>`
 

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -474,7 +474,7 @@ const knownResources = [
 
 const fetchResources = permissions =>
     fetch('https://myapi/resources', {
-        method: 'POST,
+        method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -466,7 +466,7 @@ import RichTextInput from 'aor-rich-text-input';
 const knownInputs = [
     <TextInput source="title" />,
     <TextInput source="teaser" options={{ multiLine: true }} />,
-    <RichTextInput source="body,
+    <RichTextInput source="body" />,
     <DateInput label="Publication date" source="published_at" defaultValue={new Date()} />,
 ];
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -472,7 +472,7 @@ const knownInputs = [
 
 const fetchInputs = permissions =>
     fetch('https://myapi/inputs', {
-        method: 'POST,
+        method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -432,7 +432,7 @@ The most common use case is to display two submit buttons in the `<Create>` view
 For that use case, use the `<SaveButton>` component with a custom `redirect` prop:
 
 ```jsx
-import { SaveButton, Toolbar } from 'admin-on-rest';
+import { Edit, SimpleForm, SaveButton, Toolbar } from 'admin-on-rest';
 
 const PostCreateToolbar = props => <Toolbar {...props} >
     <SaveButton label="post.action.save_and_show" redirect="show" submitOnEnter={true} />
@@ -451,3 +451,47 @@ export const PostEdit = (props) => (
 **Tip**: Use admin-on-rest's `<Toolbar>` component instead of material-ui's `<Toolbar>` component. The former builds up on the latter, and adds support for an alternative mobile layout (and is therefore responsive).
 
 **Tip**: Don't forget to also set the `redirect` prop of the Form component to handle submission by the `ENTER` key.
+
+## Declaring inputs at runtime
+
+You might want to dynamically define the inputs when the `<Create>` or `<Edit>` components are rendered. They both accepts a function as their child and this function can return a Promise. If you also defined an `authClient` on the `<Admin>` component, the function will receive the result of a call to `authClient` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+
+For instance, getting the inputs from an API might look like:
+
+```js
+import React from 'react';
+import { Create, Edit, SimpleForm, TextInput, DateInput } from 'admin-on-rest';
+import RichTextInput from 'aor-rich-text-input';
+
+const knownInputs = [
+    <TextInput source="title" />,
+    <TextInput source="teaser" options={{ multiLine: true }} />,
+    <RichTextInput source="body,
+    <DateInput label="Publication date" source="published_at" defaultValue={new Date()} />,
+];
+
+const fetchInputs = permissions =>
+    fetch('https://myapi/inputs', {
+        method: 'POST,
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            permissions,
+            resource: 'posts',
+        }),
+    })
+    .then(response => response.json())
+    .then(json => knownInputs.filter(input => json.fields.includes(input.props.source)))
+    .then(inputs => (
+        <SimpleForm>
+            {inputs}
+        </SimpleForm>
+    ));
+
+export const PostCreate = (props) => (
+    <Create {...props}>
+        {fetchInputs}
+    </Create>
+);
+```

--- a/docs/List.md
+++ b/docs/List.md
@@ -507,3 +507,47 @@ export const CommentList = (props) => (
 {% endraw %}
 
 As you can see, nothing prevents you from using `<Field>` components inside your own components... provided you inject the current `record`. Also, notice that components building links require the `basePath` component, which is also injected.
+
+## Declaring fields at runtime
+
+You might want to dynamically define the fields when the `<List>` component is rendered. It accepts a function as its child and this function can return a Promise. If you also defined an `authClient` on the `<Admin>` component, the function will receive the result of a call to `authClient` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+
+For instance, getting the fields from an API might look like:
+
+```js
+import React from 'react';
+import { List, Datagrid, TextField } from 'admin-on-rest';
+
+const knownFields = [
+    <TextField source="id" />,
+    <TextField source="title" />,
+    <TextField source="body" />,
+];
+
+const fetchFields = permissions =>
+    fetch('https://myapi/fields', {
+        method: 'POST,
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            permissions,
+            resource: 'posts',
+        }),
+    })
+    .then(response => response.json())
+    .then(json => knownFields.filter(field => json.fields.includes(field.props.source)))
+    .then(fields => (
+        <Datagrid>
+            {fields}
+        </Datagrid>
+    ));
+
+export const PostList = (props) => (
+    <List {...props}>
+        {fetchFields}
+    </List>
+);
+```
+
+**Tip**: This pattern also work for the `<Filter>` component.

--- a/docs/List.md
+++ b/docs/List.md
@@ -526,7 +526,7 @@ const knownFields = [
 
 const fetchFields = permissions =>
     fetch('https://myapi/fields', {
-        method: 'POST,
+        method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -158,3 +158,46 @@ export const PostShow = (props) => (
     </Show>
 );
 ```
+
+## Declaring fields at runtime
+
+You might want to dynamically define the fields when the `<Show>` component is rendered. It accepts a function as its child and this function can return a Promise. If you also defined an `authClient` on the `<Admin>` component, the function will receive the result of a call to `authClient` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+
+For instance, getting the fields from an API might look like:
+
+```js
+import React from 'react';
+import { Show, SimpleShowLayout, TextField, DateField, EditButton, RichTextField } from 'admin-on-rest';
+
+const knownFields = [
+    <TextField source="title" />,
+    <TextField source="teaser" />,
+    <RichTextField source="body" />,
+    <DateField label="Publication date" source="created_at" />,
+];
+
+const fetchFields = permissions =>
+    fetch('https://myapi/fields', {
+        method: 'POST,
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            permissions,
+            resource: 'posts',
+        }),
+    })
+    .then(response => response.json())
+    .then(json => knownFields.filter(field => json.fields.includes(field.props.source)))
+    .then(fields => (
+        <SimpleShowLayout>
+            {fields}
+        </SimpleShowLayout>
+    ));
+
+export const PostShow = (props) => (
+    <Show {...props}>
+        {fetchFields}
+    </Show>
+);
+```

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -178,7 +178,7 @@ const knownFields = [
 
 const fetchFields = permissions =>
     fetch('https://myapi/fields', {
-        method: 'POST,
+        method: 'POST',
         headers: {
             'Content-Type': 'application/json'
         },

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -10,25 +10,24 @@ import NotFound from './mui/layout/NotFound';
 import Restricted from './auth/Restricted';
 import { AUTH_GET_PERMISSIONS } from './auth';
 import { declareResources as declareResourcesAction } from './actions';
-import getMissingAuthClientError from './util/getMissingAuthClientError';
 
 export class AdminRoutes extends Component {
     componentDidMount() {
-        this.initializeResources(this.props.children);
+        return this.initializeResources(this.props.children);
     }
 
-    initializeResources(children) {
+    async initializeResources(children) {
         if (typeof children === 'function') {
-            if (!this.props.authClient) {
-                throw new Error(getMissingAuthClientError('Admin'));
+            let permissions;
+            if (this.props.authClient) {
+                permissions = await this.props.authClient(AUTH_GET_PERMISSIONS);
             }
 
-            this.props.authClient(AUTH_GET_PERMISSIONS).then(permissions => {
-                const resources = children(permissions)
-                    .filter(node => node)
-                    .map(node => node.props);
-                this.props.declareResources(resources);
-            });
+            const resources = children(permissions)
+                .filter(node => node)
+                .map(node => node.props);
+
+            this.props.declareResources(resources);
         } else {
             const resources =
                 React.Children.map(children, ({ props }) => props) || [];

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -23,11 +23,18 @@ export class AdminRoutes extends Component {
                 permissions = await this.props.authClient(AUTH_GET_PERMISSIONS);
             }
 
-            const resources = children(permissions)
+            const childrenResult = children(permissions);
+            let resources = childrenResult;
+
+            if (typeof childrenResult.then === 'function') {
+                resources = await childrenResult;
+            }
+
+            const finalResources = resources
                 .filter(node => node)
                 .map(node => node.props);
 
-            this.props.declareResources(resources);
+            this.props.declareResources(finalResources);
         } else {
             const resources =
                 React.Children.map(children, ({ props }) => props) || [];

--- a/src/AdminRoutes.spec.js
+++ b/src/AdminRoutes.spec.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { Route, MemoryRouter } from 'react-router-dom';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { render } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import assert from 'assert';
+import sinon from 'sinon';
 
 import { AdminRoutes } from './AdminRoutes';
 
@@ -90,5 +91,45 @@ describe('<AdminRoutes>', () => {
             </Provider>
         );
         assert.equal(wrapper.html(), '<div>Custom</div>');
+    });
+
+    it('should accept a function as children and declare the returned resources', () => {
+        const declareResources = sinon.stub();
+
+        shallow(
+            <AdminRoutes declareResources={declareResources}>
+                {() => resources}
+            </AdminRoutes>,
+            { lifecycleExperimental: true }
+        );
+
+        return new Promise(resolve => {
+            setTimeout(() => {
+                assert(
+                    declareResources.calledWith(resources.map(r => r.props))
+                );
+                resolve();
+            }, 0);
+        });
+    });
+
+    it('should accept a promise as children and declare the returned resources', () => {
+        const declareResources = sinon.stub();
+
+        shallow(
+            <AdminRoutes declareResources={declareResources}>
+                {() => Promise.resolve(resources)}
+            </AdminRoutes>,
+            { lifecycleExperimental: true }
+        );
+
+        return new Promise(resolve => {
+            setTimeout(() => {
+                assert(
+                    declareResources.calledWith(resources.map(r => r.props))
+                );
+                resolve();
+            }, 0);
+        });
     });
 });

--- a/src/mui/detail/Create.js
+++ b/src/mui/detail/Create.js
@@ -9,7 +9,7 @@ import Title from '../layout/Title';
 import { crudCreate as crudCreateAction } from '../../actions/dataActions';
 import DefaultActions from './CreateActions';
 import translate from '../../i18n/translate';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 class Create extends Component {
     getBasePath() {
@@ -110,7 +110,7 @@ function mapStateToProps(state) {
 const enhance = compose(
     connect(mapStateToProps, { crudCreate: crudCreateAction }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(Create);

--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -12,7 +12,7 @@ import {
 } from '../../actions/dataActions';
 import DefaultActions from './EditActions';
 import translate from '../../i18n/translate';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 export class Edit extends Component {
     constructor(props) {
@@ -172,7 +172,7 @@ const enhance = compose(
         crudUpdate: crudUpdateAction,
     }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(Edit);

--- a/src/mui/detail/Show.js
+++ b/src/mui/detail/Show.js
@@ -9,7 +9,7 @@ import Title from '../layout/Title';
 import { crudGetOne as crudGetOneAction } from '../../actions/dataActions';
 import DefaultActions from './ShowActions';
 import translate from '../../i18n/translate';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 export class Show extends Component {
     componentDidMount() {
@@ -127,7 +127,7 @@ function mapStateToProps(state, props) {
 const enhance = compose(
     connect(mapStateToProps, { crudGetOne: crudGetOneAction }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(Show);

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -7,7 +7,7 @@ import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
 import defaultTheme from '../defaultTheme';
 import removeEmpty from '../../util/removeEmpty';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 export class Filter extends Component {
     constructor(props) {
@@ -100,4 +100,4 @@ Filter.defaultProps = {
     theme: defaultTheme,
 };
 
-export default withPermissionsFilteredChildren(Filter);
+export default withChildrenAsFunction(Filter);

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -25,7 +25,7 @@ import { refreshView as refreshViewAction } from '../../actions/uiActions';
 import translate from '../../i18n/translate';
 import removeKey from '../../util/removeKey';
 import defaultTheme from '../defaultTheme';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 const styles = {
     noResults: { padding: 20 },
@@ -375,7 +375,7 @@ const enhance = compose(
         refreshView: refreshViewAction,
     }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(List);

--- a/src/mui/withChildrenAsFunction.js
+++ b/src/mui/withChildrenAsFunction.js
@@ -4,7 +4,7 @@ import getContext from 'recompose/getContext';
 import { AUTH_GET_PERMISSIONS } from '../auth/types';
 
 export default BaseComponent => {
-    class WithPermissionsFilteredChildren extends Component {
+    class WithChildrenAsFunction extends Component {
         state = { children: null };
 
         static propTypes = {
@@ -27,8 +27,14 @@ export default BaseComponent => {
                     );
                 }
 
-                const allowedChildren = children(permissions);
-                this.setState({ children: allowedChildren });
+                const childrenResult = children(permissions);
+                let finalChildren = childrenResult;
+
+                if (typeof childrenResult.then === 'function') {
+                    finalChildren = await childrenResult;
+                }
+
+                this.setState({ children: finalChildren });
             } else {
                 this.setState({ children });
             }
@@ -61,5 +67,5 @@ export default BaseComponent => {
 
     return getContext({
         authClient: PropTypes.func,
-    })(WithPermissionsFilteredChildren);
+    })(WithChildrenAsFunction);
 };

--- a/src/mui/withChildrenAsFunction.js
+++ b/src/mui/withChildrenAsFunction.js
@@ -1,8 +1,7 @@
 import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import getContext from 'recompose/getContext';
-import { AUTH_GET_PERMISSIONS } from './types';
-import getMissingAuthClientError from '../util/getMissingAuthClientError';
+import { AUTH_GET_PERMISSIONS } from '../auth/types';
 
 export default BaseComponent => {
     class WithPermissionsFilteredChildren extends Component {
@@ -15,23 +14,21 @@ export default BaseComponent => {
         };
 
         componentDidMount() {
-            this.initializeChildren(this.props.children);
+            return this.initializeChildren(this.props.children);
         }
 
-        initializeChildren(children) {
+        async initializeChildren(children) {
             if (typeof children === 'function') {
-                if (!this.props.authClient) {
-                    throw new Error(
-                        getMissingAuthClientError(BaseComponent.name)
+                let permissions;
+
+                if (this.props.authClient) {
+                    permissions = await this.props.authClient(
+                        AUTH_GET_PERMISSIONS
                     );
                 }
 
-                this.props
-                    .authClient(AUTH_GET_PERMISSIONS)
-                    .then(permissions => {
-                        const allowedChildren = children(permissions);
-                        this.setState({ children: allowedChildren });
-                    });
+                const allowedChildren = children(permissions);
+                this.setState({ children: allowedChildren });
             } else {
                 this.setState({ children });
             }

--- a/src/mui/withChildrenAsFunction.spec.js
+++ b/src/mui/withChildrenAsFunction.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import assert from 'assert';
+import withChildrenAsFunction from './withChildrenAsFunction';
+
+describe('WithChildrenAsFunction', () => {
+    const DecoratedComponent = withChildrenAsFunction(<div />);
+
+    it('passes through standard children (no function)', () => {
+        const wrapper = shallow(
+            <DecoratedComponent>
+                <div id="1" />
+                <div id="2" />
+            </DecoratedComponent>
+        );
+
+        assert(wrapper.find(<div id="1" />));
+        assert(wrapper.find(<div id="2" />));
+    });
+
+    it('passes through children returned by the function', () => {
+        const wrapper = shallow(
+            <DecoratedComponent>
+                {() => [<div key="1" id="1" />, <div key="2" id="2" />]}
+            </DecoratedComponent>
+        );
+
+        assert(wrapper.find(<div id="1" />));
+        assert(wrapper.find(<div id="2" />));
+    });
+
+    it('passes through children resolved by the function', () => {
+        const wrapper = shallow(
+            <DecoratedComponent>
+                {() =>
+                    Promise.resolve([
+                        <div key="1" id="1" />,
+                        <div key="2" id="2" />,
+                    ])}
+            </DecoratedComponent>
+        );
+
+        assert(wrapper.find(<div id="1" />));
+        assert(wrapper.find(<div id="2" />));
+    });
+});

--- a/src/util/getMissingAuthClientError.js
+++ b/src/util/getMissingAuthClientError.js
@@ -1,7 +1,0 @@
-const errorMessage = component => `
-    You specified a function as the child of the ${component} component. 
-    This requires you to set up an authClient as well.
-    See the documentation: https://marmelab.com/admin-on-rest/Authorization.html
-`;
-
-export default errorMessage;


### PR DESCRIPTION
Allows to use the function as child pattern in components that support it, without an authClient.
This function might return a promise.

Fixes #1009 

- [x] Implementation
- [x] Documentation