### PR TITLE
[RFR] Minor copywriting updates

### DIFF
--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -42,7 +42,7 @@ export default {
         message: {
             yes: 'Yes',
             no: 'No',
-            are_you_sure: 'Are you sure ?',
+            are_you_sure: 'Are you sure?',
             about: 'About',
             not_found:
                 'Either you typed a wrong URL, or you followed a bad link',

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -45,7 +45,7 @@ export default {
             are_you_sure: 'Are you sure?',
             about: 'About',
             not_found:
-                'Either you typed a wrong URL, or you followed a bad link',
+                'Either you typed a wrong URL, or you followed a bad link.',
         },
         navigation: {
             no_results: 'No results found',

--- a/src/mui/layout/NotFound.js
+++ b/src/mui/layout/NotFound.js
@@ -50,7 +50,7 @@ const NotFound = ({ width, translate }) => (
         <div style={styles.message}>
             <HotTub style={styles.icon} />
             <h1>{translate('aor.page.not_found')}</h1>
-            <div>{translate('aor.message.not_found')}.</div>
+            <div>{translate('aor.message.not_found')}</div>
         </div>
         <div style={styles.toolbar}>
             <RaisedButton


### PR DESCRIPTION
This PR proposes two small updates regarding `src/i18n/messages.js`.

1. Removed space before `?` for `aor.message.are_you_sure`.
2. Moved the trailing `.` from `src/mui/layout/NotFound.js` to `aor.message.not_found` instead to allow proper i18n for languages that don't typically use `.` for sentence ends, e.g. Japanese and Chinese.