### PR TITLE
[RFR] Function as children without permissions

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -428,6 +428,7 @@ const App = () => (
 ```
 
 ## `initialState`
+
 The `initialState` prop lets you pass preloaded state to Redux. See the [Redux Documentation](http://redux.js.org/docs/api/createStore.html#createstorereducer-preloadedstate-enhancer) for more details.
 
 ## `history`
@@ -451,6 +452,43 @@ const App = () => (
 ## Internationalization
 
 The `locale` and `messages` props let you translate the GUI. The [Translation Documentation](./Translation.md) details this process.
+
+## Declaring resources at runtime
+
+You might want to dynamically define the resources when the app starts. The `<Admin>` component accepts a function as its child and this function can return a Promise. If you also defined an `authClient`, the function will receive the result of a call to `authClient` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+
+For instance, getting the resource from an API might look like:
+
+```js
+import React from 'react';
+
+import { simpleRestClient, Admin, Resource } from 'admin-on-rest';
+
+import { PostList } from './posts';
+import { CommentList } from './comments';
+
+const knownResources = [
+    <Resource name="posts" list={PostList} />,
+    <Resource name="comments" list={CommentList} />,
+];
+
+const fetchResources = permissions =>
+    fetch('https://myapi/resources', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(permissions),
+    })
+    .then(response => response.json())
+    .then(json => knownResources.filter(resource => json.resources.includes(resource.props.name)));
+
+const App = () => (
+    <Admin restClient={simpleRestClient('http://path.to.my.api')}>
+        {fetchResources}
+    </Admin>
+);
+```
 
 ## Using admin-on-rest without `<Admin>` and `<Resource>`
 

--- a/docs/List.md
+++ b/docs/List.md
@@ -507,3 +507,47 @@ export const CommentList = (props) => (
 {% endraw %}
 
 As you can see, nothing prevents you from using `<Field>` components inside your own components... provided you inject the current `record`. Also, notice that components building links require the `basePath` component, which is also injected.
+
+## Declaring fields at runtime
+
+You might want to dynamically define the fields when the `<List>` component is rendered. It accepts a function as its child and this function can return a Promise. If you also defined an `authClient` on the `<Admin>` component, the function will receive the result of a call to `authClient` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+
+For instance, getting the fields from an API might look like:
+
+```js
+import React from 'react';
+import { List, Datagrid, TextField } from 'admin-on-rest';
+
+const knownFields = [
+    <TextField source="id" />,
+    <TextField source="title" />,
+    <TextField source="body" />,
+];
+
+const fetchFields = permissions =>
+    fetch('https://myapi/fields', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            permissions,
+            resource: 'posts',
+        }),
+    })
+    .then(response => response.json())
+    .then(json => knownFields.filter(field => json.fields.includes(field.props.source)))
+    .then(fields => (
+        <Datagrid>
+            {fields}
+        </Datagrid>
+    ));
+
+export const PostList = (props) => (
+    <List {...props}>
+        {fetchFields}
+    </List>
+);
+```
+
+**Tip**: This pattern also work for the `<Filter>` component.

--- a/docs/Show.md
+++ b/docs/Show.md
@@ -158,3 +158,46 @@ export const PostShow = (props) => (
     </Show>
 );
 ```
+
+## Declaring fields at runtime
+
+You might want to dynamically define the fields when the `<Show>` component is rendered. It accepts a function as its child and this function can return a Promise. If you also defined an `authClient` on the `<Admin>` component, the function will receive the result of a call to `authClient` with the `AUTH_GET_PERMISSIONS` type (you can read more about this in the [Authorization](./Authorization.md) chapter).
+
+For instance, getting the fields from an API might look like:
+
+```js
+import React from 'react';
+import { Show, SimpleShowLayout, TextField, DateField, EditButton, RichTextField } from 'admin-on-rest';
+
+const knownFields = [
+    <TextField source="title" />,
+    <TextField source="teaser" />,
+    <RichTextField source="body" />,
+    <DateField label="Publication date" source="created_at" />,
+];
+
+const fetchFields = permissions =>
+    fetch('https://myapi/fields', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            permissions,
+            resource: 'posts',
+        }),
+    })
+    .then(response => response.json())
+    .then(json => knownFields.filter(field => json.fields.includes(field.props.source)))
+    .then(fields => (
+        <SimpleShowLayout>
+            {fields}
+        </SimpleShowLayout>
+    ));
+
+export const PostShow = (props) => (
+    <Show {...props}>
+        {fetchFields}
+    </Show>
+);
+```

