### PR TITLE
ImageField: allow to style the img tag

### DIFF
--- a/packages/react-admin/src/mui/field/ImageField.js
+++ b/packages/react-admin/src/mui/field/ImageField.js
@@ -19,6 +19,11 @@ export const ImageField = ({ elStyle = {}, record, source, src, title }) => {
         return <div />;
     }
 
+    const imageStyle = {
+        ...styles.image,
+        ...elStyle.image,
+    };
+
     if (Array.isArray(sourceValue)) {
         const style = {
             ...styles.list,
@@ -36,7 +41,7 @@ export const ImageField = ({ elStyle = {}, record, source, src, title }) => {
                                 alt={titleValue}
                                 title={titleValue}
                                 src={srcValue}
-                                style={styles.image}
+                                style={imageStyle}
                             />
                         </li>
                     );
@@ -53,7 +58,7 @@ export const ImageField = ({ elStyle = {}, record, source, src, title }) => {
                 title={titleValue}
                 alt={titleValue}
                 src={sourceValue}
-                style={styles.image}
+                style={imageStyle}
             />
         </div>
     );


### PR DESCRIPTION
Useful for example if you want to change the size of the image:
```javascript
<ImageField key="imageLink" source="imageLink" elStyle={{image: {height: 40}}} />
``` 
If you are okay with this, I could add tests and/or docs.