### PR TITLE
[RFR] Change dependencies to peerDependencies

### DIFF
--- a/packages/ra-data-fakerest/package.json
+++ b/packages/ra-data-fakerest/package.json
@@ -31,7 +31,9 @@
     },
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "dependencies": {
-        "fakerest": "~2.1.0",
+        "fakerest": "~2.1.0"
+    },
+    "peerDependencies": {
         "react-admin": "^2.0.0-beta1"
     }
 }

--- a/packages/ra-data-graphcool/package.json
+++ b/packages/ra-data-graphcool/package.json
@@ -29,7 +29,12 @@
     "graphql-tag": "~2.4.2",
     "lodash.merge": "~4.6.0",
     "pluralize": "~7.0.0",
-    "ra-data-graphql": "^2.0.0-beta1",
+    "ra-data-graphql": "^2.0.0-beta1"
+  },
+  "peerDependencies": {
+    "react-admin": "^2.0.0-beta1"
+  },
+  "devDependencies": {
     "react-admin": "^2.0.0-beta1"
   }
 }

--- a/packages/ra-data-graphql/package.json
+++ b/packages/ra-data-graphql/package.json
@@ -29,7 +29,12 @@
     "graphql-tag": "^2.4.2",
     "lodash.get": "~4.4.2",
     "lodash.merge": "~4.6.0",
-    "pluralize": "~7.0.0",
+    "pluralize": "~7.0.0"
+  },
+  "peerDependencies": {
+    "react-admin": "^2.0.0-beta1"
+  },
+  "devDependencies": {
     "react-admin": "^2.0.0-beta1"
   }
 }

--- a/packages/ra-dependent-input/package.json
+++ b/packages/ra-dependent-input/package.json
@@ -10,11 +10,11 @@
   "license": "MIT",
   "dependencies": {
     "lodash.get": "~4.4.2",
-    "prop-types": "~15.6.0",
-    "react-admin": "^2.0.0-beta1"
+    "prop-types": "~15.6.0"
   },
   "peerDependencies": {
     "react": "^15.6.2",
-    "react-dom": "^15.6.2"
+    "react-dom": "^15.6.2",
+    "react-admin": "^2.0.0-beta1"
   }
 }

--- a/packages/ra-input-rich-text/package.json
+++ b/packages/ra-input-rich-text/package.json
@@ -35,12 +35,12 @@
     "homepage": "https://github.com/marmelab/react-admin#readme",
     "peerDependencies": {
         "react": "^15.4.0 || ~16.0.0",
+        "react-admin": "^2.0.0-beta1",
         "react-dom": "^15.4.0 || ~16.0.0"
     },
     "dependencies": {
         "lodash.debounce": "~4.0.8",
         "prop-types": "~15.5.7",
-        "quill": "~1.1.9",
-        "react-admin": "^2.0.0-beta1"
+        "quill": "~1.1.9"
     }
 }

--- a/packages/ra-realtime/package.json
+++ b/packages/ra-realtime/package.json
@@ -27,7 +27,15 @@
     "lodash.merge": "~4.6.0",
     "lodash.omit": "~4.5.0",
     "lodash.pick": "~4.4.0",
-    "lodash.pickby": "~4.6.0",
+    "lodash.pickby": "~4.6.0"
+  },
+  "peerDependencies": {
+    "react-admin": "^2.0.0-beta1",
+    "react-router": "~4.2.0",
+    "react-router-redux": "~5.0.0-alpha.6",
+    "redux-saga": "~0.15.6"
+  },
+  "devDependencies": {
     "react-admin": "^2.0.0-beta1",
     "react-router": "~4.2.0",
     "react-router-redux": "~5.0.0-alpha.6",


### PR DESCRIPTION
The plugins shouldn't dependent on react-admin but rather have a peerDependency on it. For testing it should be added to devDependencies. 