### PR TITLE
[RFR] Documentation fixes

### DIFF
--- a/docs/Resource.md
+++ b/docs/Resource.md
@@ -59,7 +59,7 @@ const App = () => (
 * `/:id/show` maps to the `show` component
 * `/:id/delete` maps to the `remove` component
 
-**Tip**: You must add a `<Resource>` when you declare a reference (via `<ReferenceField>`, `<ReferenceArrayField>`, `<ReferenceManyField>`, `<ReferenceInput>`, `<ReferenceArrayInput>`, or `<ReferenceManyInput>`), because admin-on-rest uses resources to define the data store structure. That's why there is an empty `tag` resource in the example above.
+**Tip**: You must add a `<Resource>` when you declare a reference (via `<ReferenceField>`, `<ReferenceArrayField>`, `<ReferenceManyField>`, `<ReferenceInput>` or `<ReferenceArrayInput>`), because admin-on-rest uses resources to define the data store structure. That's why there is an empty `tag` resource in the example above.
 
 `<Resource>` also accepts additional props:
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -411,13 +411,13 @@
                                 <a href="#configuring-the-auth-client">Configuring the Auth Client</a>
                             </li>
                             <li class="chapter">
-                                <a href="#restricting_access_to_resources_or_views">Restricting Access To Resources or Views</a>
+                                <a href="#restricting-access-to-resources-or-views">Restricting Access To Resources or Views</a>
                             </li>
                             <li class="chapter">
-                                <a href="#restricting_access_to_fields_and_inputs">Restricting Access To Fields And Inputs</a>
+                                <a href="#restricting-access-to-fields-and-inputs">Restricting Access To Fields And Inputs</a>
                             </li>
                             <li class="chapter">
-                                <a href="#restricting_access_to_content_in_custom_pages_or_menus">Restricting Access To Content In Custom Pages or Menus</a>
+                                <a href="#restricting-access-to-content-in-custom-pages-or-menus">Restricting Access To Content In Custom Pages or Menus</a>
                             </li>
                         </ul>
                     </li>


### PR DESCRIPTION
- [x] Fixed bad links for authorization chapters
- [x] Fixed mention about a `ReferenceManyInput`, which does not exist (see [stackoverflow](https://stackoverflow.com/questions/46486514/input-components-not-working/46500718)