### PR TITLE
[RFR]: Show loading component while resources are being declared.

### DIFF
--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -25,6 +25,8 @@ module.exports = {
             delete: 'Delete %{name} #%{id}',
             dashboard: 'Dashboard',
             not_found: 'Not Found',
+            loading: 'Page loading',
+            loading_resources: 'Resources loading',
         },
         input: {
             file: {
@@ -46,6 +48,8 @@ module.exports = {
             about: 'About',
             not_found:
                 'Either you typed a wrong URL, or you followed a bad link.',
+            loading: 'The current page is loading, just a moment please',
+            loading_resources: 'Resources are loading, just a moment please',
         },
         navigation: {
             no_results: 'No results found',

--- a/packages/react-admin/src/AdminRoutes.js
+++ b/packages/react-admin/src/AdminRoutes.js
@@ -7,9 +7,12 @@ import getContext from 'recompose/getContext';
 
 import CrudRoute from './CrudRoute';
 import NotFound from './mui/layout/NotFound';
+import Loading from './mui/layout/Loading';
 import WithPermissions from './auth/WithPermissions';
 import { declareResources as declareResourcesAction } from './actions';
 import { AUTH_GET_PERMISSIONS } from './auth/types';
+
+import { getResources, hasDeclaredResources } from './index';
 
 const initialPermissions = '@@ar/initialPermissions';
 
@@ -70,6 +73,7 @@ export class AdminRoutes extends Component {
             resources = [],
             dashboard,
             catchAll,
+            areResourcesBeingDeclared,
             title,
         } = this.props;
 
@@ -86,6 +90,18 @@ export class AdminRoutes extends Component {
                             children={route.props.children} // eslint-disable-line react/no-children-prop
                         />
                     ))}
+                {areResourcesBeingDeclared && (
+                    <Route
+                        path="/"
+                        key="loading"
+                        render={() => (
+                            <Loading
+                                loadingPrimary="ra.page.loading_resources"
+                                loadingSecondary="ra.message.loading_resources"
+                            />
+                        )}
+                    />
+                )}
                 {resources.map(resource => (
                     <Route
                         path={`/${resource.name}`}
@@ -148,13 +164,13 @@ AdminRoutes.propTypes = {
     customRoutes: PropTypes.array,
     declareResources: PropTypes.func.isRequired,
     resources: PropTypes.array,
+    areResourcesBeingDeclared: PropTypes.bool,
     dashboard: componentPropType,
 };
 
 const mapStateToProps = state => ({
-    resources: Object.keys(state.admin.resources).map(
-        key => state.admin.resources[key].props
-    ),
+    resources: getResources(state),
+    areResourcesBeingDeclared: !hasDeclaredResources(state),
 });
 
 export default compose(

--- a/packages/react-admin/src/mui/layout/Loading.js
+++ b/packages/react-admin/src/mui/layout/Loading.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import compose from 'recompose/compose';
+import classnames from 'classnames';
+import { CircularProgress } from 'material-ui/Progress';
+import translate from '../../i18n/translate';
+
+const styles = theme => ({
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        [theme.breakpoints.up('md')]: {
+            height: '100%',
+        },
+        [theme.breakpoints.down('md')]: {
+            height: '100vh',
+            marginTop: '-3em',
+        },
+    },
+    icon: {
+        width: '9em',
+        height: '9em',
+    },
+    message: {
+        textAlign: 'center',
+        fontFamily: 'Roboto, sans-serif',
+        opacity: 0.5,
+        margin: '0 1em',
+    },
+});
+
+const Loading = ({
+    classes,
+    className,
+    translate,
+    loadingPrimary = 'ra.page.loading',
+    loadingSecondary = 'ra.message.loading',
+}) => (
+    <div className={classnames(classes.container, className)}>
+        <div className={classes.message}>
+            <CircularProgress className={classes.icon} />
+            <h1>{translate(loadingPrimary)}</h1>
+            <div>{translate(loadingSecondary)}.</div>
+        </div>
+    </div>
+);
+
+Loading.propTypes = {
+    classes: PropTypes.object,
+    className: PropTypes.string,
+    translate: PropTypes.func.isRequired,
+    loadingPrimary: PropTypes.string,
+    loadingSecondary: PropTypes.string,
+};
+
+const enhance = compose(withStyles(styles), translate);
+
+export default enhance(Loading);

--- a/packages/react-admin/src/reducer/admin/index.js
+++ b/packages/react-admin/src/reducer/admin/index.js
@@ -1,5 +1,8 @@
 import { combineReducers } from 'redux';
-import resources, { getResources as innerGetResources } from './resource';
+import resources, {
+    getResources as innerGetResources,
+    hasDeclaredResources as innerHasDeclaredResources,
+} from './resource';
 import loading from './loading';
 import notifications from './notifications';
 import record from './record';
@@ -17,4 +20,6 @@ export default combineReducers({
     ui,
 });
 
+export const hasDeclaredResources = state =>
+    innerHasDeclaredResources(state.resources);
 export const getResources = state => innerGetResources(state.resources);

--- a/packages/react-admin/src/reducer/admin/resource/index.js
+++ b/packages/react-admin/src/reducer/admin/resource/index.js
@@ -58,5 +58,6 @@ export default (
     return newState;
 };
 
+export const hasDeclaredResources = state => state !== initialState;
 export const getResources = state =>
     Object.keys(state).map(key => state[key].props);

--- a/packages/react-admin/src/reducer/index.js
+++ b/packages/react-admin/src/reducer/index.js
@@ -1,7 +1,10 @@
 import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { routerReducer } from 'react-router-redux';
-import admin, { getResources as getAdminResources } from './admin';
+import admin, {
+    getResources as getAdminResources,
+    hasDeclaredResources as hasAdminDeclaredResources,
+} from './admin';
 import localeReducer from './locale';
 
 export default (customReducers, locale) =>
@@ -14,3 +17,5 @@ export default (customReducers, locale) =>
     });
 
 export const getResources = state => getAdminResources(state.admin);
+export const hasDeclaredResources = state =>
+    hasAdminDeclaredResources(state.admin);


### PR DESCRIPTION
When resources are being loaded async, the `NotFound` component is shown while they are not declared. This behaviour can be shown by: 
```
    <Admin
        authClient={authClient}
        dataProvider={delayedDataProvider}
        title="Example Admin"
        locale="en"
        messages={messages}
    >
        {permissions =>
            new Promise(resolve => {
                setTimeout(
                    () =>
                        resolve([
                            <Resource
                                name="posts"
                                list={PostList}
                                create={PostCreate}
                                edit={PostEdit}
                                show={PostShow}
                                remove={Delete}
                                icon={PostIcon}
                            />,
                        ]),
                    1000
                );
            })}
    </Admin>,
```
This is the current behaviour: 
![2017-12-16_11-05-20](https://user-images.githubusercontent.com/621098/34069445-bfc2fe52-e251-11e7-96e9-859bdb10b8dc.gif)
After applying this PR: 
![2017-12-16_11-05-49](https://user-images.githubusercontent.com/621098/34069452-dcd6eefe-e251-11e7-9460-538604330a8e.gif)
