### PR TITLE
[RFR]: Add context to AUTH_CHECK in authClient

### DIFF
--- a/packages/react-admin/src/AdminRoutes.spec.js
+++ b/packages/react-admin/src/AdminRoutes.spec.js
@@ -12,7 +12,9 @@ describe('<AdminRoutes>', () => {
     const Dashboard = () => <div>Dashboard</div>;
     const Custom = () => <div>Custom</div>;
     // the Provider is required because the dashboard is wrapped by <Authenticated>, which is a connected component
-    const store = createStore(x => x);
+    const store = createStore(() => ({
+        admin: { auth: { isLoggedIn: true } },
+    }));
 
     it('should show dashboard on / when provided', () => {
         const wrapper = render(

--- a/packages/react-admin/src/Resource.js
+++ b/packages/react-admin/src/Resource.js
@@ -61,6 +61,7 @@ export class Resource extends Component {
             show,
             remove,
             options,
+            authParams,
         } = this.props;
 
         if (context === 'registration') {
@@ -88,6 +89,11 @@ export class Resource extends Component {
                                 render={props => createElement(create, props)}
                                 {...routeProps}
                                 {...resource}
+                                authParams={{
+                                    resource: name,
+                                    type: 'create',
+                                    ...authParams,
+                                }}
                             />
                         )}
                     />
@@ -101,6 +107,11 @@ export class Resource extends Component {
                                 render={props => createElement(show, props)}
                                 {...routeProps}
                                 {...resource}
+                                authParams={{
+                                    resource: name,
+                                    type: 'show',
+                                    ...authParams,
+                                }}
                             />
                         )}
                     />
@@ -114,6 +125,11 @@ export class Resource extends Component {
                                 render={props => createElement(remove, props)}
                                 {...routeProps}
                                 {...resource}
+                                authParams={{
+                                    resource: name,
+                                    type: 'delete',
+                                    ...authParams,
+                                }}
                             />
                         )}
                     />
@@ -127,6 +143,11 @@ export class Resource extends Component {
                                 render={props => createElement(edit, props)}
                                 {...routeProps}
                                 {...resource}
+                                authParams={{
+                                    resource: name,
+                                    type: 'edit',
+                                    ...authParams,
+                                }}
                             />
                         )}
                     />
@@ -140,6 +161,11 @@ export class Resource extends Component {
                                 render={props => createElement(list, props)}
                                 {...routeProps}
                                 {...resource}
+                                authParams={{
+                                    resource: name,
+                                    type: 'list',
+                                    ...authParams,
+                                }}
                             />
                         )}
                     />

--- a/packages/react-admin/src/actions/authActions.js
+++ b/packages/react-admin/src/actions/authActions.js
@@ -16,6 +16,7 @@ export const userCheck = (payload, pathName, routeParams) => ({
     type: USER_CHECK,
     payload: {
         ...payload,
+        location: pathName,
         routeParams,
     },
     meta: { auth: true, pathName },

--- a/packages/react-admin/src/auth/WithPermissions.js
+++ b/packages/react-admin/src/auth/WithPermissions.js
@@ -7,6 +7,7 @@ import warning from 'warning';
 
 import { userCheck } from '../actions/authActions';
 import { AUTH_GET_PERMISSIONS } from '../auth/types';
+import { isLoggedIn } from '../reducer';
 
 const isEmptyChildren = children => Children.count(children) === 0;
 /**
@@ -51,6 +52,7 @@ export class WithPermissions extends Component {
         location: PropTypes.object,
         match: PropTypes.object,
         render: PropTypes.func,
+        isLoggedIn: PropTypes.bool,
         staticContext: PropTypes.object,
         userCheck: PropTypes.func,
     };
@@ -76,7 +78,8 @@ export class WithPermissions extends Component {
     componentWillReceiveProps(nextProps) {
         if (
             nextProps.location !== this.props.location ||
-            nextProps.authParams !== this.props.authParams
+            nextProps.authParams !== this.props.authParams ||
+            nextProps.isLoggedIn !== this.props.isLoggedIn
         ) {
             this.checkAuthentication(nextProps);
             this.checkPermissions(this.props);
@@ -84,8 +87,12 @@ export class WithPermissions extends Component {
     }
 
     checkAuthentication(params) {
-        const { userCheck, authParams, location } = params;
-        userCheck(authParams, location && location.pathname);
+        const { userCheck, authParams, location, match } = params;
+        userCheck(
+            authParams,
+            location && location.pathname,
+            match && match.params
+        );
     }
 
     async checkPermissions(params) {
@@ -125,10 +132,13 @@ export class WithPermissions extends Component {
         }
     }
 }
+const mapStateToProps = state => ({
+    isLoggedIn: isLoggedIn(state),
+});
 
 export default compose(
     getContext({
         authClient: PropTypes.func,
     }),
-    connect(null, { userCheck })
+    connect(mapStateToProps, { userCheck })
 )(WithPermissions);

--- a/packages/react-admin/src/auth/WithPermissions.js
+++ b/packages/react-admin/src/auth/WithPermissions.js
@@ -116,6 +116,8 @@ export class WithPermissions extends Component {
         const {
             authClient,
             userCheck,
+            authParams,
+            isLoggedIn,
             render,
             children,
             staticContext,


### PR DESCRIPTION
When evaluating AUTH_CHECK in the `authClient` additional information is required. This PR supplies `resource`, `type`, `location` and routeParams to the authParams and allows additional `authParams` to be supplied on the `Resource` component. 

It also adds a `isLoggedIn` check on `WithPermissions`, because it should reevaluate when the `isLoggedIn` state changes. 