### PR TITLE
Prop name is validate not validation

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -156,7 +156,7 @@ The `<SimpleForm>` renders its child components line by line (within `<div>` com
 Here are all the props accepted by the `<SimpleForm>` component:
 
 * [`defautValue`](#default-values)
-* [`validation`](#validation)
+* [`validate`](#validation)
 * [`submitOnEnter`](#submit-on-enter)
 * [`redirect`](#redirection-after-submission)
 * [`toolbar`](#toolbar)
@@ -185,7 +185,7 @@ to change this behaviour you can pass `false` for the `submitOnEnter` property.
 Here are all the props accepted by the `<TabbedForm>` component:
 
 * [`defautValue`](#default-values)
-* [`validation`](#validation)
+* [`validate`](#validation)
 * [`submitOnEnter`](#submit-on-enter)
 * [`redirect`](#redirection-after-submission)
 * [`toolbar`](#toolbar)
@@ -377,7 +377,7 @@ export const UserCreate = (props) => (
             <SelectInput label="Sex" source="sex" choices={[
                 { id: 'm', name: 'Male' },
                 { id: 'f', name: 'Female' },
-            ]} validation={choices(['m', 'f'], 'Must be Male or Female')}/>
+            ]} validate={choices(['m', 'f'], 'Must be Male or Female')}/>
         </SimpleForm>
     </Create>
 );


### PR DESCRIPTION
The docs seem to use "validation" and "validate" as the prop name.  I believe the prop is always "validate", is that correct?  I think the help docs section title "Validation" is fine, but the prop definition list and examples should use validate.