### PR TITLE
WithPermission: Component can unmount before setting state.

### DIFF
--- a/packages/react-admin/src/auth/WithPermissions.js
+++ b/packages/react-admin/src/auth/WithPermissions.js
@@ -95,10 +95,18 @@ export class WithPermissions extends Component {
                 location: location ? location.pathname : undefined,
             });
 
-            this.setState({ permissions });
+            if (!this.didUnmount) {
+                this.setState({ permissions });
+            }
         } catch (error) {
-            this.setState({ permissions: null });
+            if (!this.didUnmount) {
+                this.setState({ permissions: null });
+            }
         }
+    }
+
+    componentWillUnmount() {
+        this.didUnmount = true;
     }
 
     // render even though the AUTH_GET_PERMISSIONS


### PR DESCRIPTION
Minor issue with switching path before permissions are resolved.  This happens if an unauthorized user browses to a restricted path directly and is redirected to login. 