### PR TITLE
Connecting saga and redux-form through promises proposal

### DIFF
--- a/packages/react-admin/src/Admin.js
+++ b/packages/react-admin/src/Admin.js
@@ -12,7 +12,7 @@ import withContext from 'recompose/withContext';
 import { USER_LOGOUT } from './actions/authActions';
 
 import createAppReducer from './reducer';
-import { crudSaga } from './sideEffect/saga';
+import { crudSaga, promiseAction } from './sideEffect/saga';
 import DefaultLayout from './mui/layout/Layout';
 import Menu from './mui/layout/Menu';
 import Login from './mui/auth/Login';
@@ -44,7 +44,11 @@ const Admin = ({
         appReducer(action.type !== USER_LOGOUT ? state : undefined, action);
     const saga = function* rootSaga() {
         yield all(
-            [crudSaga(dataProvider, authClient), ...customSagas].map(fork)
+            [
+                crudSaga(dataProvider, authClient),
+                promiseAction,
+                ...customSagas,
+            ].map(fork)
         );
     };
     const sagaMiddleware = createSagaMiddleware();

--- a/packages/react-admin/src/actions/dataActions.js
+++ b/packages/react-admin/src/actions/dataActions.js
@@ -8,138 +8,78 @@ import {
     GET_MANY_REFERENCE,
 } from '../dataFetchActions';
 
-export const CRUD_GET_LIST = 'RA/CRUD_GET_LIST';
-export const CRUD_GET_LIST_LOADING = 'RA/CRUD_GET_LIST_LOADING';
-export const CRUD_GET_LIST_FAILURE = 'RA/CRUD_GET_LIST_FAILURE';
-export const CRUD_GET_LIST_SUCCESS = 'RA/CRUD_GET_LIST_SUCCESS';
+import { promisingActionCreator } from '../util/promisingActionCreator';
 
-export const crudGetList = (
-    resource,
-    pagination,
-    sort,
-    filter,
-    cancelPrevious = true
-) => ({
-    type: CRUD_GET_LIST,
-    payload: { pagination, sort, filter },
-    meta: { resource, fetch: GET_LIST, cancelPrevious },
-});
+export const crudGetList = promisingActionCreator(
+    `RA/CRUD_${GET_LIST}`,
+    ({ resource, pagination, sort, filter, cancelPrevious = true }) => ({
+        payload: { pagination, sort, filter },
+        meta: { resource, fetch: GET_LIST, cancelPrevious },
+    })
+);
 
-export const CRUD_GET_ONE = 'RA/CRUD_GET_ONE';
-export const CRUD_GET_ONE_LOADING = 'RA/CRUD_GET_ONE_LOADING';
-export const CRUD_GET_ONE_FAILURE = 'RA/CRUD_GET_ONE_FAILURE';
-export const CRUD_GET_ONE_SUCCESS = 'RA/CRUD_GET_ONE_SUCCESS';
+export const crudGetOne = promisingActionCreator(
+    `RA/CRUD_${GET_ONE}`,
+    ({ resource, id, basePath, cancelPrevious = true }) => ({
+        payload: { id, basePath },
+        meta: { resource, fetch: GET_ONE, cancelPrevious },
+    })
+);
 
-export const crudGetOne = (resource, id, basePath, cancelPrevious = true) => ({
-    type: CRUD_GET_ONE,
-    payload: { id, basePath },
-    meta: { resource, fetch: GET_ONE, cancelPrevious },
-});
+export const crudCreate = promisingActionCreator(
+    `RA/CRUD_${CREATE}`,
+    ({ resource, data, basePath, redirectTo = 'edit' }) => ({
+        payload: { data, basePath, redirectTo },
+        meta: { resource, fetch: CREATE, cancelPrevious: false },
+    })
+);
 
-export const CRUD_CREATE = 'RA/CRUD_CREATE';
-export const CRUD_CREATE_LOADING = 'RA/CRUD_CREATE_LOADING';
-export const CRUD_CREATE_FAILURE = 'RA/CRUD_CREATE_FAILURE';
-export const CRUD_CREATE_SUCCESS = 'RA/CRUD_CREATE_SUCCESS';
+export const crudUpdate = promisingActionCreator(
+    `RA/CRUD_${UPDATE}`,
+    ({ resource, id, data, previousData, basePath, redirectTo = 'show' }) => ({
+        payload: { id, data, previousData, basePath, redirectTo },
+        meta: { resource, fetch: UPDATE, cancelPrevious: false },
+    })
+);
 
-export const crudCreate = (resource, data, basePath, redirectTo = 'edit') => ({
-    type: CRUD_CREATE,
-    payload: { data, basePath, redirectTo },
-    meta: { resource, fetch: CREATE, cancelPrevious: false },
-});
+export const crudDelete = promisingActionCreator(
+    `RA/CRUD_${DELETE}`,
+    ({ resource, id, previousData, basePath, redirectTo = 'list' }) => ({
+        payload: { id, previousData, basePath, redirectTo },
+        meta: { resource, fetch: DELETE, cancelPrevious: false },
+    })
+);
 
-export const CRUD_UPDATE = 'RA/CRUD_UPDATE';
-export const CRUD_UPDATE_LOADING = 'RA/CRUD_UPDATE_LOADING';
-export const CRUD_UPDATE_FAILURE = 'RA/CRUD_UPDATE_FAILURE';
-export const CRUD_UPDATE_SUCCESS = 'RA/CRUD_UPDATE_SUCCESS';
+export const crudGetMany = promisingActionCreator(
+    `RA/CRUD_${GET_MANY}`,
+    ({ resource, ids }) => ({
+        payload: { ids },
+        meta: { resource, fetch: GET_MANY, cancelPrevious: false },
+    })
+);
 
-export const crudUpdate = (
-    resource,
-    id,
-    data,
-    previousData,
-    basePath,
-    redirectTo = 'show'
-) => ({
-    type: CRUD_UPDATE,
-    payload: { id, data, previousData, basePath, redirectTo },
-    meta: { resource, fetch: UPDATE, cancelPrevious: false },
-});
+export const crudGetMatching = promisingActionCreator(
+    `RA/CRUD_GET_MATCHING`,
+    ({ reference, relatedTo, pagination, sort, filter }) => ({
+        payload: { pagination, sort, filter },
+        meta: {
+            resource: reference,
+            relatedTo,
+            fetch: GET_LIST,
+            cancelPrevious: false,
+        },
+    })
+);
 
-export const CRUD_DELETE = 'RA/CRUD_DELETE';
-export const CRUD_DELETE_LOADING = 'RA/CRUD_DELETE_LOADING';
-export const CRUD_DELETE_FAILURE = 'RA/CRUD_DELETE_FAILURE';
-export const CRUD_DELETE_SUCCESS = 'RA/CRUD_DELETE_SUCCESS';
-
-export const crudDelete = (
-    resource,
-    id,
-    previousData,
-    basePath,
-    redirectTo = 'list'
-) => ({
-    type: CRUD_DELETE,
-    payload: { id, previousData, basePath, redirectTo },
-    meta: { resource, fetch: DELETE, cancelPrevious: false },
-});
-
-export const CRUD_GET_MANY = 'RA/CRUD_GET_MANY';
-export const CRUD_GET_MANY_LOADING = 'RA/CRUD_GET_MANY_LOADING';
-export const CRUD_GET_MANY_FAILURE = 'RA/CRUD_GET_MANY_FAILURE';
-export const CRUD_GET_MANY_SUCCESS = 'RA/CRUD_GET_MANY_SUCCESS';
-
-// Reference related actions
-
-export const crudGetMany = (resource, ids) => ({
-    type: CRUD_GET_MANY,
-    payload: { ids },
-    meta: { resource, fetch: GET_MANY, cancelPrevious: false },
-});
-
-export const CRUD_GET_MATCHING = 'RA/CRUD_GET_MATCHING';
-export const CRUD_GET_MATCHING_LOADING = 'RA/CRUD_GET_MATCHING_LOADING';
-export const CRUD_GET_MATCHING_FAILURE = 'RA/CRUD_GET_MATCHING_FAILURE';
-export const CRUD_GET_MATCHING_SUCCESS = 'RA/CRUD_GET_MATCHING_SUCCESS';
-
-export const crudGetMatching = (
-    reference,
-    relatedTo,
-    pagination,
-    sort,
-    filter
-) => ({
-    type: CRUD_GET_MATCHING,
-    payload: { pagination, sort, filter },
-    meta: {
-        resource: reference,
-        relatedTo,
-        fetch: GET_LIST,
-        cancelPrevious: false,
-    },
-});
-
-export const CRUD_GET_MANY_REFERENCE = 'RA/CRUD_GET_MANY_REFERENCE';
-export const CRUD_GET_MANY_REFERENCE_LOADING =
-    'RA/CRUD_GET_MANY_REFERENCE_LOADING';
-export const CRUD_GET_MANY_REFERENCE_FAILURE =
-    'RA/CRUD_GET_MANY_REFERENCE_FAILURE';
-export const CRUD_GET_MANY_REFERENCE_SUCCESS =
-    'RA/CRUD_GET_MANY_REFERENCE_SUCCESS';
-
-export const crudGetManyReference = (
-    reference,
-    target,
-    id,
-    relatedTo,
-    pagination,
-    sort,
-    filter
-) => ({
-    type: CRUD_GET_MANY_REFERENCE,
-    payload: { target, id, pagination, sort, filter },
-    meta: {
-        resource: reference,
-        relatedTo,
-        fetch: GET_MANY_REFERENCE,
-        cancelPrevious: false,
-    },
-});
+export const crudGetManyReference = promisingActionCreator(
+    `RA/CRUD_${GET_MANY_REFERENCE}`,
+    ({ reference, target, id, relatedTo, pagination, sort, filter }) => ({
+        payload: { target, id, pagination, sort, filter },
+        meta: {
+            resource: reference,
+            relatedTo,
+            fetch: GET_MANY_REFERENCE,
+            cancelPrevious: false,
+        },
+    })
+);

--- a/packages/react-admin/src/mui/delete/Delete.js
+++ b/packages/react-admin/src/mui/delete/Delete.js
@@ -76,20 +76,20 @@ export class Delete extends Component {
     }
 
     componentDidMount() {
-        this.props.crudGetOne(
-            this.props.resource,
-            this.props.id,
-            this.getBasePath()
-        );
+        this.props.crudGetOne({
+            resource: this.props.resource,
+            id: this.props.id,
+            basePath: this.getBasePath(),
+        });
     }
 
     componentWillReceiveProps(nextProps) {
         if (this.props.id !== nextProps.id) {
-            this.props.crudGetOne(
-                nextProps.resource,
-                nextProps.id,
-                this.getBasePath()
-            );
+            this.props.crudGetOne({
+                resource: nextProps.resource,
+                id: nextProps.id,
+                basePath: this.getBasePath(),
+            });
         }
     }
 
@@ -107,15 +107,15 @@ export class Delete extends Component {
 
     handleSubmit(event) {
         event.preventDefault();
-        this.props.crudDelete(
-            this.props.resource,
-            this.props.id,
-            this.props.data,
-            this.getBasePath(),
-            this.props.redirect
+        this.props.crudDelete({
+            resource: this.props.resource,
+            id: this.props.id,
+            previousData: this.props.data,
+            basePath: this.getBasePath(),
+            redirectTo: this.props.redirect
                 ? this.props.redirect
-                : this.defaultRedirectRoute()
-        );
+                : this.defaultRedirectRoute(),
+        });
     }
 
     goBack() {

--- a/packages/react-admin/src/mui/detail/Create.js
+++ b/packages/react-admin/src/mui/detail/Create.js
@@ -68,12 +68,15 @@ class Create extends Component {
         return 'list';
     }
 
-    save = (record, redirect) => {
-        this.props.crudCreate(
-            this.props.resource,
-            record,
-            this.getBasePath(),
-            redirect
+    save = (record, redirect, dispatch) => {
+        return crudCreateAction(
+            {
+                resource: this.props.resource,
+                data: record,
+                basePath: this.getBasePath(),
+                redirectTo: redirect,
+            },
+            dispatch
         );
     };
 

--- a/packages/react-admin/src/mui/detail/Create.js
+++ b/packages/react-admin/src/mui/detail/Create.js
@@ -77,7 +77,11 @@ class Create extends Component {
                 redirectTo: redirect,
             },
             dispatch
-        );
+        )
+            .then(
+                result => this.props.onSuccess && this.props.onSuccess(result)
+            )
+            .catch(err => this.props.onError && this.props.onError(err));
     };
 
     render() {
@@ -145,6 +149,8 @@ Create.propTypes = {
     resource: PropTypes.string.isRequired,
     title: PropTypes.any,
     translate: PropTypes.func.isRequired,
+    onSuccess: PropTypes.func,
+    onError: PropTypes.func,
     hasList: PropTypes.bool,
 };
 

--- a/packages/react-admin/src/mui/detail/Edit.js
+++ b/packages/react-admin/src/mui/detail/Edit.js
@@ -9,7 +9,7 @@ import Header from '../layout/Header';
 import Title from '../layout/Title';
 import {
     crudGetOne as crudGetOneAction,
-    crudUpdate as crudUpdateAction,
+    crudUpdate,
 } from '../../actions/dataActions';
 import DefaultActions from './EditActions';
 import translate from '../../i18n/translate';
@@ -100,17 +100,24 @@ export class Edit extends Component {
     }
 
     updateData(resource = this.props.resource, id = this.props.id) {
-        this.props.crudGetOne(resource, id, this.getBasePath());
+        this.props.crudGetOne({
+            resource,
+            id,
+            basePath: this.getBasePath(),
+        });
     }
 
-    save = (record, redirect) => {
-        this.props.crudUpdate(
-            this.props.resource,
-            this.props.id,
-            record,
-            this.props.data,
-            this.getBasePath(),
-            redirect
+    save = (record, redirect, dispatch) => {
+        return crudUpdate(
+            {
+                resource: this.props.resource,
+                id: this.props.id,
+                data: record,
+                previousData: this.props.data,
+                basePath: this.getBasePath(),
+                redirectTo: redirect,
+            },
+            dispatch
         );
     };
 
@@ -186,7 +193,6 @@ Edit.propTypes = {
     actions: PropTypes.element,
     children: PropTypes.node,
     crudGetOne: PropTypes.func.isRequired,
-    crudUpdate: PropTypes.func.isRequired,
     data: PropTypes.object,
     hasDelete: PropTypes.bool,
     hasShow: PropTypes.bool,
@@ -217,7 +223,6 @@ function mapStateToProps(state, props) {
 const enhance = compose(
     connect(mapStateToProps, {
         crudGetOne: crudGetOneAction,
-        crudUpdate: crudUpdateAction,
     }),
     translate,
     withChildrenAsFunction

--- a/packages/react-admin/src/mui/detail/Edit.js
+++ b/packages/react-admin/src/mui/detail/Edit.js
@@ -118,7 +118,11 @@ export class Edit extends Component {
                 redirectTo: redirect,
             },
             dispatch
-        );
+        )
+            .then(
+                result => this.props.onSuccess && this.props.onSuccess(result)
+            )
+            .then(err => this.props.onError && this.props.onError(err));
     };
 
     render() {
@@ -205,6 +209,8 @@ Edit.propTypes = {
     title: PropTypes.any,
     translate: PropTypes.func,
     version: PropTypes.number.isRequired,
+    onSuccess: PropTypes.func,
+    onError: PropTypes.func,
 };
 
 function mapStateToProps(state, props) {

--- a/packages/react-admin/src/mui/detail/Show.js
+++ b/packages/react-admin/src/mui/detail/Show.js
@@ -77,7 +77,11 @@ export class Show extends Component {
     }
 
     updateData(resource = this.props.resource, id = this.props.id) {
-        this.props.crudGetOne(resource, id, this.getBasePath());
+        this.props.crudGetOne({
+            resource,
+            id,
+            basePath: this.getBasePath(),
+        });
     }
 
     render() {

--- a/packages/react-admin/src/mui/field/ReferenceManyField.js
+++ b/packages/react-admin/src/mui/field/ReferenceManyField.js
@@ -96,15 +96,15 @@ export class ReferenceManyField extends Component {
             target,
             filter
         );
-        crudGetManyReference(
+        crudGetManyReference({
             reference,
             target,
-            record.id,
+            id: record.id,
             relatedTo,
             pagination,
-            this.state.sort,
-            filter
-        );
+            sort: this.state.sort,
+            filter,
+        });
     }
 
     render() {

--- a/packages/react-admin/src/mui/form/SimpleForm.js
+++ b/packages/react-admin/src/mui/form/SimpleForm.js
@@ -11,7 +11,9 @@ const formStyle = { padding: '0 1em 1em 1em' };
 
 export class SimpleForm extends Component {
     handleSubmitWithRedirect = (redirect = this.props.redirect) =>
-        this.props.handleSubmit(values => this.props.save(values, redirect));
+        this.props.handleSubmit((values, dispatch) =>
+            this.props.save(values, redirect, dispatch)
+        );
 
     render() {
         const {

--- a/packages/react-admin/src/mui/form/TabbedForm.js
+++ b/packages/react-admin/src/mui/form/TabbedForm.js
@@ -34,7 +34,9 @@ export class TabbedForm extends Component {
     };
 
     handleSubmitWithRedirect = (redirect = this.props.redirect) =>
-        this.props.handleSubmit(values => this.props.save(values, redirect));
+        this.props.handleSubmit((values, dispatch) =>
+            this.props.save(values, redirect, dispatch)
+        );
 
     render() {
         const {

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.js
@@ -143,15 +143,18 @@ export class ReferenceArrayInput extends Component {
                     'The value of ReferenceArrayInput should be an array'
                 );
             }
-            this.props.crudGetMany(reference, ids);
+            this.props.crudGetMany({
+                reference,
+                ids,
+            });
         }
-        this.props.crudGetMatching(
+        this.props.crudGetMatching({
             reference,
-            referenceSource(resource, source),
+            relatedTo: referenceSource(resource, source),
             pagination,
             sort,
-            filter
-        );
+            filter,
+        });
     }
 
     render() {

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
@@ -46,17 +46,19 @@ describe('<ReferenceArrayInput />', () => {
             </ReferenceArrayInput>
         );
         assert.deepEqual(crudGetMatching.mock.calls[0], [
-            'tags',
-            'posts@tag_ids',
             {
-                page: 1,
-                perPage: 25,
+                reference: 'tags',
+                relatedTo: 'posts@tag_ids',
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
             },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {},
         ]);
     });
 
@@ -75,18 +77,20 @@ describe('<ReferenceArrayInput />', () => {
             </ReferenceArrayInput>
         );
         assert.deepEqual(crudGetMatching.mock.calls[0], [
-            'tags',
-            'posts@tag_ids',
             {
-                page: 1,
-                perPage: 5,
-            },
-            {
-                field: 'foo',
-                order: 'ASC',
-            },
-            {
-                q: 'foo',
+                reference: 'tags',
+                relatedTo: 'posts@tag_ids',
+                pagination: {
+                    page: 1,
+                    perPage: 5,
+                },
+                sort: {
+                    field: 'foo',
+                    order: 'ASC',
+                },
+                filter: {
+                    q: 'foo',
+                },
             },
         ]);
     });
@@ -104,18 +108,20 @@ describe('<ReferenceArrayInput />', () => {
         );
         wrapper.instance().setFilter('bar');
         assert.deepEqual(crudGetMatching.mock.calls[1], [
-            'tags',
-            'posts@tag_ids',
             {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                q: 'bar',
+                reference: 'tags',
+                relatedTo: 'posts@tag_ids',
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {
+                    q: 'bar',
+                },
             },
         ]);
     });
@@ -134,18 +140,20 @@ describe('<ReferenceArrayInput />', () => {
         );
         wrapper.instance().setFilter('bar');
         assert.deepEqual(crudGetMatching.mock.calls[1], [
-            'tags',
-            'posts@tag_ids',
             {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                foo: 'bar',
+                reference: 'tags',
+                relatedTo: 'posts@tag_ids',
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {
+                    foo: 'bar',
+                },
             },
         ]);
     });
@@ -162,7 +170,9 @@ describe('<ReferenceArrayInput />', () => {
                 <MyComponent />
             </ReferenceArrayInput>
         );
-        assert.deepEqual(crudGetMany.mock.calls[0], ['tags', [5, 6]]);
+        assert.deepEqual(crudGetMany.mock.calls[0], [
+            { reference: 'tags', ids: [5, 6] },
+        ]);
     });
 
     it('should pass onChange down to child component', () => {

--- a/packages/react-admin/src/mui/input/ReferenceInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.js
@@ -142,16 +142,21 @@ export class ReferenceInput extends Component {
 
         const id = input.value;
         if (id) {
-            this.props.crudGetOne(reference, id, null, false);
+            this.props.crudGetOne({
+                resource: reference,
+                id,
+                basePath: null,
+                cancelPrevious: false,
+            });
         }
         const finalFilter = { ...filterFromProps, ...filter };
-        this.props.crudGetMatching(
+        this.props.crudGetMatching({
             reference,
-            referenceSource(resource, source),
+            relatedTo: referenceSource(resource, source),
             pagination,
             sort,
-            finalFilter
-        );
+            filter: finalFilter,
+        });
     }
 
     render() {

--- a/packages/react-admin/src/mui/input/ReferenceInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.spec.js
@@ -46,17 +46,19 @@ describe('<ReferenceInput />', () => {
             </ReferenceInput>
         );
         assert.deepEqual(crudGetMatching.mock.calls[0], [
-            'posts',
-            'comments@post_id',
             {
-                page: 1,
-                perPage: 25,
+                reference: 'posts',
+                relatedTo: 'comments@post_id',
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {},
             },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {},
         ]);
     });
 
@@ -75,18 +77,20 @@ describe('<ReferenceInput />', () => {
             </ReferenceInput>
         );
         assert.deepEqual(crudGetMatching.mock.calls[0], [
-            'posts',
-            'comments@post_id',
             {
-                page: 1,
-                perPage: 5,
-            },
-            {
-                field: 'foo',
-                order: 'ASC',
-            },
-            {
-                q: 'foo',
+                reference: 'posts',
+                relatedTo: 'comments@post_id',
+                pagination: {
+                    page: 1,
+                    perPage: 5,
+                },
+                sort: {
+                    field: 'foo',
+                    order: 'ASC',
+                },
+                filter: {
+                    q: 'foo',
+                },
             },
         ]);
     });
@@ -109,19 +113,21 @@ describe('<ReferenceInput />', () => {
         wrapper.instance().setFilter('search_me');
 
         assert.deepEqual(crudGetMatching.mock.calls[1], [
-            'posts',
-            'comments@post_id',
             {
-                page: 1,
-                perPage: 5,
-            },
-            {
-                field: 'foo',
-                order: 'ASC',
-            },
-            {
-                foo: 'bar',
-                q: 'search_me',
+                reference: 'posts',
+                relatedTo: 'comments@post_id',
+                pagination: {
+                    page: 1,
+                    perPage: 5,
+                },
+                sort: {
+                    field: 'foo',
+                    order: 'ASC',
+                },
+                filter: {
+                    foo: 'bar',
+                    q: 'search_me',
+                },
             },
         ]);
     });
@@ -139,18 +145,20 @@ describe('<ReferenceInput />', () => {
         );
         wrapper.instance().setFilter('bar');
         assert.deepEqual(crudGetMatching.mock.calls[1], [
-            'posts',
-            'comments@post_id',
             {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                q: 'bar',
+                reference: 'posts',
+                relatedTo: 'comments@post_id',
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {
+                    q: 'bar',
+                },
             },
         ]);
     });
@@ -169,18 +177,20 @@ describe('<ReferenceInput />', () => {
         );
         wrapper.instance().setFilter('bar');
         assert.deepEqual(crudGetMatching.mock.calls[1], [
-            'posts',
-            'comments@post_id',
             {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                foo: 'bar',
+                reference: 'posts',
+                relatedTo: 'comments@post_id',
+                pagination: {
+                    page: 1,
+                    perPage: 25,
+                },
+                sort: {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                filter: {
+                    foo: 'bar',
+                },
             },
         ]);
     });
@@ -197,7 +207,9 @@ describe('<ReferenceInput />', () => {
                 <MyComponent />
             </ReferenceInput>
         );
-        assert.deepEqual(crudGetOne.mock.calls[0], ['posts', 5, null, false]);
+        assert.deepEqual(crudGetOne.mock.calls[0], [
+            { resource: 'posts', id: 5, basePath: null, cancelPrevious: false },
+        ]);
     });
 
     it('should pass onChange down to child component', () => {

--- a/packages/react-admin/src/mui/list/List.js
+++ b/packages/react-admin/src/mui/list/List.js
@@ -144,12 +144,12 @@ export class List extends Component {
             perPage: parseInt(perPage, 10),
         };
         const permanentFilter = this.props.filter;
-        this.props.crudGetList(
-            this.props.resource,
-            pagination,
-            { field: sort, order },
-            { ...filter, ...permanentFilter }
-        );
+        this.props.crudGetList({
+            resource: this.props.resource,
+            pagination: pagination,
+            sort: { field: sort, order },
+            filter: { ...filter, ...permanentFilter },
+        });
     }
 
     setSort = sort => this.changeParams({ type: SET_SORT, payload: sort });

--- a/packages/react-admin/src/reducer/admin/references/oneToMany.js
+++ b/packages/react-admin/src/reducer/admin/references/oneToMany.js
@@ -1,10 +1,10 @@
-import { CRUD_GET_MANY_REFERENCE_SUCCESS } from '../../../actions/dataActions';
+import { crudGetManyReference } from '../../../actions/dataActions';
 
 const initialState = {};
 
 export default (previousState = initialState, { type, payload, meta }) => {
     switch (type) {
-        case CRUD_GET_MANY_REFERENCE_SUCCESS:
+        case crudGetManyReference.SUCCESS:
             return {
                 ...previousState,
                 [meta.relatedTo]: payload.data.map(record => record.id),

--- a/packages/react-admin/src/reducer/admin/references/possibleValues.js
+++ b/packages/react-admin/src/reducer/admin/references/possibleValues.js
@@ -1,10 +1,10 @@
-import { CRUD_GET_MATCHING_SUCCESS } from '../../../actions/dataActions';
+import { crudGetMatching } from '../../../actions/dataActions';
 
 const initialState = {};
 
 export default (previousState = initialState, { type, payload, meta }) => {
     switch (type) {
-        case CRUD_GET_MATCHING_SUCCESS:
+        case crudGetMatching.SUCCESS:
             return {
                 ...previousState,
                 [meta.relatedTo]: payload.data.map(record => record.id),

--- a/packages/react-admin/src/reducer/admin/resource/list/ids.js
+++ b/packages/react-admin/src/reducer/admin/resource/list/ids.js
@@ -1,12 +1,12 @@
 import uniq from 'lodash.uniq';
 import {
-    CRUD_GET_LIST_SUCCESS,
-    CRUD_DELETE_SUCCESS,
-    CRUD_GET_MANY_SUCCESS,
-    CRUD_GET_MANY_REFERENCE_SUCCESS,
-    CRUD_GET_ONE_SUCCESS,
-    CRUD_CREATE_SUCCESS,
-    CRUD_UPDATE_SUCCESS,
+    crudGetList,
+    crudDelete,
+    crudGetMany,
+    crudGetManyReference,
+    crudGetOne,
+    crudCreate,
+    crudUpdate,
 } from '../../../../actions/dataActions';
 
 import getFetchedAt from '../../../../util/getFetchedAt';
@@ -36,21 +36,21 @@ export default resource => (
         return previousState;
     }
     switch (type) {
-        case CRUD_GET_LIST_SUCCESS:
+        case crudGetList.SUCCESS:
             return addRecordIds(payload.data.map(({ id }) => id), []);
-        case CRUD_GET_MANY_SUCCESS:
-        case CRUD_GET_MANY_REFERENCE_SUCCESS:
+        case crudGetMany.SUCCESS:
+        case crudGetManyReference.SUCCESS:
             return addRecordIds(
                 payload.data
                     .map(({ id }) => id)
                     .filter(id => previousState.indexOf(id) !== -1),
                 previousState
             );
-        case CRUD_GET_ONE_SUCCESS:
-        case CRUD_CREATE_SUCCESS:
-        case CRUD_UPDATE_SUCCESS:
+        case crudGetOne.SUCCESS:
+        case crudCreate.SUCCESS:
+        case crudUpdate.SUCCESS:
             return addRecordIds([payload.data.id], previousState);
-        case CRUD_DELETE_SUCCESS: {
+        case crudDelete.SUCCESS: {
             const index = previousState
                 .map(el => el == requestPayload.id) // eslint-disable-line eqeqeq
                 .indexOf(true);

--- a/packages/react-admin/src/reducer/admin/resource/list/total.js
+++ b/packages/react-admin/src/reducer/admin/resource/list/total.js
@@ -1,10 +1,10 @@
-import { CRUD_GET_LIST_SUCCESS } from '../../../../actions/dataActions';
+import { crudGetList } from '../../../../actions/dataActions';
 
 export default resource => (previousState = 0, { type, payload, meta }) => {
     if (!meta || meta.resource !== resource) {
         return previousState;
     }
-    if (type === CRUD_GET_LIST_SUCCESS) {
+    if (type === crudGetList.SUCCESS) {
         return payload.total;
     }
     return previousState;

--- a/packages/react-admin/src/reducer/admin/saving.js
+++ b/packages/react-admin/src/reducer/admin/saving.js
@@ -1,25 +1,18 @@
 import { actionTypes } from 'redux-form';
 import { LOCATION_CHANGE } from 'react-router-redux';
-import {
-    CRUD_CREATE,
-    CRUD_CREATE_SUCCESS,
-    CRUD_CREATE_FAILURE,
-    CRUD_UPDATE,
-    CRUD_UPDATE_SUCCESS,
-    CRUD_UPDATE_FAILURE,
-} from '../../actions';
+import { crudCreate, crudUpdate } from '../../actions';
 
 export default (previousState = false, { type, payload }) => {
     switch (type) {
-        case CRUD_CREATE:
-        case CRUD_UPDATE:
+        case crudCreate.REQUEST:
+        case crudUpdate.REQUEST:
             return { redirect: payload.redirectTo };
         case LOCATION_CHANGE:
         case actionTypes.SET_SUBMIT_FAILED:
-        case CRUD_CREATE_SUCCESS:
-        case CRUD_CREATE_FAILURE:
-        case CRUD_UPDATE_SUCCESS:
-        case CRUD_UPDATE_FAILURE:
+        case crudCreate.SUCCESS:
+        case crudCreate.FAILURE:
+        case crudUpdate.SUCCESS:
+        case crudUpdate.FAILURE:
             return false;
         default:
             return previousState;

--- a/packages/react-admin/src/sideEffect/saga/crudResponse.js
+++ b/packages/react-admin/src/sideEffect/saga/crudResponse.js
@@ -21,10 +21,6 @@ import resolveRedirectTo from '../../util/resolveRedirectTo';
 function* handleResponse({ type, requestPayload, error, payload }) {
     switch (type) {
         case crudUpdate.SUCCESS:
-            yield crudUpdate.success({
-                requestPayload,
-                data: payload,
-            });
             return requestPayload.redirectTo
                 ? yield all([
                       put(showNotification('ra.notification.updated')),
@@ -40,10 +36,6 @@ function* handleResponse({ type, requestPayload, error, payload }) {
                   ])
                 : yield [put(showNotification('ra.notification.updated'))];
         case crudCreate.SUCCESS:
-            yield crudCreate.success({
-                requestPayload,
-                data: payload,
-            });
             return requestPayload.redirectTo
                 ? yield all([
                       put(showNotification('ra.notification.created')),
@@ -104,20 +96,6 @@ function* handleResponse({ type, requestPayload, error, payload }) {
         case crudGetMany.FAILURE:
         case crudGetManyReference.FAILURE:
         case crudDelete.FAILURE: {
-            switch (type) {
-                case crudCreate.FAILURE:
-                    yield crudCreate.failure({
-                        request: requestPayload,
-                        error,
-                    });
-                    break;
-                case crudUpdate.FAILURE:
-                    yield crudUpdate.failure({
-                        request: requestPayload,
-                        error,
-                    });
-                    break;
-            }
             console.error(error); // eslint-disable-line no-console
             const errorMessage =
                 typeof error === 'string'

--- a/packages/react-admin/src/sideEffect/saga/crudResponse.js
+++ b/packages/react-admin/src/sideEffect/saga/crudResponse.js
@@ -2,17 +2,13 @@ import { all, put, takeEvery } from 'redux-saga/effects';
 import { push } from 'react-router-redux';
 import { reset } from 'redux-form';
 import {
-    CRUD_CREATE_FAILURE,
-    CRUD_CREATE_SUCCESS,
-    CRUD_DELETE_FAILURE,
-    CRUD_DELETE_SUCCESS,
-    CRUD_GET_LIST_FAILURE,
-    CRUD_GET_MANY_FAILURE,
-    CRUD_GET_MANY_REFERENCE_FAILURE,
-    CRUD_GET_ONE_SUCCESS,
-    CRUD_GET_ONE_FAILURE,
-    CRUD_UPDATE_FAILURE,
-    CRUD_UPDATE_SUCCESS,
+    crudCreate,
+    crudDelete,
+    crudGetList,
+    crudGetMany,
+    crudGetManyReference,
+    crudGetOne,
+    crudUpdate,
 } from '../../actions/dataActions';
 import { showNotification } from '../../actions/notificationActions';
 import resolveRedirectTo from '../../util/resolveRedirectTo';
@@ -24,7 +20,11 @@ import resolveRedirectTo from '../../util/resolveRedirectTo';
  */
 function* handleResponse({ type, requestPayload, error, payload }) {
     switch (type) {
-        case CRUD_UPDATE_SUCCESS:
+        case crudUpdate.SUCCESS:
+            yield crudUpdate.success({
+                requestPayload,
+                data: payload,
+            });
             return requestPayload.redirectTo
                 ? yield all([
                       put(showNotification('ra.notification.updated')),
@@ -39,7 +39,11 @@ function* handleResponse({ type, requestPayload, error, payload }) {
                       ),
                   ])
                 : yield [put(showNotification('ra.notification.updated'))];
-        case CRUD_CREATE_SUCCESS:
+        case crudCreate.SUCCESS:
+            yield crudCreate.success({
+                requestPayload,
+                data: payload,
+            });
             return requestPayload.redirectTo
                 ? yield all([
                       put(showNotification('ra.notification.created')),
@@ -57,7 +61,7 @@ function* handleResponse({ type, requestPayload, error, payload }) {
                       put(showNotification('ra.notification.created')),
                       put(reset('record-form')),
                   ]);
-        case CRUD_DELETE_SUCCESS:
+        case crudDelete.SUCCESS:
             return requestPayload.redirectTo
                 ? yield all([
                       put(showNotification('ra.notification.deleted')),
@@ -72,7 +76,7 @@ function* handleResponse({ type, requestPayload, error, payload }) {
                       ),
                   ])
                 : yield [put(showNotification('ra.notification.deleted'))];
-        case CRUD_GET_ONE_SUCCESS:
+        case crudGetOne.SUCCESS:
             if (
                 !('id' in payload.data) ||
                 payload.data.id != requestPayload.id
@@ -82,7 +86,7 @@ function* handleResponse({ type, requestPayload, error, payload }) {
                 );
             }
             break;
-        case CRUD_GET_ONE_FAILURE:
+        case crudGetOne.FAILURE:
             return requestPayload.basePath
                 ? yield all([
                       put(
@@ -94,12 +98,26 @@ function* handleResponse({ type, requestPayload, error, payload }) {
                       put(push(requestPayload.basePath)),
                   ])
                 : yield all([]);
-        case CRUD_GET_LIST_FAILURE:
-        case CRUD_GET_MANY_FAILURE:
-        case CRUD_GET_MANY_REFERENCE_FAILURE:
-        case CRUD_CREATE_FAILURE:
-        case CRUD_UPDATE_FAILURE:
-        case CRUD_DELETE_FAILURE: {
+        case crudCreate.FAILURE:
+        case crudUpdate.FAILURE:
+        case crudGetList.FAILURE:
+        case crudGetMany.FAILURE:
+        case crudGetManyReference.FAILURE:
+        case crudDelete.FAILURE: {
+            switch (type) {
+                case crudCreate.FAILURE:
+                    yield crudCreate.failure({
+                        request: requestPayload,
+                        error,
+                    });
+                    break;
+                case crudUpdate.FAILURE:
+                    yield crudUpdate.failure({
+                        request: requestPayload,
+                        error,
+                    });
+                    break;
+            }
             console.error(error); // eslint-disable-line no-console
             const errorMessage =
                 typeof error === 'string'

--- a/packages/react-admin/src/sideEffect/saga/index.js
+++ b/packages/react-admin/src/sideEffect/saga/index.js
@@ -3,3 +3,4 @@ export crudFetch from './crudFetch';
 export crudResponse from './crudResponse';
 export crudSaga from './crudSaga';
 export referenceFetch from './referenceFetch';
+export promiseAction from './promiseAction';

--- a/packages/react-admin/src/sideEffect/saga/promiseAction.js
+++ b/packages/react-admin/src/sideEffect/saga/promiseAction.js
@@ -15,13 +15,13 @@ function* handlePromiseSaga({ payload }) {
 
     if (winner.success) {
         yield call(resolve, {
-            data: winner.success.payload,
-            requestPayload: winner.success.requestPayload,
+            response: winner.success.payload,
+            request: winner.success.requestPayload,
         });
     } else {
         yield call(reject, {
             error: winner.fail.error,
-            requestPayload: winner.fail.requestPayload,
+            request: winner.fail.requestPayload,
         });
     }
 }

--- a/packages/react-admin/src/sideEffect/saga/promiseAction.js
+++ b/packages/react-admin/src/sideEffect/saga/promiseAction.js
@@ -1,0 +1,35 @@
+import { take, takeEvery, race, put, call, all } from 'redux-saga/effects';
+import { PROMISE } from '../../util/promisingActionCreator';
+function* handlePromiseSaga({ payload }) {
+    const { request, defer, types } = payload;
+    const { resolve, reject } = defer;
+    const [SUCCESS, FAIL] = types;
+
+    const [winner] = yield all([
+        race({
+            success: take(SUCCESS),
+            fail: take(FAIL),
+        }),
+        put(request),
+    ]);
+
+    if (winner.success) {
+        yield call(
+            resolve,
+            winner.success && winner.success.payload
+                ? winner.success.payload
+                : winner.success
+        );
+    } else {
+        yield call(
+            reject,
+            winner.fail && winner.fail.payload
+                ? winner.fail.payload
+                : winner.fail
+        );
+    }
+}
+
+export default function* formActionSaga() {
+    yield takeEvery(PROMISE, handlePromiseSaga);
+}

--- a/packages/react-admin/src/sideEffect/saga/promiseAction.js
+++ b/packages/react-admin/src/sideEffect/saga/promiseAction.js
@@ -14,19 +14,15 @@ function* handlePromiseSaga({ payload }) {
     ]);
 
     if (winner.success) {
-        yield call(
-            resolve,
-            winner.success && winner.success.payload
-                ? winner.success.payload
-                : winner.success
-        );
+        yield call(resolve, {
+            data: winner.success.payload,
+            requestPayload: winner.success.requestPayload,
+        });
     } else {
-        yield call(
-            reject,
-            winner.fail && winner.fail.payload
-                ? winner.fail.payload
-                : winner.fail
-        );
+        yield call(reject, {
+            error: winner.fail.error,
+            requestPayload: winner.fail.requestPayload,
+        });
     }
 }
 

--- a/packages/react-admin/src/sideEffect/saga/referenceFetch.js
+++ b/packages/react-admin/src/sideEffect/saga/referenceFetch.js
@@ -38,7 +38,7 @@ const tasks = {};
 function* finalize(resource, actionCreator) {
     // combined with cancel(), this debounces the calls
     yield call(delay, 50);
-    yield put(actionCreator(resource, getIds(resource)));
+    yield put(actionCreator({ resource, ids: getIds(resource) }));
     delete tasks[resource];
 }
 

--- a/packages/react-admin/src/util/promisingActionCreator.js
+++ b/packages/react-admin/src/util/promisingActionCreator.js
@@ -1,0 +1,60 @@
+export const PROMISE = 'RA/PROMISE_ACTION';
+
+const defaultAction = payload => ({ payload });
+const status = ['REQUEST', 'LOADING', 'SUCCESS', 'FAILURE'];
+
+function promisingActionCreator(
+    requestAction,
+    types,
+    actionCreator = defaultAction
+) {
+    const actionMethods = {};
+    const formAction = payload => ({
+        type: PROMISE,
+        payload,
+    });
+
+    // Allow a type prefix to be passed in
+    if (typeof requestAction === 'string') {
+        requestAction = status.map(s => {
+            let a = status[0] === s ? requestAction : `${requestAction}_${s}`;
+            let subAction = (...payload) => ({
+                type: a,
+                ...actionCreator(...payload),
+            });
+
+            // translate specific actionType to generic actionType
+            actionMethods[s] = a;
+            actionMethods[s.toLowerCase()] = subAction;
+
+            return subAction;
+        })[0];
+
+        if (types) {
+            actionCreator = types;
+        }
+
+        types = [actionMethods.SUCCESS, actionMethods.FAILURE];
+    }
+
+    if (types.length !== 2) {
+        throw new Error('Must include two action types: [ SUCCESS, FAILURE ]');
+    }
+
+    return Object.assign((data, dispatch) => {
+        // Behave like a normal actionCreator
+        if (!dispatch) return requestAction(data);
+
+        return new Promise((resolve, reject) => {
+            dispatch(
+                formAction({
+                    request: requestAction(data),
+                    defer: { resolve, reject },
+                    types,
+                })
+            );
+        });
+    }, actionMethods);
+}
+
+export { promisingActionCreator };


### PR DESCRIPTION
This PR allows direct communication from redux-saga to redux-form through promises. It uses a customized implementation of https://github.com/mhssmnn/redux-form-saga which is a smart solution to do this. 

What it basically does is to change the actionCreator to emit a promise instead of a pojo (plain old javascript object) which can be handed to handleSubmit of redux-form. The action creator implements methods `success` and `failure` which emit a pojo action object which is monitored by a saga and this saga resolves or rejects the promise. 

Because it implements static accessors for `SUCCESS`, `FAILURE` and `LOADING` the dataActions look a bit cleaner. 

I implemented this with a basic callback `onError` and `onSuccess` in `Create` and `Edit` (which actually don't make much sense now, because of the redirect). But it should give some insight in the power of the pattern used. This would easily allow implementation of multiple form identifiers in redux-form and server-side validation callback (simple transform .catch to redux's ValidationError). 

I had to change the signature of the action creators to accept an object instead of params (which looks cleaner imho as well), because the actionCreator can be called with or without dispatch (the latter simple emits a default pojo action). 

Not sure if you're interested in this for `ra-admin` , but I am going to use it in my project and thought to share. 