### PR TITLE
Responsive actions

### DIFF
--- a/packages/react-admin/src/mui/button/RefreshButton.js
+++ b/packages/react-admin/src/mui/button/RefreshButton.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import Button from 'material-ui/Button';
+import IconButton from 'material-ui/IconButton';
 import NavigationRefresh from 'material-ui-icons/Refresh';
 import translate from '../../i18n/translate';
+import Responsive from '../../mui/layout/Responsive';
 import { refreshView as refreshViewAction } from '../../actions/uiActions';
 
 class RefreshButton extends Component {
@@ -24,14 +26,21 @@ class RefreshButton extends Component {
     };
 
     render() {
-        const { label, translate } = this.props;
+        let { label, translate } = this.props;
 
         return (
-            <Button color="primary" onClick={this.handleClick}>
-                <NavigationRefresh />
-                &nbsp;
-                {label && translate(label)}
-            </Button>
+            <Responsive
+                small={
+                    <IconButton color="contrast" onClick={this.handleClick}>
+                        <NavigationRefresh />
+                    </IconButton>
+                }
+                medium={
+                    <Button color="primary" onClick={this.handleClick}>
+                        <NavigationRefresh /> {label && translate(label)}
+                    </Button>
+                }
+            />
         );
     }
 }

--- a/packages/react-admin/src/mui/layout/AppBarMobile.js
+++ b/packages/react-admin/src/mui/layout/AppBarMobile.js
@@ -20,6 +20,7 @@ const styles = {
     title: {
         fontSize: '1.25em',
         lineHeight: '2.5em',
+        flex: 1,
     },
     icon: {
         marginTop: 0,
@@ -39,7 +40,13 @@ class AppBarMobile extends Component {
     };
 
     render() {
-        const { classes, title, toggleSidebar } = this.props;
+        const {
+            classes,
+            title,
+            toggleSidebar,
+            mobileActions,
+            actionProps,
+        } = this.props;
         return (
             <MuiAppBar className={classes.bar}>
                 <Toolbar>
@@ -51,9 +58,15 @@ class AppBarMobile extends Component {
                     >
                         <MenuIcon />
                     </IconButton>
-                    <Typography type="title" color="inherit">
+                    <Typography
+                        type="title"
+                        color="inherit"
+                        className={classes.title}
+                    >
                         {title}
                     </Typography>
+                    {mobileActions &&
+                        React.cloneElement(mobileActions, actionProps)}
                 </Toolbar>
             </MuiAppBar>
         );
@@ -62,9 +75,10 @@ class AppBarMobile extends Component {
 
 AppBarMobile.propTypes = {
     classes: PropTypes.object,
-    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
-        .isRequired,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     toggleSidebar: PropTypes.func.isRequired,
+    mobileActions: PropTypes.element,
+    actionProps: PropTypes.object,
 };
 
 const enhance = compose(connect(null, { toggleSidebar }), withStyles(styles));

--- a/packages/react-admin/src/mui/layout/Header.js
+++ b/packages/react-admin/src/mui/layout/Header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-
+import Responsive from '../../mui/layout/Responsive';
 import ViewTitle from './ViewTitle';
 
 const styles = {
@@ -11,16 +11,36 @@ const styles = {
     },
 };
 
-export const Header = ({ classes, title, actions, actionProps }) => (
-    <div className={classes.root}>
-        <ViewTitle title={title} />
-        {actions && React.cloneElement(actions, actionProps)}
-    </div>
+export const Header = ({
+    classes,
+    title,
+    mobileActions,
+    actions,
+    actionProps,
+}) => (
+    <Responsive
+        small={
+            <div className={classes.root}>
+                <ViewTitle
+                    title={title}
+                    mobileActions={mobileActions}
+                    actionProps={actionProps}
+                />
+            </div>
+        }
+        medium={
+            <div className={classes.root}>
+                <ViewTitle title={title} />
+                {actions && React.cloneElement(actions, actionProps)}
+            </div>
+        }
+    />
 );
 
 Header.propTypes = {
     classes: PropTypes.object,
     title: PropTypes.any,
+    mobileActions: PropTypes.element,
     actions: PropTypes.element,
     actionProps: PropTypes.object,
 };

--- a/packages/react-admin/src/mui/layout/ViewTitle.js
+++ b/packages/react-admin/src/mui/layout/ViewTitle.js
@@ -1,13 +1,20 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { CardContent } from 'material-ui/Card';
 import Typography from 'material-ui/Typography';
 
 import Responsive from './Responsive';
 import AppBarMobile from './AppBarMobile';
 
-const ViewTitle = ({ title }) => (
+const ViewTitle = ({ title, mobileActions, actionProps }) => (
     <Responsive
-        small={<AppBarMobile title={title} />}
+        small={
+            <AppBarMobile
+                title={title}
+                mobileActions={mobileActions}
+                actionProps={actionProps}
+            />
+        }
         medium={
             <CardContent className="title">
                 <Typography type="headline">{title}</Typography>
@@ -15,5 +22,9 @@ const ViewTitle = ({ title }) => (
         }
     />
 );
-
+ViewTitle.propTypes = {
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    mobileActions: PropTypes.element,
+    actionProps: PropTypes.object,
+};
 export default ViewTitle;

--- a/packages/react-admin/src/mui/list/FilterButton.js
+++ b/packages/react-admin/src/mui/list/FilterButton.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import Button from 'material-ui/Button';
+import IconButton from 'material-ui/IconButton';
 import Popover from 'material-ui/Popover';
 import { MenuList } from 'material-ui/Menu';
 import ContentFilter from 'material-ui-icons/FilterList';
 import translate from '../../i18n/translate';
 import FilterButtonMenuItem from './FilterButtonMenuItem';
+import Responsive from '../../mui/layout/Responsive';
 
 export class FilterButton extends Component {
     constructor(props) {
@@ -36,7 +37,7 @@ export class FilterButton extends Component {
 
         this.setState({
             open: true,
-            anchorEl: findDOMNode(this.button), // eslint-disable-line react/no-find-dom-node
+            anchorEl: event.currentTarget,
         });
     }
 
@@ -53,54 +54,69 @@ export class FilterButton extends Component {
         });
     }
 
-    button = null;
-
     render() {
         const hiddenFilters = this.getHiddenFilters();
         const { resource } = this.props;
         const { open, anchorEl } = this.state;
 
+        const FilterButtonMenu = (
+            <Popover
+                open={open}
+                anchorEl={anchorEl}
+                anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'left',
+                }}
+                transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                }}
+                onRequestClose={this.handleRequestClose}
+            >
+                <MenuList>
+                    {hiddenFilters.map(filterElement => (
+                        <FilterButtonMenuItem
+                            key={filterElement.props.source}
+                            filter={filterElement.props}
+                            resource={resource}
+                            onShow={this.handleShow}
+                        />
+                    ))}
+                </MenuList>
+            </Popover>
+        );
+
         return (
-            hiddenFilters.length > 0 && (
-                <div style={{ display: 'inline-block' }}>
-                    <Button
-                        ref={node => {
-                            this.button = node;
-                        }}
-                        className="add-filter"
-                        color="primary"
-                        onClick={this.handleClickButton}
-                    >
-                        <ContentFilter />
-                        &nbsp;
-                        {this.props.translate('ra.action.add_filter')}
-                    </Button>
-                    <Popover
-                        open={open}
-                        anchorEl={anchorEl}
-                        anchorOrigin={{
-                            vertical: 'bottom',
-                            horizontal: 'left',
-                        }}
-                        transformOrigin={{
-                            vertical: 'top',
-                            horizontal: 'left',
-                        }}
-                        onRequestClose={this.handleRequestClose}
-                    >
-                        <MenuList>
-                            {hiddenFilters.map(filterElement => (
-                                <FilterButtonMenuItem
-                                    key={filterElement.props.source}
-                                    filter={filterElement.props}
-                                    resource={resource}
-                                    onShow={this.handleShow}
-                                />
-                            ))}
-                        </MenuList>
-                    </Popover>
-                </div>
-            )
+            <Responsive
+                small={
+                    <div style={{ display: 'inline-block' }}>
+                        <IconButton
+                            className="add-filter"
+                            color="contrast"
+                            onClick={this.handleClickButton}
+                        >
+                            <ContentFilter />
+                        </IconButton>
+                        {FilterButtonMenu}
+                    </div>
+                }
+                medium={
+                    hiddenFilters.length > 0 && (
+                        <div style={{ display: 'inline-block' }}>
+                            <Button
+                                className="add-filter"
+                                color="primary"
+                                onClick={this.handleClickButton}
+                            >
+                                <ContentFilter />
+                                &nbsp;
+                                {this.props.translate('ra.action.add_filter')}
+                            </Button>
+                            {FilterButtonMenu}
+                        </div>
+                    )
+                }
+            />
         );
     }
 }

--- a/packages/react-admin/src/mui/list/List.js
+++ b/packages/react-admin/src/mui/list/List.js
@@ -18,6 +18,7 @@ import Header from '../layout/Header';
 import Title from '../layout/Title';
 import DefaultPagination from './Pagination';
 import DefaultActions from './Actions';
+import DefaultMobileActions from './MobileActions';
 import { crudGetList as crudGetListAction } from '../../actions/dataActions';
 import { changeListParams as changeListParamsAction } from '../../actions/listActions';
 import translate from '../../i18n/translate';
@@ -193,6 +194,7 @@ export class List extends Component {
             filters,
             pagination = <DefaultPagination />,
             actions = <DefaultActions />,
+            mobileActions = <DefaultMobileActions />,
             resource,
             hasCreate,
             title,
@@ -224,6 +226,7 @@ export class List extends Component {
                     <Header
                         title={titleElement}
                         actions={actions}
+                        mobileActions={mobileActions}
                         actionProps={{
                             resource,
                             filters,
@@ -283,6 +286,7 @@ export class List extends Component {
 List.propTypes = {
     // the props you can change
     actions: PropTypes.element,
+    mobileActions: PropTypes.element,
     children: PropTypes.node,
     filter: PropTypes.object,
     filters: PropTypes.element,

--- a/packages/react-admin/src/mui/list/MobileActions.js
+++ b/packages/react-admin/src/mui/list/MobileActions.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import onlyUpdateForKeys from 'recompose/onlyUpdateForKeys';
+import { CreateButton, RefreshButton } from '../button';
+
+class MobileActions extends React.Component {
+    state = {
+        open: true,
+    };
+
+    handleClick() {
+        this.setState({ open: true });
+    }
+
+    render() {
+        const {
+            //selection,
+            filters,
+            showFilter,
+            resource,
+            basePath,
+            displayedFilters,
+            filterValues,
+            hasCreate,
+            //selectActions,
+            //selectable,
+        } = this.props;
+
+        return (
+            <div>
+                {filters &&
+                    React.cloneElement(filters, {
+                        resource,
+                        showFilter,
+                        displayedFilters,
+                        filterValues,
+                        context: 'button',
+                    })}
+                <RefreshButton />
+                {hasCreate && <CreateButton basePath={basePath} />}
+            </div>
+        );
+    }
+}
+// TODO: add SelectActions from next-bulk-actions here.
+
+MobileActions.propTypes = {
+    basePath: PropTypes.string,
+    displayedFilters: PropTypes.object,
+    filters: PropTypes.element,
+    filterValues: PropTypes.object,
+    hasCreate: PropTypes.bool,
+    //    selectable: PropTypes.bool,
+    //    selection: PropTypes.array,
+    //    selectMode: PropTypes.oneOf(['single', 'page', 'bulk']),
+    //    selectActions: PropTypes.element,
+    resource: PropTypes.string,
+    showFilter: PropTypes.func,
+    theme: PropTypes.object,
+};
+
+export default onlyUpdateForKeys([
+    'resource',
+    'filters',
+    'displayedFilters',
+    'filterValues',
+])(MobileActions);


### PR DESCRIPTION
@see: https://github.com/marmelab/admin-on-rest/pull/1241#discussion_r153512966

On request I created an separate PR for this feature. To make it mergeable with `next` I removed `SelectActionButton` from the PR in `next-bulk-actions`. This should be added at a later stage.
