### PR TITLE
[RFR]: Reevaluate permissions on user logout.

### DIFF
--- a/packages/react-admin/src/AdminRoutes.spec.js
+++ b/packages/react-admin/src/AdminRoutes.spec.js
@@ -12,7 +12,9 @@ describe('<AdminRoutes>', () => {
     const Dashboard = () => <div>Dashboard</div>;
     const Custom = () => <div>Custom</div>;
     // the Provider is required because the dashboard is wrapped by <Authenticated>, which is a connected component
-    const store = createStore(x => x);
+    const store = createStore(() => ({
+        admin: { auth: { isLoggedIn: true } },
+    }));
 
     it('should show dashboard on / when provided', () => {
         const wrapper = render(

--- a/packages/react-admin/src/auth/WithPermissions.js
+++ b/packages/react-admin/src/auth/WithPermissions.js
@@ -7,6 +7,7 @@ import warning from 'warning';
 
 import { userCheck } from '../actions/authActions';
 import { AUTH_GET_PERMISSIONS } from '../auth/types';
+import { isLoggedIn } from '../reducer';
 
 const isEmptyChildren = children => Children.count(children) === 0;
 /**
@@ -51,6 +52,7 @@ export class WithPermissions extends Component {
         location: PropTypes.object,
         match: PropTypes.object,
         render: PropTypes.func,
+        isLoggedIn: PropTypes.bool,
         staticContext: PropTypes.object,
         userCheck: PropTypes.func,
     };
@@ -76,7 +78,8 @@ export class WithPermissions extends Component {
     componentWillReceiveProps(nextProps) {
         if (
             nextProps.location !== this.props.location ||
-            nextProps.authParams !== this.props.authParams
+            nextProps.authParams !== this.props.authParams ||
+            nextProps.isLoggedIn !== this.props.isLoggedIn
         ) {
             this.checkAuthentication(nextProps);
             this.checkPermissions(this.props);
@@ -109,6 +112,7 @@ export class WithPermissions extends Component {
         const {
             authClient,
             userCheck,
+            isLoggedIn,
             render,
             children,
             staticContext,
@@ -125,10 +129,13 @@ export class WithPermissions extends Component {
         }
     }
 }
+const mapStateToProps = state => ({
+    isLoggedIn: isLoggedIn(state),
+});
 
 export default compose(
     getContext({
         authClient: PropTypes.func,
     }),
-    connect(null, { userCheck })
+    connect(mapStateToProps, { userCheck })
 )(WithPermissions);


### PR DESCRIPTION
When an user logs out, the permissions of `WithPermissions` should be reevaluated. 