### PR TITLE
AutocompleteInput does not render text for existing value on initial render

### DIFF
--- a/src/mui/input/AutocompleteInput.js
+++ b/src/mui/input/AutocompleteInput.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash.get';
+import isEqual from 'lodash.isequal';
 import AutoComplete from 'material-ui/AutoComplete';
 
 import FieldTitle from '../../util/FieldTitle';
@@ -80,7 +81,10 @@ export class AutocompleteInput extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (this.props.input.value !== nextProps.input.value) {
+        if (
+            this.props.input.value !== nextProps.input.value ||
+            !isEqual(this.props.choices, nextProps.choices)
+        ) {
             this.setSearchText(nextProps);
         }
     }


### PR DESCRIPTION
The `AutocompleteInput` when used in conjunction with `ReferenceInput` does not populate for existing values when initially rendered if the `allowEmpty` property is true for `ReferenceInput`. However, if you force a re-render (for example by navigating away and back) the field will be populated as expected.

I think the bug was introduced in this commit: 0432a56c6edf9ec7930ac6226116465383a0cb17

**Steps to reproduce:**
You can reproduce the bug in this application: https://codesandbox.io/s/m46njp1r6p
When you first view the "Edit" action for any "Comment" resource, you should notice that the "Post" field does not get populated. If you remove the `allowEmpty` property though, it will be populated.

**Environment**

* Admin-on-rest version: 1.3.2
* Last version that did not exhibit the issue: 1.3.1
* React version: 15.5.4
* Browser: Any