### PR TITLE
Check that window exists before checking for devToolsExtension

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -52,7 +52,9 @@ const Admin = ({
         initialState,
         compose(
             applyMiddleware(sagaMiddleware, routerMiddleware(routerHistory)),
-            window.devToolsExtension ? window.devToolsExtension() : f => f
+            typeof window !== 'undefined' && window.devToolsExtension
+                ? window.devToolsExtension()
+                : f => f
         )
     );
     sagaMiddleware.run(saga);


### PR DESCRIPTION
Using a-o-r as part of a gatsbyjs app, this change makes it possible to build.