### PR TITLE
Bug: Validate not being passed on redux-form field.

### DIFF
--- a/packages/react-admin/src/mui/form/FormField.js
+++ b/packages/react-admin/src/mui/form/FormField.js
@@ -46,6 +46,7 @@ export class FormField extends Component {
                 {...props}
                 name={props.source}
                 component={component}
+                validate={validate}
                 isRequired={isRequired(validate)}
             />
         );


### PR DESCRIPTION
This bug is also visible in the example app, edit a post title (which is required) and remove all text. The validation error will not appear and the post is saved. 