### PR TITLE
#1165 Fixed vertical scroll issue on page on IE11

### DIFF
--- a/src/mui/layout/Layout.js
+++ b/src/mui/layout/Layout.js
@@ -30,7 +30,7 @@ const styles = {
     body: {
         backgroundColor: '#edecec',
         display: 'flex',
-        flex: 1,
+        flex: '1 1 auto',
         overflowY: 'hidden',
         overflowX: 'scroll',
     },


### PR DESCRIPTION
Which is not possible when content height e.g number list items exceeds the screen height.

https://github.com/marmelab/admin-on-rest/issues/1165