### PR TITLE
Added jsnext:main and module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
         "src"
     ],
     "main": "lib/index",
+    "module": "src/index",
+    "jsnext:main": "src/index",
     "scripts": {
         "test": "make test"
     },


### PR DESCRIPTION
This allows usage of es6 modules instead of the transpiled es5 module.
My IDE (Intellij IDEA) doesn't recognize the transpiled exports. 