### PR TITLE
AutocompleteInput: translate is a required property

### DIFF
--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -195,6 +195,7 @@ AutocompleteInput.defaultProps = {
     options: {},
     optionText: 'name',
     optionValue: 'id',
+    translate,
     translateChoice: true,
 };
 


### PR DESCRIPTION
AutocompleteInput: translate is a required property, but it is not defaulted?

I think this is meant to be defaulted to the imported translate? I saw property warnings in the console and this change removed the warnings.