### PR TITLE
Allow disabled option on Create / Save / Edit / Delete buttons

### DIFF
--- a/src/mui/button/CreateButton.js
+++ b/src/mui/button/CreateButton.js
@@ -23,16 +23,20 @@ const styles = {
     },
 };
 
-const CreateButton = ({
+export const CreateButton = ({
     basePath = '',
     translate,
     label = 'aor.action.create',
     width,
+    disabled,
 }) =>
     width === 1 ? (
         <FloatingActionButton
             style={styles.floating}
-            containerElement={<Link to={`${basePath}/create`} />}
+            containerElement={
+                disabled ? 'div' : <Link to={`${basePath}/create`} />
+            }
+            disabled={disabled}
         >
             <ContentAdd />
         </FloatingActionButton>
@@ -41,8 +45,11 @@ const CreateButton = ({
             primary
             label={label && translate(label)}
             icon={<ContentAdd />}
-            containerElement={<Link to={`${basePath}/create`} />}
+            containerElement={
+                disabled ? 'div' : <Link to={`${basePath}/create`} />
+            }
             style={styles.flat}
+            disabled={disabled}
         />
     );
 
@@ -51,6 +58,7 @@ CreateButton.propTypes = {
     label: PropTypes.string,
     translate: PropTypes.func.isRequired,
     width: PropTypes.number,
+    disabled: PropTypes.bool,
 };
 
 const enhance = compose(

--- a/src/mui/button/CreateButton.spec.js
+++ b/src/mui/button/CreateButton.spec.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { CreateButton } from './CreateButton';
+import { Link } from 'react-router-dom';
+
+const translate = label => label;
+
+describe('<CreateButton />', () => {
+    it('should render <FlatButton />', () => {
+        const wrapper = shallow(<CreateButton translate={translate} />);
+
+        assert.equal(wrapper.type().muiName, 'FlatButton');
+    });
+
+    it('should be displayed as a <Link />', () => {
+        const wrapper = shallow(<CreateButton translate={translate} />);
+
+        assert.equal(wrapper.prop('containerElement').type, Link);
+    });
+
+    it('should not be displayed as a <Link /> when disable', () => {
+        const wrapper = shallow(
+            <CreateButton translate={translate} disabled />
+        );
+
+        assert.equal(wrapper.prop('containerElement').type, null);
+        assert.equal(wrapper.prop('disabled'), true);
+    });
+});

--- a/src/mui/button/DeleteButton.js
+++ b/src/mui/button/DeleteButton.js
@@ -6,20 +6,26 @@ import ActionDelete from 'material-ui/svg-icons/action/delete';
 import linkToRecord from '../../util/linkToRecord';
 import translate from '../../i18n/translate';
 
-const DeleteButton = ({
+export const DeleteButton = ({
     basePath = '',
     label = 'aor.action.delete',
     record = {},
     translate,
+    disabled,
 }) => (
     <FlatButton
         secondary
         label={label && translate(label)}
         icon={<ActionDelete />}
         containerElement={
-            <Link to={`${linkToRecord(basePath, record.id)}/delete`} />
+            disabled ? (
+                'div'
+            ) : (
+                <Link to={`${linkToRecord(basePath, record.id)}/delete`} />
+            )
         }
         style={{ overflow: 'inherit' }}
+        disabled={disabled}
     />
 );
 
@@ -28,6 +34,7 @@ DeleteButton.propTypes = {
     label: PropTypes.string,
     record: PropTypes.object,
     translate: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
 };
 
 export default translate(DeleteButton);

--- a/src/mui/button/DeleteButton.spec.js
+++ b/src/mui/button/DeleteButton.spec.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { DeleteButton } from './DeleteButton';
+import { Link } from 'react-router-dom';
+
+const translate = label => label;
+
+describe('<DeleteButton />', () => {
+    it('should render <FlatButton />', () => {
+        const wrapper = shallow(<DeleteButton translate={translate} />);
+
+        assert.equal(wrapper.type().muiName, 'FlatButton');
+    });
+
+    it('should be displayed as a <Link />', () => {
+        const wrapper = shallow(<DeleteButton translate={translate} />);
+
+        assert.equal(wrapper.prop('containerElement').type, Link);
+    });
+
+    it('should not be displayed as a <Link /> when disable', () => {
+        const wrapper = shallow(
+            <DeleteButton translate={translate} disabled />
+        );
+
+        assert.equal(wrapper.prop('containerElement').type, null);
+        assert.equal(wrapper.prop('disabled'), true);
+    });
+});

--- a/src/mui/button/EditButton.js
+++ b/src/mui/button/EditButton.js
@@ -8,18 +8,22 @@ import ContentCreate from 'material-ui/svg-icons/content/create';
 import linkToRecord from '../../util/linkToRecord';
 import translate from '../../i18n/translate';
 
-const EditButton = ({
+export const EditButton = ({
     basePath = '',
     label = 'aor.action.edit',
     record = {},
     translate,
+    disabled,
 }) => (
     <FlatButton
         primary
         label={label && translate(label)}
         icon={<ContentCreate />}
-        containerElement={<Link to={linkToRecord(basePath, record.id)} />}
+        containerElement={
+            disabled ? 'div' : <Link to={linkToRecord(basePath, record.id)} />
+        }
         style={{ overflow: 'inherit' }}
+        disabled={disabled}
     />
 );
 
@@ -28,6 +32,7 @@ EditButton.propTypes = {
     label: PropTypes.string,
     record: PropTypes.object,
     translate: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
 };
 
 const enhance = compose(

--- a/src/mui/button/EditButton.spec.js
+++ b/src/mui/button/EditButton.spec.js
@@ -1,0 +1,29 @@
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { EditButton } from './EditButton';
+import { Link } from 'react-router-dom';
+
+const translate = label => label;
+
+describe('<EditButton />', () => {
+    it('should render <FlatButton />', () => {
+        const wrapper = shallow(<EditButton translate={translate} />);
+
+        assert.equal(wrapper.type().muiName, 'FlatButton');
+    });
+
+    it('should be displayed as a <Link />', () => {
+        const wrapper = shallow(<EditButton translate={translate} />);
+
+        assert.equal(wrapper.prop('containerElement').type, Link);
+    });
+
+    it('should not be displayed as a <Link /> when disable', () => {
+        const wrapper = shallow(<EditButton translate={translate} disabled />);
+
+        assert.equal(wrapper.prop('containerElement').type, null);
+        assert.equal(wrapper.prop('disabled'), true);
+    });
+});

--- a/src/mui/button/SaveButton.js
+++ b/src/mui/button/SaveButton.js
@@ -9,8 +9,8 @@ import translate from '../../i18n/translate';
 
 export class SaveButton extends Component {
     handleClick = e => {
-        if (this.props.saving) {
-            // prevent double submission
+        if (this.props.saving || this.props.disabled) {
+            // prevent double submission and deal with disabled button
             e.preventDefault();
         } else {
             // always submit form explicitly regardless of button type
@@ -30,11 +30,13 @@ export class SaveButton extends Component {
             translate,
             submitOnEnter,
             redirect,
+            disabled,
         } = this.props;
         const type = submitOnEnter ? 'submit' : 'button';
         const ButtonComponent = raised ? RaisedButton : FlatButton;
         return (
             <ButtonComponent
+                disabled={disabled}
                 type={type}
                 label={label && translate(label, { _: label })}
                 icon={
@@ -63,10 +65,12 @@ SaveButton.propTypes = {
     submitOnEnter: PropTypes.bool,
     handleSubmitWithRedirect: PropTypes.func,
     redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    disabled: PropTypes.bool,
 };
 
 SaveButton.defaultProps = {
     handleSubmitWithRedirect: () => () => {},
+    disabled: false,
 };
 
 const mapStateToProps = state => ({

--- a/src/mui/button/SaveButton.spec.js
+++ b/src/mui/button/SaveButton.spec.js
@@ -117,4 +117,33 @@ describe('<SaveButton />', () => {
 
         assert(onSubmit.notCalled);
     });
+
+    it('should not trigger submit action when disabled', () => {
+        const onSubmit = sinon.spy();
+        const event = { preventDefault: sinon.spy() };
+
+        const raisedButtonWrapper = shallow(
+            <SaveButton
+                raised={true}
+                translate={translate}
+                handleSubmitWithRedirect={() => onSubmit}
+                disabled={true}
+            />
+        );
+        const flatButtonWrapper = shallow(
+            <SaveButton
+                raised={false}
+                translate={translate}
+                handleSubmitWithRedirect={() => onSubmit}
+                disabled={true}
+            />
+        );
+
+        raisedButtonWrapper.simulate('click', event);
+        assert(event.preventDefault.calledOnce);
+        flatButtonWrapper.simulate('click', event);
+        assert(event.preventDefault.calledTwice);
+
+        assert(onSubmit.notCalled);
+    });
 });


### PR DESCRIPTION
Hey,

I have this case where I allow user to see the Edit view based on READ permission and then disable Save button if he doesn't have EDIT permission. But unfortunately, the Save button can't be disabled, I have to create the whole RaisedButton when user doesn't have permission:

```
const CustomToolbar = ({ permissions, ...props }) => (
  <Toolbar {...props}>
    {canEdit(permissions, true) ? (
      <SaveButton redirect="list" submitOnEnter />
    ) : (
      <RaisedButton
        type="button"
        label="Save"
        icon={<ContentSave />}
        primary={true}
        disabled={true}
        style={{ margin: "10px 24px", position: "relative" }}
      />
    )}
  </Toolbar>
);

export const MyObjectEdit = props => (
  <Edit {...props}>
    {permissions => (
      <SimpleForm toolbar={<CustomToolbar permissions={permissions} />}>
         // ...
      </SimpleForm>
    )}
  </Edit>
);
```

I wanted something easier:

```
const CustomToolbar = ({ permissions, ...props }) => (
  <Toolbar {...props}>
      <SaveButton redirect="list" submitOnEnter disabled={canEdit(permissions, true)} />
  </Toolbar>
);
```