### PR TITLE
Added customPages prop on Admin

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -26,6 +26,7 @@ const Admin = ({
     customReducers = {},
     customSagas = [],
     customRoutes = [],
+    customPages = [],
     dashboard,
     history,
     locale,
@@ -75,6 +76,19 @@ const Admin = ({
                                         theme,
                                     })}
                             />
+                            {customPages.map(customPage => (
+                                <Route
+                                    exact
+                                    path={customPage.path}
+                                    key={customPage.path}
+                                    render={({ location }) =>
+                                        createElement(customPage.page, {
+                                            location,
+                                            title,
+                                            theme,
+                                        })}
+                                />
+                            ))}
                             {customRoutes
                                 .filter(route => route.props.noLayout)
                                 .map((route, index) => (
@@ -140,6 +154,7 @@ Admin.propTypes = {
     customSagas: PropTypes.array,
     customReducers: PropTypes.object,
     customRoutes: PropTypes.array,
+    customPages: PropTypes.array,
     dashboard: componentPropType,
     history: PropTypes.object,
     loginPage: componentPropType,


### PR DESCRIPTION
This will allow the creation of completely custom pages within the Admin component

I often feel the need to add completely custom routes to the admin (eg: `/register`).. I cannot do this in the context of unauthenticated page, which means that the default layout would be visible

Therefore I am suggesting the addition of a simple change on the `Admin` component which will allow the creation of completely independent routes without the fuss of creating your own admin component

If this is something you would consider, I am open to feedback and willing to update the docs to reflect this change