### PR TITLE
Documentation update for 'Writing Actions'

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -78,7 +78,6 @@ export const CommentList = (props) =>
 
 Or, in the `<Edit>` page, as a [custom action](./CreateEdit.md#actions):
 
-{% raw %}
 ```jsx
 // in src/comments/CommentEditActions.js
 import React from 'react';
@@ -86,8 +85,14 @@ import { CardActions } from 'material-ui/Card';
 import { ListButton, DeleteButton } from 'admin-on-rest';
 import ApproveButton from './ApproveButton';
 
+const cardActionStyle = {
+    zIndex: 2,
+    display: 'inline-block',
+    float: 'right',
+};
+
 const CommentEditActions = ({ basePath, data }) => (
-    <CardActions style={{ float: 'right' }}>
+    <CardActions style={cardActionStyle}>
         <ApproveButton record={data} />
         <ListButton basePath={basePath} />
         <DeleteButton basePath={basePath} record={data} />
@@ -102,9 +107,8 @@ import CommentEditActions from './CommentEditActions';
 export const CommentEdit = (props) =>
     <Edit {...props} actions={<CommentEditActions />}>
         ...
-    </List>;
+    </Edit>;
 ```
-{% endraw %}
 
 ## Using The REST Client Instead of Fetch
 


### PR DESCRIPTION
In 'Writing Actions', the suggested styling for `CommentEditActions` (`float: right`) leads to the custom actions being non-clickable.  I've updated the styles to mirror those suggested in the documentation for [CreateEdit](https://github.com/marmelab/admin-on-rest/blob/master/docs/CreateEdit.md#actions).