### PR TITLE
[Fix]: User logout & setState moved away from componentWillUpdate

### DIFF
--- a/packages/react-admin/src/AdminRoutes.js
+++ b/packages/react-admin/src/AdminRoutes.js
@@ -12,7 +12,6 @@ import { AUTH_GET_PERMISSIONS } from './auth/types';
 import { isLoggedIn } from './reducer';
 
 export class AdminRoutes extends Component {
-    // Can't use null or undefined here as authClient may return any those values
     state = { childrenToRender: [] };
 
     componentWillMount() {

--- a/packages/react-admin/src/AdminRoutes.js
+++ b/packages/react-admin/src/AdminRoutes.js
@@ -11,47 +11,28 @@ import WithPermissions from './auth/WithPermissions';
 import { AUTH_GET_PERMISSIONS } from './auth/types';
 import { isLoggedIn } from './reducer';
 
-const initialPermissions = '@@ar/initialPermissions';
-
 export class AdminRoutes extends Component {
     // Can't use null or undefined here as authClient may return any those values
-    state = { childrenToRender: [], permissions: initialPermissions };
+    state = { childrenToRender: [] };
 
     componentWillMount() {
-        if (typeof this.props.children === 'function') {
-            this.getPermissions();
-        } else {
-            this.setState({ childrenToRender: this.props.children });
-        }
+        this.initializeResources(this.props);
     }
 
-    getPermissions = async () => {
-        const { authClient } = this.props;
-        try {
-            const permissions = await authClient(AUTH_GET_PERMISSIONS);
-            this.setState({ permissions });
-        } catch (error) {
-            this.setState({ permissions: initialPermissions });
+    initializeResources = nextProps => {
+        if (typeof nextProps.children === 'function') {
+            this.initializeResourcesAsync(nextProps);
+        } else {
+            this.setState({ childrenToRender: nextProps.children });
         }
     };
-
-    componentWillUpdate(nextProps, nextState) {
-        if (
-            !nextProps.isLoggedIn &&
-            nextProps.isLoggedIn !== this.props.isLoggedIn
-        ) {
-            this.setState({ permissions: initialPermissions }, () =>
-                this.getPermissions()
-            );
-        }
-
-        if (
-            typeof nextProps.children === 'function' &&
-            nextState.permissions !== this.state.permissions
-        ) {
+    initializeResourcesAsync = async nextProps => {
+        const { authClient } = nextProps;
+        try {
+            const permissions = await authClient(AUTH_GET_PERMISSIONS);
             const { children } = nextProps;
 
-            const childrenFuncResult = children(nextState.permissions);
+            const childrenFuncResult = children(permissions);
             if (childrenFuncResult.then) {
                 childrenFuncResult.then(resolvedChildren => {
                     this.setState({
@@ -60,12 +41,23 @@ export class AdminRoutes extends Component {
                         ),
                     });
                 });
-                return;
+            } else {
+                this.setState({
+                    childrenToRender: childrenFuncResult.filter(child => child),
+                });
             }
-
-            return this.setState({
-                childrenToRender: childrenFuncResult.filter(child => child),
-            });
+        } catch (error) {
+            this.setState({ childrenToRender: [] });
+        }
+    };
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.isLoggedIn !== this.props.isLoggedIn) {
+            this.setState(
+                {
+                    childrenToRender: [],
+                },
+                () => this.initializeResources(nextProps)
+            );
         }
     }
 


### PR DESCRIPTION
Resources aren't reloaded after logout (@see https://github.com/marmelab/admin-on-rest/pull/1306), because of `isLoggedIn` not being checked correctly. This PR fixes that.

Then I saw that `setState` is called in `componentWillUpdate`; The react docs say not to call `setState` within `componentWillUpdate`: https://reactjs.org/docs/react-component.html#componentwillupdate. 
This PR fixes that as well. 