### PR TITLE
[RFR] Remove outdated path

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -540,7 +540,7 @@ If you were using `SwitchPermissions` before, here's how to migrate to `WithPerm
 import React from 'react';
 import BenefitsSummary from './BenefitsSummary';
 import BenefitsDetailsWithSensitiveData from './BenefitsDetailsWithSensitiveData';
-import { ViewTitle, SwitchPermissions, Permission } from 'admin-on-rest/lib/mui';
+import { ViewTitle, SwitchPermissions, Permission } from 'admin-on-rest';
 
 export default () => (
     <div>
@@ -559,7 +559,7 @@ export default () => (
 import React from 'react';
 import BenefitsSummary from './BenefitsSummary';
 import BenefitsDetailsWithSensitiveData from './BenefitsDetailsWithSensitiveData';
-import { ViewTitle, WithPermissions } from 'react-admin/lib/mui';
+import { ViewTitle, WithPermissions } from 'react-admin';
 
 export default () => (
     <div>
@@ -770,7 +770,7 @@ Moreover, you won't need the now deprecated `<WithPermission>` or `<SwitchPermis
 import React from 'react';
 import BenefitsSummary from './BenefitsSummary';
 import BenefitsDetailsWithSensitiveData from './BenefitsDetailsWithSensitiveData';
-import { ViewTitle SwitchPermissions, Permission } from 'admin-on-rest/lib/mui';
+import { ViewTitle SwitchPermissions, Permission } from 'admin-on-rest';
 
 export default () => (
     <Card>
@@ -792,7 +792,7 @@ export default () => (
 import React from 'react';
 import BenefitsSummary from './BenefitsSummary';
 import BenefitsDetailsWithSensitiveData from './BenefitsDetailsWithSensitiveData';
-import { ViewTitle } from 'react-admin/lib/mui';
+import { ViewTitle } from 'react-admin';
 
 export default ({ permissions }) => (
     <Card>

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -121,7 +121,7 @@ You can customize this page to use the component of your choice by passing it as
 // in src/NotFound.js
 import React from 'react';
 import Card, { CardContent } from 'material-ui/Card';
-import { ViewTitle } from 'react-admin/lib/mui';
+import { ViewTitle } from 'react-admin';
 
 export default () => (
     <Card>

--- a/packages/ra-dependent-input/src/DependentField.js
+++ b/packages/ra-dependent-input/src/DependentField.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import get from 'lodash.get';
 import set from 'lodash.set';
-import FormField from 'react-admin/lib/mui/form/FormField';
+import { FormField } from 'react-admin';
 import getValue from './getValue';
 
 export const DependentFieldComponent = ({

--- a/packages/ra-dependent-input/src/DependentInput.js
+++ b/packages/ra-dependent-input/src/DependentInput.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { formValueSelector, getFormValues } from 'redux-form';
 import get from 'lodash.get';
-import FormField from 'react-admin/lib/mui/form/FormField';
+import { FormField } from 'react-admin';
 import getValue from './getValue';
 
 const REDUX_FORM_NAME = 'record-form';


### PR DESCRIPTION
imports no longer use the `lib/mui` path.