### PR TITLE
Blog example with dot.notation reference

### DIFF
--- a/example/comments.js
+++ b/example/comments.js
@@ -36,7 +36,7 @@ export CommentIcon from 'material-ui/svg-icons/communication/chat-bubble';
 
 const CommentFilter = ({ ...props }) => (
     <Filter {...props}>
-        <ReferenceInput source="post_id" reference="posts">
+        <ReferenceInput source="post.id" reference="posts">
             <SelectInput optionText="title" />
         </ReferenceInput>
     </Filter>
@@ -102,7 +102,7 @@ const CommentGrid = translate(({ ids, data, basePath, translate }) => (
                     <ReferenceField
                         resource="comments"
                         record={data[id]}
-                        source="post_id"
+                        source="post.id"
                         reference="posts"
                         basePath={basePath}
                     >
@@ -159,7 +159,7 @@ export const CommentEdit = ({ ...props }) => (
         <SimpleForm>
             <DisabledInput source="id" />
             <ReferenceInput
-                source="post_id"
+                source="post.id"
                 reference="posts"
                 perPage={5}
                 sort={{ field: 'title', order: 'ASC' }}
@@ -177,7 +177,7 @@ export const CommentCreate = ({ ...props }) => (
     <Create {...props}>
         <SimpleForm defaultValue={{ created_at: new Date() }}>
             <ReferenceInput
-                source="post_id"
+                source="post.id"
                 reference="posts"
                 allowEmpty
                 validation={{ required: true }}
@@ -194,7 +194,7 @@ export const CommentShow = ({ ...props }) => (
     <Show {...props}>
         <SimpleShowLayout>
             <TextField source="id" />
-            <ReferenceField source="post_id" reference="posts">
+            <ReferenceField source="post.id" reference="posts">
                 <TextField source="title" />
             </ReferenceField>
             <TextField source="author.name" />

--- a/example/data.js
+++ b/example/data.js
@@ -270,7 +270,7 @@ export default {
         {
             id: 1,
             author: {},
-            post_id: 6,
+            post: { id: 6},
             body:
                 "Queen, tossing her head through the wood. 'If it had lost something; and she felt sure it.",
             created_at: new Date('2012-08-02'),
@@ -281,7 +281,7 @@ export default {
                 name: 'Kiley Pouros',
                 email: 'kiley@gmail.com',
             },
-            post_id: 9,
+            post: { id: 9 },
             body:
                 "White Rabbit: it was indeed: she was out of the ground--and I should frighten them out of its right paw round, 'lives a March Hare. 'Sixteenth,'.",
             created_at: new Date('2012-08-08'),
@@ -291,7 +291,7 @@ export default {
             author: {
                 name: 'Justina Hegmann',
             },
-            post_id: 3,
+            post: { id: 3 },
             body:
                 "I'm not Ada,' she said, 'and see whether it's marked \"poison\" or.",
             created_at: new Date('2012-08-02'),
@@ -301,7 +301,7 @@ export default {
             author: {
                 name: 'Ms. Brionna Smitham MD',
             },
-            post_id: 6,
+            post: { id: 6 },
             body:
                 "Dormouse. 'Fourteenth of March, I think I can say.' This was such a noise inside, no one else seemed inclined.",
             created_at: new Date('2014-09-24'),
@@ -311,7 +311,7 @@ export default {
             author: {
                 name: 'Edmond Schulist',
             },
-            post_id: 1,
+            post: { id: 1 },
             body:
                 "I ought to tell me your history, you know,' the Hatter and the happy summer days. THE.",
             created_at: new Date('2012-08-07'),
@@ -321,7 +321,7 @@ export default {
             author: {
                 name: 'Danny Greenholt',
             },
-            post_id: 6,
+            post: { id: 6 },
             body:
                 'Duchess asked, with another hedgehog, which seemed to be lost: away went Alice after it, never once considering how in the other. In the very tones of.',
             created_at: new Date('2012-08-09'),
@@ -331,7 +331,7 @@ export default {
             author: {
                 name: 'Luciano Berge',
             },
-            post_id: 5,
+            post: { id: 5 },
             body:
                 "While the Panther were sharing a pie--' [later editions continued as follows.",
             created_at: new Date('2012-09-06'),
@@ -341,7 +341,7 @@ export default {
             author: {
                 name: 'Annamarie Mayer',
             },
-            post_id: 5,
+            post: { id: 5 },
             body:
                 "I tell you, you coward!' and at once and put it more clearly,' Alice.",
             created_at: new Date('2012-10-03'),
@@ -351,7 +351,7 @@ export default {
             author: {
                 name: 'Breanna Gibson',
             },
-            post_id: 2,
+            post: { id: 2 },
             body:
                 "THAT. Then again--\"BEFORE SHE HAD THIS FIT--\" you never tasted an egg!' 'I HAVE tasted eggs, certainly,' said Alice, as she spoke. Alice did not like to have it.",
             created_at: new Date('2012-11-06'),
@@ -361,7 +361,7 @@ export default {
             author: {
                 name: 'Logan Schowalter',
             },
-            post_id: 3,
+            post: { id: 3 },
             body:
                 "I'd been the whiting,' said the Hatter, it woke up again with a T!' said the Gryphon. '--you advance twice--' 'Each with a growl, And concluded the banquet--] 'What IS the fun?' said.",
             created_at: new Date('2012-12-07'),
@@ -371,7 +371,7 @@ export default {
             author: {
                 name: 'Logan Schowalter',
             },
-            post_id: 1,
+            post: { id: 1 },
             body:
                 "I don't want to be?' it asked. 'Oh, I'm not Ada,' she said, 'and see whether it's marked \"poison\" or not'; for she had asked it aloud; and in despair she put her hand on the end of the.",
             created_at: new Date('2012-08-05'),

--- a/example/data.js
+++ b/example/data.js
@@ -270,7 +270,7 @@ export default {
         {
             id: 1,
             author: {},
-            post: { id: 6},
+            post: { id: 6 },
             body:
                 "Queen, tossing her head through the wood. 'If it had lost something; and she felt sure it.",
             created_at: new Date('2012-08-02'),

--- a/example/i18n/en.js
+++ b/example/i18n/en.js
@@ -26,7 +26,7 @@ export const messages = {
             fields: {
                 body: 'Body',
                 created_at: 'Created at',
-                post_id: 'Posts',
+                post: {id: 'Posts'},
                 author: {
                     name: 'Author',
                 },

--- a/example/i18n/en.js
+++ b/example/i18n/en.js
@@ -26,7 +26,7 @@ export const messages = {
             fields: {
                 body: 'Body',
                 created_at: 'Created at',
-                post: {id: 'Posts'},
+                post: {id: 'Posts' },
                 author: {
                     name: 'Author',
                 },

--- a/example/i18n/fr.js
+++ b/example/i18n/fr.js
@@ -25,7 +25,7 @@ export const messages = {
             fields: {
                 body: 'Contenu',
                 created_at: 'Créé le',
-                post: {id: 'Article'},
+                post: {id: 'Article' },
                 author: {
                     name: 'Auteur',
                 },

--- a/example/i18n/fr.js
+++ b/example/i18n/fr.js
@@ -25,7 +25,7 @@ export const messages = {
             fields: {
                 body: 'Contenu',
                 created_at: 'Créé le',
-                post_id: 'Article',
+                post: {id: 'Article'},
                 author: {
                     name: 'Auteur',
                 },


### PR DESCRIPTION
The blog sample is lacking an example where the dot notation is used to reference another resources.
This PR modify the data.json to include such an example