### PR TITLE
update CommentList example in docs

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -468,7 +468,7 @@ const cardStyle = {
     display: 'inline-block',
     verticalAlign: 'top'
 };
-const CommentGrid = ({ ids, data, basePath }) => (
+const CommentGrid = ({ ids=[], data={}, basePath }) => (
     <div style={{ margin: '1em' }}>
     {ids.map(id =>
         <Card key={id} style={cardStyle}>
@@ -493,10 +493,6 @@ const CommentGrid = ({ ids, data, basePath }) => (
     )}
     </div>
 );
-CommentGrid.defaultProps = {
-    data: {},
-    ids: [],
-};
 
 export const CommentList = (props) => (
     <List title="All comments" {...props}>


### PR DESCRIPTION
Deleted the assignment of the reference type in defaultProps.
It is a bad practice to use the reference types in defaultProps.