### PR TITLE
[RFR]: Only redirect if error status indicates it's required

### DIFF
--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -71,6 +71,7 @@ module.exports = {
             deleted: 'Element deleted',
             bad_item: 'Incorrect element',
             item_doesnt_exist: 'Element does not exist',
+            item_forbidden: "You're not authorized for this item",
             http_error: 'Server communication error',
         },
         validation: {

--- a/packages/react-admin/src/actions/authActions.js
+++ b/packages/react-admin/src/actions/authActions.js
@@ -1,4 +1,5 @@
 export const USER_CHECK_SUCCESS = 'RA/USER_CHECK_SUCCESS';
+export const USER_CHECK_FAILURE = 'RA/USER_CHECK_FAILURE';
 export const USER_LOGIN = 'RA/USER_LOGIN';
 export const USER_LOGIN_LOADING = 'RA/USER_LOGIN_LOADING';
 export const USER_LOGIN_FAILURE = 'RA/USER_LOGIN_FAILURE';
@@ -19,6 +20,12 @@ export const userCheck = (payload, pathName, routeParams) => ({
         routeParams,
     },
     meta: { auth: true, pathName },
+});
+
+export const userCheckFailed = payload => ({
+    type: USER_CHECK_FAILURE,
+    payload,
+    meta: { auth: true },
 });
 
 export const USER_LOGOUT = 'RA/USER_LOGOUT';

--- a/packages/react-admin/src/sideEffect/saga/auth.js
+++ b/packages/react-admin/src/sideEffect/saga/auth.js
@@ -12,6 +12,7 @@ import {
     USER_LOGIN_FAILURE,
     USER_CHECK,
     USER_LOGOUT,
+    userCheckFailed,
 } from '../../actions/authActions';
 import { FETCH_ERROR } from '../../actions/fetchActions';
 import { AUTH_LOGIN, AUTH_CHECK, AUTH_ERROR, AUTH_LOGOUT } from '../../auth';
@@ -54,6 +55,7 @@ export default authClient => {
                 try {
                     yield call(authClient, AUTH_CHECK, payload);
                 } catch (error) {
+                    yield put(userCheckFailed(payload));
                     yield call(authClient, AUTH_LOGOUT);
                     yield put(
                         replace({

--- a/packages/react-admin/src/sideEffect/saga/crudFetch.js
+++ b/packages/react-admin/src/sideEffect/saga/crudFetch.js
@@ -14,7 +14,7 @@ import {
     FETCH_ERROR,
     FETCH_CANCEL,
 } from '../../actions/fetchActions';
-import { USER_LOGOUT } from '../../actions/authActions';
+import { USER_CHECK_FAILURE } from '../../actions/authActions';
 
 const crudFetch = dataProvider => {
     function* handleFetch(action) {
@@ -87,7 +87,7 @@ const crudFetch = dataProvider => {
                 ),
             ]);
 
-            yield take(USER_LOGOUT);
+            yield take(USER_CHECK_FAILURE);
             yield all([cancel(taskLatest, taskEvery)]);
         }
     };

--- a/packages/react-admin/src/sideEffect/saga/crudFetch.js
+++ b/packages/react-admin/src/sideEffect/saga/crudFetch.js
@@ -50,8 +50,7 @@ const crudFetch = dataProvider => {
         } catch (error) {
             yield put({
                 type: `${type}_FAILURE`,
-                error: error.message ? error.message : error,
-                payload: error.body ? error.body : null,
+                error,
                 requestPayload: payload,
                 meta: {
                     ...meta,

--- a/packages/react-admin/src/sideEffect/saga/crudResponse.js
+++ b/packages/react-admin/src/sideEffect/saga/crudResponse.js
@@ -83,23 +83,36 @@ function* handleResponse({ type, requestPayload, error, payload }) {
             }
             break;
         case CRUD_GET_ONE_FAILURE:
-            return requestPayload.basePath
-                ? yield all([
-                      put(
-                          showNotification(
-                              'ra.notification.item_doesnt_exist',
-                              'warning'
-                          )
-                      ),
-                      put(push(requestPayload.basePath)),
-                  ])
-                : yield all([]);
         case CRUD_GET_LIST_FAILURE:
         case CRUD_GET_MANY_FAILURE:
         case CRUD_GET_MANY_REFERENCE_FAILURE:
         case CRUD_CREATE_FAILURE:
         case CRUD_UPDATE_FAILURE:
         case CRUD_DELETE_FAILURE: {
+            if (
+                CRUD_GET_ONE_FAILURE === type &&
+                error &&
+                (404 === error.status || 403 === error.status)
+            ) {
+                if (404 === error.status) {
+                    yield put(
+                        showNotification(
+                            'ra.notification.item_doesnt_exist',
+                            'warning'
+                        )
+                    );
+                } else if (403 === error.status) {
+                    yield put(
+                        showNotification(
+                            'ra.notification.item_forbidden',
+                            'warning'
+                        )
+                    );
+                }
+                return requestPayload.basePath
+                    ? yield put(push(requestPayload.basePath))
+                    : yield all([]);
+            }
             console.error(error); // eslint-disable-line no-console
             const errorMessage =
                 typeof error === 'string'


### PR DESCRIPTION
Changed how `CRUD_GET_ONE_FAILURE` is handled. Consider that the fetch to `users/1` fails with a 401.  This will trigger a `USER_LOGOUT`, but `CRUD_GET_ONE_FAILURE` will also be handled. The latter moves the user to `/users`, so effectively the following behaviour is happening: 
`users/1` -> `/login` -> `/users` -> `/login`. This is not desired, so I changed CRUD_GET_ONE_FAILURE only to redirect to basepath if status 404 (not found) or 403 (forbidden) is returned and show a notification accordingly. 