### PR TITLE
Reinitialize resources after logout

### DIFF
--- a/packages/react-admin/src/AdminRoutes.js
+++ b/packages/react-admin/src/AdminRoutes.js
@@ -23,7 +23,9 @@ export class AdminRoutes extends Component {
 
     componentDidUpdate(prevProps, prevState) {
         if (
+            this.props.resources &&
             this.props.resources.length === 0 &&
+            prevProps.resources &&
             prevProps.resources.length !== 0
         ) {
             this.getPermissions();

--- a/packages/react-admin/src/AdminRoutes.js
+++ b/packages/react-admin/src/AdminRoutes.js
@@ -23,6 +23,12 @@ export class AdminRoutes extends Component {
 
     componentDidUpdate(prevProps, prevState) {
         if (
+            this.props.resources.length === 0 &&
+            prevProps.resources.length !== 0
+        ) {
+            this.getPermissions();
+        }
+        if (
             prevState.permissions !== this.state.permissions &&
             this.state.permissions !== initialPermissions
         ) {


### PR DESCRIPTION
Resources are removed from the redux store after logout (which is fine if the user is redirected to `/login`), but if the user is redirected to another page the resources aren't reinitialized. This PR simply calls `getPermissions()` to  trigger this if needed. 