### PR TITLE
[RFR] Add missing import in Menu Documentation

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -157,6 +157,7 @@ If you want to add or remove menu items, for instance to link to non-resources p
 import React from 'react';
 import { connect } from 'react-redux';
 import { MenuItemLink } from 'admin-on-rest';
+import { getResources } from 'admin-on-rest/lib/reducer';
 
 const Menu = ({ resources, onMenuTap, logout }) => (
     <div>


### PR DESCRIPTION
Since I've updated my project from AOR 1.2.3 to 1.3.2, my own "CustomMenu" does not work anymore because we need to "connect" it manually. There's no BC in CHANGELOG about that, I don't know when change append exactly.

Anyway, I've added a missing import on the new "CustomMenu" example in documentation.
