### PR TITLE
[Fix]: Set notification message to empty if no notification

### DIFF
--- a/packages/react-admin/src/mui/layout/Notification.js
+++ b/packages/react-admin/src/mui/layout/Notification.js
@@ -60,9 +60,13 @@ class Notification extends React.Component {
             <Snackbar
                 open={this.state.open}
                 message={
-                    notification &&
-                    notification.message &&
-                    translate(notification.message, notification.messageArgs)
+                    (notification &&
+                        notification.message &&
+                        translate(
+                            notification.message,
+                            notification.messageArgs
+                        )) ||
+                    ''
                 }
                 autoHideDuration={
                     (notification && notification.autoHideDuration) ||


### PR DESCRIPTION
If `hideNotification` is called from a sideEffect the notification can become undefined. Message is a required prop, so simply display empty message. 