### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ Admin-on-rest is available from npm. You can install it (and its required depend
 using:
 
 ```sh
-npm install --save-dev admin-on-rest
+npm install admin-on-rest
 ```
 
 ## Usage


### PR DESCRIPTION
The documentation's readme suggests installing via npm as a dev dependency.

```
npm install --save-dev admin-on-rest
```

It should not be a dev dependency, `--save` should have been used instead. As of npm5, that can actually even be omitted. [`npm install` will `--save` by default](http://blog.npmjs.org/post/161081169345/v500).