--- a/src/AdminRoutes.js
+++ b/src/AdminRoutes.js
@@ -10,25 +10,31 @@ import NotFound from './mui/layout/NotFound';
 import Restricted from './auth/Restricted';
 import { AUTH_GET_PERMISSIONS } from './auth';
 import { declareResources as declareResourcesAction } from './actions';
-import getMissingAuthClientError from './util/getMissingAuthClientError';
 
 export class AdminRoutes extends Component {
     componentDidMount() {
-        this.initializeResources(this.props.children);
+        return this.initializeResources(this.props.children);
     }
 
-    initializeResources(children) {
+    async initializeResources(children) {
         if (typeof children === 'function') {
-            if (!this.props.authClient) {
-                throw new Error(getMissingAuthClientError('Admin'));
+            let permissions;
+            if (this.props.authClient) {
+                permissions = await this.props.authClient(AUTH_GET_PERMISSIONS);
             }
 
-            this.props.authClient(AUTH_GET_PERMISSIONS).then(permissions => {
-                const resources = children(permissions)
-                    .filter(node => node)
-                    .map(node => node.props);
-                this.props.declareResources(resources);
-            });
+            const childrenResult = children(permissions);
+            let resources = childrenResult;
+
+            if (typeof childrenResult.then === 'function') {
+                resources = await childrenResult;
+            }
+
+            const finalResources = resources
+                .filter(node => node)
+                .map(node => node.props);
+
+            this.props.declareResources(finalResources);
         } else {
             const resources =
                 React.Children.map(children, ({ props }) => props) || [];

--- a/src/AdminRoutes.spec.js
+++ b/src/AdminRoutes.spec.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { Route, MemoryRouter } from 'react-router-dom';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import { render } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import assert from 'assert';
+import sinon from 'sinon';
 
 import { AdminRoutes } from './AdminRoutes';
 
@@ -90,5 +91,45 @@ describe('<AdminRoutes>', () => {
             </Provider>
         );
         assert.equal(wrapper.html(), '<div>Custom</div>');
+    });
+
+    it('should accept a function as children and declare the returned resources', () => {
+        const declareResources = sinon.stub();
+
+        shallow(
+            <AdminRoutes declareResources={declareResources}>
+                {() => resources}
+            </AdminRoutes>,
+            { lifecycleExperimental: true }
+        );
+
+        return new Promise(resolve => {
+            setTimeout(() => {
+                assert(
+                    declareResources.calledWith(resources.map(r => r.props))
+                );
+                resolve();
+            }, 0);
+        });
+    });
+
+    it('should accept a promise as children and declare the returned resources', () => {
+        const declareResources = sinon.stub();
+
+        shallow(
+            <AdminRoutes declareResources={declareResources}>
+                {() => Promise.resolve(resources)}
+            </AdminRoutes>,
+            { lifecycleExperimental: true }
+        );
+
+        return new Promise(resolve => {
+            setTimeout(() => {
+                assert(
+                    declareResources.calledWith(resources.map(r => r.props))
+                );
+                resolve();
+            }, 0);
+        });
     });
 });

--- a/src/mui/detail/Create.js
+++ b/src/mui/detail/Create.js
@@ -9,7 +9,7 @@ import Title from '../layout/Title';
 import { crudCreate as crudCreateAction } from '../../actions/dataActions';
 import DefaultActions from './CreateActions';
 import translate from '../../i18n/translate';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 class Create extends Component {
     getBasePath() {
@@ -110,7 +110,7 @@ function mapStateToProps(state) {
 const enhance = compose(
     connect(mapStateToProps, { crudCreate: crudCreateAction }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(Create);

--- a/src/mui/detail/Edit.js
+++ b/src/mui/detail/Edit.js
@@ -12,7 +12,7 @@ import {
 } from '../../actions/dataActions';
 import DefaultActions from './EditActions';
 import translate from '../../i18n/translate';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 export class Edit extends Component {
     constructor(props) {
@@ -172,7 +172,7 @@ const enhance = compose(
         crudUpdate: crudUpdateAction,
     }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(Edit);

--- a/src/mui/detail/Show.js
+++ b/src/mui/detail/Show.js
@@ -9,7 +9,7 @@ import Title from '../layout/Title';
 import { crudGetOne as crudGetOneAction } from '../../actions/dataActions';
 import DefaultActions from './ShowActions';
 import translate from '../../i18n/translate';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 export class Show extends Component {
     componentDidMount() {
@@ -127,7 +127,7 @@ function mapStateToProps(state, props) {
 const enhance = compose(
     connect(mapStateToProps, { crudGetOne: crudGetOneAction }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(Show);

--- a/src/mui/list/Filter.js
+++ b/src/mui/list/Filter.js
@@ -7,7 +7,7 @@ import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
 import defaultTheme from '../defaultTheme';
 import removeEmpty from '../../util/removeEmpty';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 export class Filter extends Component {
     constructor(props) {
@@ -100,4 +100,4 @@ Filter.defaultProps = {
     theme: defaultTheme,
 };
 
-export default withPermissionsFilteredChildren(Filter);
+export default withChildrenAsFunction(Filter);

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -24,7 +24,7 @@ import { changeListParams as changeListParamsAction } from '../../actions/listAc
 import translate from '../../i18n/translate';
 import removeKey from '../../util/removeKey';
 import defaultTheme from '../defaultTheme';
-import withPermissionsFilteredChildren from '../../auth/withPermissionsFilteredChildren';
+import withChildrenAsFunction from '../withChildrenAsFunction';
 
 const styles = {
     noResults: { padding: 20 },
@@ -361,7 +361,7 @@ const enhance = compose(
         push: pushAction,
     }),
     translate,
-    withPermissionsFilteredChildren
+    withChildrenAsFunction
 );
 
 export default enhance(List);

--- a/src/mui/withChildrenAsFunction.spec.js
+++ b/src/mui/withChildrenAsFunction.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import assert from 'assert';
+import withChildrenAsFunction from './withChildrenAsFunction';
+
+describe('WithChildrenAsFunction', () => {
+    const DecoratedComponent = withChildrenAsFunction(<div />);
+
+    it('passes through standard children (no function)', () => {
+        const wrapper = shallow(
+            <DecoratedComponent>
+                <div id="1" />
+                <div id="2" />
+            </DecoratedComponent>
+        );
+
+        assert(wrapper.find(<div id="1" />));
+        assert(wrapper.find(<div id="2" />));
+    });
+
+    it('passes through children returned by the function', () => {
+        const wrapper = shallow(
+            <DecoratedComponent>
+                {() => [<div key="1" id="1" />, <div key="2" id="2" />]}
+            </DecoratedComponent>
+        );
+
+        assert(wrapper.find(<div id="1" />));
+        assert(wrapper.find(<div id="2" />));
+    });
+
+    it('passes through children resolved by the function', () => {
+        const wrapper = shallow(
+            <DecoratedComponent>
+                {() =>
+                    Promise.resolve([
+                        <div key="1" id="1" />,
+                        <div key="2" id="2" />,
+                    ])}
+            </DecoratedComponent>
+        );
+
+        assert(wrapper.find(<div id="1" />));
+        assert(wrapper.find(<div id="2" />));
+    });
+});

--- a/src/util/getMissingAuthClientError.js
+++ b/src/util/getMissingAuthClientError.js
@@ -1,7 +1,0 @@
-const errorMessage = component => `
-    You specified a function as the child of the ${component} component. 
-    This requires you to set up an authClient as well.
-    See the documentation: https://marmelab.com/admin-on-rest/Authorization.html
-`;
-
-export default errorMessage;


### PR DESCRIPTION
Allows to use the function as child pattern in components that support it, without an authClient.
This function might return a promise.

Fixes #1009

- [x] Implementation
- [x] Documentation