### PR TITLE
dynamic redirects

### DIFF
--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -444,6 +444,22 @@ export const PostEdit = (props) => (
 );
 ```
 
+In case when this is not enough you can also use a function. For example if you want set the recently added object as value of reference field in the another object:
+
+```jsx
+const redirect = (basePath, id) => {
+    return `/a/b/c?basePath=${basePath}&id=${id}`;
+};
+    
+export const PostEdit = (props) => (
+    <Edit {...props}>
+        <SimpleForm redirect={redirect}>
+            ...
+        </SimpleForm>
+    </Edit>
+);
+```
+
 This affects both the submit button, and the form submission when the user presses `ENTER` in one of the form fields.
 
 ## Toolbar

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
         "raf": "~3.4.0",
         "selenium-webdriver": "~3.5.0"
     },
-    "workspaces": ["packages/*", "examples/*"]
+    "workspaces": [
+        "packages/*",
+        "examples/*"
+    ]
 }

--- a/packages/react-admin/src/mui/button/SaveButton.js
+++ b/packages/react-admin/src/mui/button/SaveButton.js
@@ -92,7 +92,11 @@ SaveButton.propTypes = {
     classes: PropTypes.object,
     handleSubmitWithRedirect: PropTypes.func,
     label: PropTypes.string,
-    redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    redirect: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.func,
+    ]),
     invalid: PropTypes.bool,
     raised: PropTypes.bool,
     saving: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),

--- a/packages/react-admin/src/mui/form/SimpleForm.js
+++ b/packages/react-admin/src/mui/form/SimpleForm.js
@@ -113,7 +113,11 @@ SimpleForm.propTypes = {
     invalid: PropTypes.bool,
     record: PropTypes.object,
     resource: PropTypes.string,
-    redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    redirect: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.func,
+    ]),
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     submitOnEnter: PropTypes.bool,
     toolbar: PropTypes.element,

--- a/packages/react-admin/src/mui/form/TabbedForm.js
+++ b/packages/react-admin/src/mui/form/TabbedForm.js
@@ -167,7 +167,11 @@ TabbedForm.propTypes = {
     handleSubmit: PropTypes.func, // passed by redux-form
     invalid: PropTypes.bool,
     record: PropTypes.object,
-    redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    redirect: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.func,
+    ]),
     resource: PropTypes.string,
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     submitOnEnter: PropTypes.bool,

--- a/packages/react-admin/src/util/resolveRedirectTo.js
+++ b/packages/react-admin/src/util/resolveRedirectTo.js
@@ -1,6 +1,9 @@
 import linkToRecord from './linkToRecord';
 
 export default (redirectTo, basePath, id) => {
+    if (typeof redirectTo === 'function') {
+        return redirectTo(basePath, id);
+    }
     switch (redirectTo) {
         case 'list':
             return basePath;

--- a/packages/react-admin/src/util/resolveRedirectTo.spec.js
+++ b/packages/react-admin/src/util/resolveRedirectTo.spec.js
@@ -8,5 +8,7 @@ describe('resolve redirect to', () => {
         assert.equal(resolveRedirectTo('edit', 'books', 1), 'books/1');
         assert.equal(resolveRedirectTo('show', 'books', 1), 'books/1/show');
         assert.equal(resolveRedirectTo('home', 'books', 1), 'home');
+        const rFunc = (basePath, id) => `${basePath}/${id}/show`;
+        assert.equal(resolveRedirectTo(rFunc, 'books', 1), 'books/1/show');
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7659,9 +7659,13 @@ uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.0.1, uuid@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.0.tgz#19a63e22b3b32a0ba23984a4f384836465e24949"
 
 v8flags@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
redirect prop in forms or save button can be a function now.
I have some problems during tests before I have started my work:
 FAIL  packages/react-admin/src/mui/input/ImageInput.spec.js
  ● Test suite failed to run

    Cannot find module './Mime' from 'index.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:194:17)
      at Object.<anonymous> (node_modules/mime/index.js:3:12)

Also I have figure out what sanitizeRestProps is cut off redirect property from form. Any passed value is became "list". SaveButton property work as expected. Is there any hidden new feature? Please fix it before 2.0 is released.