### PR TITLE
Allow field to supply a custom header component. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ lib
 es6
 docs/_site/
 packages/ra-example/static
+# IDE 
+.idea

--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -9,6 +9,7 @@
         "src"
     ],
     "main": "lib/index",
+    "jsnext:main": "src/index",
     "authors": [
         "François Zaninotto"
     ],

--- a/packages/react-admin/src/mui/list/DatagridHeaderCell.js
+++ b/packages/react-admin/src/mui/list/DatagridHeaderCell.js
@@ -1,15 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import defaultsDeep from 'lodash.defaultsdeep';
-import classNames from 'classnames';
 import shouldUpdate from 'recompose/shouldUpdate';
 import compose from 'recompose/compose';
 import { TableCell } from 'material-ui/Table';
-import Button from 'material-ui/Button';
 import { withStyles } from 'material-ui/styles';
-import ContentSort from 'material-ui-icons/Sort';
-
-import FieldTitle from '../../util/FieldTitle';
+import DefaultHeaderCellContent from './DatagridHeaderCellContent';
 
 const styles = {
     sortButton: {
@@ -34,56 +30,22 @@ const styles = {
     },
 };
 
-export const DatagridHeaderCell = ({
-    classes = {},
-    field,
-    defaultStyle,
-    currentSort,
-    updateSort,
-    resource,
-}) => {
+export const DatagridHeaderCell = ({ field, defaultStyle, ...props }) => {
     const style = defaultsDeep(
         {},
         field.props.headerStyle,
         field.type.defaultProps ? field.type.defaultProps.headerStyle : {},
         defaultStyle
     );
+    const tableCellContent = field.props.header || <DefaultHeaderCellContent />;
+
     return (
         <TableCell style={style}>
-            {field.props.sortable !== false && field.props.source ? (
-                <Button
-                    onClick={updateSort}
-                    data-sort={field.props.source}
-                    className={classes.sortButton}
-                >
-                    <FieldTitle
-                        label={field.props.label}
-                        source={field.props.source}
-                        resource={resource}
-                    />
-
-                    {field.props.source === currentSort.field && (
-                        <ContentSort
-                            className={classNames(
-                                classes.sortIcon,
-                                currentSort.order === 'ASC'
-                                    ? classes.sortIconReversed
-                                    : ''
-                            )}
-                        />
-                    )}
-                </Button>
-            ) : (
-                <span className={classes.nonSortableLabel}>
-                    {
-                        <FieldTitle
-                            label={field.props.label}
-                            source={field.props.source}
-                            resource={resource}
-                        />
-                    }
-                </span>
-            )}
+            {tableCellContent &&
+                React.cloneElement(tableCellContent, {
+                    field,
+                    ...props,
+                })}
         </TableCell>
     );
 };

--- a/packages/react-admin/src/mui/list/DatagridHeaderCell.spec.js
+++ b/packages/react-admin/src/mui/list/DatagridHeaderCell.spec.js
@@ -5,14 +5,15 @@ import { shallow } from 'enzyme';
 import { DatagridHeaderCell } from './DatagridHeaderCell';
 
 describe('<DatagridHeaderCell />', () => {
-    describe('sorting on a column', () => {
+    describe('content rendering', () => {
         const Field = () => <div />;
+        const MyHeader = () => <span />;
         Field.defaultProps = {
             type: 'foo',
             updateSort: () => true,
         };
 
-        it('should be enabled when field has a source', () => {
+        it('should use default header content renderer if none defined', () => {
             const wrapper = shallow(
                 <DatagridHeaderCell
                     currentSort={{}}
@@ -20,31 +21,18 @@ describe('<DatagridHeaderCell />', () => {
                     updateSort={() => true}
                 />
             );
-            assert.equal(wrapper.find('withStyles(Button)').length, 1);
+            assert.equal(wrapper.find('DatagridHeaderCellContent').length, 1);
         });
 
-        it('should be disabled when field has no source', () => {
+        it('should allow custom header renderer in field', () => {
             const wrapper = shallow(
                 <DatagridHeaderCell
                     currentSort={{}}
-                    field={<Field />}
+                    field={<Field source="title" header={<MyHeader />} />}
                     updateSort={() => true}
                 />
             );
-
-            assert.equal(wrapper.find('withStyles(Button)').length, 0);
-        });
-
-        it('should be disabled when sortable prop is explicitly set to false', () => {
-            const wrapper = shallow(
-                <DatagridHeaderCell
-                    currentSort={{}}
-                    field={<Field source="title" sortable={false} />}
-                    updateSort={() => true}
-                />
-            );
-
-            assert.equal(wrapper.find('withStyles(Button)').length, 0);
+            assert.equal(wrapper.find('MyHeader').length, 1);
         });
     });
 });

--- a/packages/react-admin/src/mui/list/DatagridHeaderCellContent.js
+++ b/packages/react-admin/src/mui/list/DatagridHeaderCellContent.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Button from 'material-ui/Button';
+import ContentSort from 'material-ui-icons/Sort';
+
+import FieldTitle from '../../util/FieldTitle';
+
+export const DatagridHeaderCellContent = ({
+    classes = {},
+    field,
+    currentSort,
+    updateSort,
+    resource,
+}) => {
+    return field.props.sortable !== false && field.props.source ? (
+        <Button
+            onClick={updateSort}
+            data-sort={field.props.source}
+            className={classes.sortButton}
+        >
+            <FieldTitle
+                label={field.props.label}
+                source={field.props.source}
+                resource={resource}
+            />
+
+            {field.props.source === currentSort.field && (
+                <ContentSort
+                    className={classNames(
+                        classes.sortIcon,
+                        currentSort.order === 'ASC'
+                            ? classes.sortIconReversed
+                            : ''
+                    )}
+                />
+            )}
+        </Button>
+    ) : (
+        <span className={classes.nonSortableLabel}>
+            {
+                <FieldTitle
+                    label={field.props.label}
+                    source={field.props.source}
+                    resource={resource}
+                />
+            }
+        </span>
+    );
+};
+
+DatagridHeaderCellContent.propTypes = {
+    classes: PropTypes.object,
+    field: PropTypes.element,
+    currentSort: PropTypes.shape({
+        sort: PropTypes.string,
+        order: PropTypes.string,
+    }),
+    isSorting: PropTypes.bool,
+    sortable: PropTypes.bool,
+    resource: PropTypes.string,
+    updateSort: PropTypes.func,
+};
+
+export default DatagridHeaderCellContent;

--- a/packages/react-admin/src/mui/list/DatagridHeaderCellContent.spec.js
+++ b/packages/react-admin/src/mui/list/DatagridHeaderCellContent.spec.js
@@ -1,0 +1,50 @@
+import assert from 'assert';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import DatagridHeaderCellContent from './DatagridHeaderCellContent';
+
+describe('<DatagridHeaderCellContent />', () => {
+    describe('sorting on a column', () => {
+        const Field = () => <div />;
+        Field.defaultProps = {
+            type: 'foo',
+            updateSort: () => true,
+        };
+
+        it('should be enabled when field has a source', () => {
+            const wrapper = shallow(
+                <DatagridHeaderCellContent
+                    currentSort={{}}
+                    field={<Field source="title" />}
+                    updateSort={() => true}
+                />
+            );
+            assert.equal(wrapper.find('withStyles(Button)').length, 1);
+        });
+
+        it('should be disabled when field has no source', () => {
+            const wrapper = shallow(
+                <DatagridHeaderCellContent
+                    currentSort={{}}
+                    field={<Field />}
+                    updateSort={() => true}
+                />
+            );
+
+            assert.equal(wrapper.find('withStyles(Button)').length, 0);
+        });
+
+        it('should be disabled when sortable prop is explicitly set to false', () => {
+            const wrapper = shallow(
+                <DatagridHeaderCellContent
+                    currentSort={{}}
+                    field={<Field source="title" sortable={false} />}
+                    updateSort={() => true}
+                />
+            );
+
+            assert.equal(wrapper.find('withStyles(Button)').length, 0);
+        });
+    });
+});


### PR DESCRIPTION
This PR allows a field to supply a component to render the header. 
@See the test added: 

        it('should allow custom header renderer in field', () => {
            const wrapper = shallow(
                <DatagridHeaderCell
                    currentSort={{}}
                    field={<Field source="title" header={<MyHeader />} />}
                    updateSort={() => true}
                />
            );
            assert.equal(wrapper.find('MyHeader').length, 1);
        });

It splits the `DatagridHeaderCell` component in two components: `DatagridHeaderCell` and `DatagridHeaderCellContent`. The latter is the default renderer if none is supplied on the field. 