### PR TITLE
[RFR]: Allow SimpleForm and TabbedForm layout customization

### DIFF
--- a/e2e/pages/CreatePage.js
+++ b/e2e/pages/CreatePage.js
@@ -8,7 +8,7 @@ export default url => driver => ({
         inputs: By.css(`.ra-input`),
         submitButton: By.css(".create-page button[type='submit']"),
         submitAndAddButton: By.css(
-            ".create-page form>div:last-child button[type='button']"
+            ".create-page form>div>div:last-child button[type='button']"
         ),
         descInput: By.css('.ql-editor'),
     },

--- a/e2e/tests/create.js
+++ b/e2e/tests/create.js
@@ -60,7 +60,6 @@ describe('Create Page', () => {
         await CreatePage.setValues(values);
         await CreatePage.submitAndAdd();
         await driver.wait(until.urlIs('http://localhost:8083/#/posts/create'));
-        await driver.sleep(3000);
         assert.equal(await CreatePage.getInputValue('title'), ''); // new empty form
         await DeletePage.navigate();
         await DeletePage.delete();

--- a/e2e/tests/create.js
+++ b/e2e/tests/create.js
@@ -60,6 +60,7 @@ describe('Create Page', () => {
         await CreatePage.setValues(values);
         await CreatePage.submitAndAdd();
         await driver.wait(until.urlIs('http://localhost:8083/#/posts/create'));
+        await driver.sleep(3000);
         assert.equal(await CreatePage.getInputValue('title'), ''); // new empty form
         await DeletePage.navigate();
         await DeletePage.delete();

--- a/packages/react-admin/src/mui/form/BaseFactory.js
+++ b/packages/react-admin/src/mui/form/BaseFactory.js
@@ -17,6 +17,7 @@ class BaseFactory extends React.Component {
         childRenderer: PropTypes.func,
         childrenFactoryProp: PropTypes.string,
         childFactoryProp: PropTypes.string,
+        defaultLayout: PropTypes.func.isRequired,
     };
 
     static defaultProps = {
@@ -27,6 +28,14 @@ class BaseFactory extends React.Component {
 
     componentWillMount() {
         this.indexComponentsByIdentifier(this.props);
+
+        const { factories, childrenFactoryProp, childFactoryProp } = this.props;
+        this.factories = {
+            ...factories,
+            [childFactoryProp]: this.createChild,
+            [childrenFactoryProp]: this.createChildren,
+            defaultLayout: this.createDefaultLayout,
+        };
     }
     componentWillReceiveProps(nextProps) {
         this.indexComponentsByIdentifier(nextProps);
@@ -65,9 +74,13 @@ class BaseFactory extends React.Component {
         );
     };
 
+    createDefaultLayout = props =>
+        this.props.defaultLayout(this.factories, props);
+
     render() {
         const {
             factories,
+            defaultLayout,
             children,
             childFactoryProp,
             childrenFactoryProp,
@@ -75,14 +88,7 @@ class BaseFactory extends React.Component {
             ...props
         } = this.props;
 
-        return render(
-            {
-                ...factories,
-                [childrenFactoryProp]: this.createChildren,
-                [childFactoryProp]: this.createChild,
-            },
-            props
-        );
+        return render(this.factories, props);
     }
 }
 export default BaseFactory;

--- a/packages/react-admin/src/mui/form/BaseFactory.js
+++ b/packages/react-admin/src/mui/form/BaseFactory.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 /**
  *
  */
-class ChildFactory extends React.Component {
+class BaseFactory extends React.Component {
     static propTypes = {
         factories: PropTypes.object,
         render: PropTypes.func.isRequired,
@@ -85,4 +85,4 @@ class ChildFactory extends React.Component {
         );
     }
 }
-export default ChildFactory;
+export default BaseFactory;

--- a/packages/react-admin/src/mui/form/ChildFactory.js
+++ b/packages/react-admin/src/mui/form/ChildFactory.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ *
+ */
+class ChildFactory extends React.Component {
+    static propTypes = {
+        factories: PropTypes.object,
+        render: PropTypes.func.isRequired,
+        children: PropTypes.oneOfType([
+            PropTypes.element,
+            PropTypes.arrayOf(PropTypes.element),
+        ]).isRequired,
+        transform: PropTypes.func,
+        childIdentifier: PropTypes.func.isRequired,
+        childRenderer: PropTypes.func,
+        childrenFactoryProp: PropTypes.string,
+        childFactoryProp: PropTypes.string,
+    };
+
+    static defaultProps = {
+        childrenFactoryProp: 'children',
+        childFactoryProp: 'child',
+        childRenderer: React.cloneElement,
+    };
+
+    componentWillMount() {
+        this.indexComponentsByIdentifier(this.props);
+    }
+    componentWillReceiveProps(nextProps) {
+        this.indexComponentsByIdentifier(nextProps);
+    }
+    indexComponentsByIdentifier(nextProps) {
+        this.childrenByIdentifier = React.Children
+            .toArray(nextProps.children)
+            .reduce((acc, child) => {
+                const identifier = nextProps.childIdentifier(child);
+                if (identifier) {
+                    acc[identifier] = child;
+                }
+                return acc;
+            }, {});
+    }
+
+    createChild = (identifier, props) => {
+        const { childRenderer, children, ...rest } = this.props;
+        const childElement =
+            typeof identifier === 'string'
+                ? this.childrenByIdentifier[identifier]
+                : identifier;
+
+        return childElement
+            ? childRenderer(childElement, {
+                  ...rest,
+                  ...props,
+              })
+            : null;
+    };
+
+    createChildren = props => {
+        const { children } = this.props;
+        return React.Children.map(children, child =>
+            this.createChild(child, props)
+        );
+    };
+
+    render() {
+        const {
+            factories,
+            children,
+            childFactoryProp,
+            childrenFactoryProp,
+            render,
+            ...props
+        } = this.props;
+
+        return render(
+            {
+                ...factories,
+                [childrenFactoryProp]: this.createChildren,
+                [childFactoryProp]: this.createChild,
+            },
+            props
+        );
+    }
+}
+export default ChildFactory;

--- a/packages/react-admin/src/mui/form/Form.js
+++ b/packages/react-admin/src/mui/form/Form.js
@@ -20,4 +20,5 @@ const Form = (props = {}) => <form {...formPropsSanitizer(props)} />;
 Form.propTypes = {
     ...formPropTypes,
 };
+
 export default Form;

--- a/packages/react-admin/src/mui/form/Form.js
+++ b/packages/react-admin/src/mui/form/Form.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { propTypes as formPropTypes } from 'redux-form';
+import compose from 'recompose/compose';
+
+import {
+    formSanitizer,
+    reduxFormSanitizer,
+    resourceSanitizer,
+    translateSanitizer,
+} from './sanitizers';
+
+const formPropsSanitizer = compose(
+    reduxFormSanitizer,
+    resourceSanitizer,
+    formSanitizer,
+    translateSanitizer
+);
+
+const Form = (props = {}) => <form {...formPropsSanitizer(props)} />;
+Form.propTypes = {
+    ...formPropTypes,
+};
+export default Form;

--- a/packages/react-admin/src/mui/form/FormTab.js
+++ b/packages/react-admin/src/mui/form/FormTab.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import FormInput from './FormInput';
+import PropTypes from 'prop-types';
+import SimpleFormLayoutFactory from './SimpleFormLayoutFactory';
+import FormTabLayout from './FormTabLayout';
 
-const FormTab = ({ label, icon, children, ...rest }) => (
-    <span>
-        {React.Children.map(
-            children,
-            input => input && <FormInput input={input} {...rest} />
-        )}
-    </span>
+const FormTab = ({ render = FormTabLayout, ...rest }) => (
+    <SimpleFormLayoutFactory render={render} {...rest} />
 );
+FormTab.propTypes = {
+    render: PropTypes.func,
+};
 
 export default FormTab;

--- a/packages/react-admin/src/mui/form/FormTabLayout.js
+++ b/packages/react-admin/src/mui/form/FormTabLayout.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const FormTabLayout = factory => <span>{factory.fields()}</span>;
+
+export default FormTabLayout;

--- a/packages/react-admin/src/mui/form/FormWrapper.js
+++ b/packages/react-admin/src/mui/form/FormWrapper.js
@@ -1,17 +1,16 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import Form from './Form';
 
-const FormWrapper = ({ render, ...props }) =>
-    render({
-        ...props,
-        defaultRenderer: Form,
-    });
+const defaultRenderer = (Component, props) => <Component {...props} />;
+
+const FormWrapper = ({ render, ...props }) => render(Form, props);
 
 FormWrapper.propTypes = {
     render: PropTypes.func,
 };
 FormWrapper.defaultProps = {
-    render: Form,
+    render: defaultRenderer,
 };
 
 export default FormWrapper;

--- a/packages/react-admin/src/mui/form/FormWrapper.js
+++ b/packages/react-admin/src/mui/form/FormWrapper.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import Form from './Form';
+
+const FormWrapper = ({ render, ...props }) =>
+    render({
+        ...props,
+        defaultRenderer: Form,
+    });
+
+FormWrapper.propTypes = {
+    render: PropTypes.func,
+};
+FormWrapper.defaultProps = {
+    render: Form,
+};
+
+export default FormWrapper;

--- a/packages/react-admin/src/mui/form/FormWrapper.spec.js
+++ b/packages/react-admin/src/mui/form/FormWrapper.spec.js
@@ -1,0 +1,57 @@
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import FormWrapper from './FormWrapper';
+
+describe('<FormWrapper />', () => {
+    it('should render a html form by default', () => {
+        const wrapper = shallow(<FormWrapper />);
+        assert.equal(wrapper.matchesElement(<form />), true);
+    });
+    it('should pass additional props', () => {
+        const wrapper = shallow(<FormWrapper method="post" />);
+        assert.equal(wrapper.matchesElement(<form method="post" />), true);
+    });
+    it('should wrap children with render func', () => {
+        const wrapper = shallow(
+            <FormWrapper
+                render={({ defaultRenderer, ...props }) => (
+                    <div>{defaultRenderer(props)}</div>
+                )}
+            >
+                <div>Layout</div>
+            </FormWrapper>
+        );
+        assert.equal(
+            wrapper.matchesElement(
+                <div>
+                    <form>
+                        <div>Layout</div>
+                    </form>
+                </div>
+            ),
+            true
+        );
+    });
+
+    describe('defaultRender prop', () => {
+        it('should supply defaultRenderer prop', () => {
+            const wrapper = shallow(
+                <FormWrapper
+                    render={({ defaultRenderer }) => defaultRenderer()}
+                />
+            );
+            assert.equal(wrapper.matchesElement(<form />), true);
+        });
+        it('should pass additional props', () => {
+            const wrapper = shallow(
+                <FormWrapper
+                    render={({ defaultRenderer }) =>
+                        defaultRenderer({ method: 'post' })}
+                />
+            );
+            assert.equal(wrapper.matchesElement(<form method="post" />), true);
+        });
+    });
+});

--- a/packages/react-admin/src/mui/form/FormWrapper.spec.js
+++ b/packages/react-admin/src/mui/form/FormWrapper.spec.js
@@ -6,17 +6,17 @@ import FormWrapper from './FormWrapper';
 
 describe('<FormWrapper />', () => {
     it('should render a html form by default', () => {
-        const wrapper = shallow(<FormWrapper />);
+        const wrapper = shallow(<FormWrapper />).dive();
         assert.equal(wrapper.matchesElement(<form />), true);
     });
     it('should pass additional props', () => {
-        const wrapper = shallow(<FormWrapper method="post" />);
+        const wrapper = shallow(<FormWrapper method="post" />).dive();
         assert.equal(wrapper.matchesElement(<form method="post" />), true);
     });
     it('should wrap children with render func', () => {
         const wrapper = shallow(
             <FormWrapper
-                render={({ defaultRenderer, ...props }) => (
+                render={(defaultRenderer, props) => (
                     <div>{defaultRenderer(props)}</div>
                 )}
             >
@@ -38,16 +38,14 @@ describe('<FormWrapper />', () => {
     describe('defaultRender prop', () => {
         it('should supply defaultRenderer prop', () => {
             const wrapper = shallow(
-                <FormWrapper
-                    render={({ defaultRenderer }) => defaultRenderer()}
-                />
+                <FormWrapper render={defaultRenderer => defaultRenderer()} />
             );
             assert.equal(wrapper.matchesElement(<form />), true);
         });
         it('should pass additional props', () => {
             const wrapper = shallow(
                 <FormWrapper
-                    render={({ defaultRenderer }) =>
+                    render={defaultRenderer =>
                         defaultRenderer({ method: 'post' })}
                 />
             );

--- a/packages/react-admin/src/mui/form/SimpleForm.js
+++ b/packages/react-admin/src/mui/form/SimpleForm.js
@@ -1,4 +1,4 @@
-import React, { Children, Component } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
 import { connect } from 'react-redux';
@@ -7,8 +7,8 @@ import { withStyles } from 'material-ui/styles';
 import classnames from 'classnames';
 
 import getDefaultValues from './getDefaultValues';
-import FormInput from './FormInput';
-import Toolbar from './Toolbar';
+import FormWrapper from './FormWrapper';
+import SimpleFormLayoutFactory from './SimpleFormLayoutFactory';
 
 const styles = theme => ({
     form: {
@@ -21,84 +21,34 @@ const styles = theme => ({
     },
 });
 
-const sanitizeRestProps = ({
-    anyTouched,
-    asyncValidate,
-    asyncValidating,
-    clearSubmit,
-    dirty,
-    handleSubmit,
-    initialized,
-    initialValues,
-    pristine,
-    submitting,
-    submitFailed,
-    submitSucceeded,
-    valid,
-    pure,
-    triggerSubmit,
-    clearSubmitErrors,
-    clearAsyncError,
-    blur,
-    change,
-    destroy,
-    dispatch,
-    initialize,
-    reset,
-    touch,
-    untouch,
-    validate,
-    save,
-    translate,
-    autofill,
-    submit,
-    redirect,
-    array,
-    form,
-    ...props
-}) => props;
-
 export class SimpleForm extends Component {
     handleSubmitWithRedirect = (redirect = this.props.redirect) =>
         this.props.handleSubmit(values => this.props.save(values, redirect));
 
     render() {
         const {
-            basePath,
-            children,
             classes = {},
             className,
-            invalid,
-            record,
-            resource,
-            submitOnEnter,
             toolbar,
-            version,
+            renderWrapper,
+            renderLayout,
             ...rest
         } = this.props;
 
         return (
-            <form
+            <FormWrapper
                 className={classnames('simple-form', className)}
-                {...sanitizeRestProps(rest)}
+                render={renderWrapper}
+                {...rest}
             >
-                <div className={classes.form} key={version}>
-                    {Children.map(children, input => (
-                        <FormInput
-                            basePath={basePath}
-                            input={input}
-                            record={record}
-                            resource={resource}
-                        />
-                    ))}
-                </div>
-                {toolbar &&
-                    React.cloneElement(toolbar, {
-                        handleSubmitWithRedirect: this.handleSubmitWithRedirect,
-                        invalid,
-                        submitOnEnter,
-                    })}
-            </form>
+                <SimpleFormLayoutFactory
+                    toolbar={toolbar}
+                    render={renderLayout}
+                    className={classes.form}
+                    handleSubmitWithRedirect={this.handleSubmitWithRedirect}
+                    {...rest}
+                />
+            </FormWrapper>
         );
     }
 }
@@ -114,16 +64,13 @@ SimpleForm.propTypes = {
     record: PropTypes.object,
     resource: PropTypes.string,
     redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    renderWrapper: PropTypes.func,
+    renderLayout: PropTypes.func,
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     submitOnEnter: PropTypes.bool,
     toolbar: PropTypes.element,
     validate: PropTypes.func,
     version: PropTypes.number,
-};
-
-SimpleForm.defaultProps = {
-    submitOnEnter: true,
-    toolbar: <Toolbar />,
 };
 
 const enhance = compose(

--- a/packages/react-admin/src/mui/form/SimpleForm.spec.js
+++ b/packages/react-admin/src/mui/form/SimpleForm.spec.js
@@ -6,46 +6,14 @@ import { SimpleForm } from './SimpleForm';
 import TextInput from '../input/TextInput';
 
 describe('<SimpleForm />', () => {
-    it('should embed a form with given component children', () => {
+    it('should embed a SimpleFormFactory with given component children', () => {
         const wrapper = shallow(
             <SimpleForm>
                 <TextInput source="name" />
                 <TextInput source="city" />
             </SimpleForm>
         );
-        const inputs = wrapper.find('WithStyles(FormInput)');
-        assert.deepEqual(inputs.map(i => i.prop('input').props.source), [
-            'name',
-            'city',
-        ]);
-    });
-
-    it('should display <Toolbar />', () => {
-        const wrapper = shallow(
-            <SimpleForm>
-                <TextInput source="name" />
-            </SimpleForm>
-        );
-        const button = wrapper.find('WithStyles(Toolbar)');
-        assert.equal(button.length, 1);
-    });
-
-    it('should pass submitOnEnter to <Toolbar />', () => {
-        const handleSubmit = () => {};
-        const wrapper1 = shallow(
-            <SimpleForm submitOnEnter={false} handleSubmit={handleSubmit}>
-                <TextInput source="name" />
-            </SimpleForm>
-        );
-        const button1 = wrapper1.find('WithStyles(Toolbar)');
-        assert.equal(button1.prop('submitOnEnter'), false);
-
-        const wrapper2 = shallow(
-            <SimpleForm submitOnEnter={true} handleSubmit={handleSubmit}>
-                <TextInput source="name" />
-            </SimpleForm>
-        );
-        const button2 = wrapper2.find('WithStyles(Toolbar)');
-        assert.equal(button2.prop('submitOnEnter'), true);
+        const inputs = wrapper.find('WithFormField');
+        assert.deepEqual(inputs.map(i => i.prop('source')), ['name', 'city']);
     });
 });

--- a/packages/react-admin/src/mui/form/SimpleFormLayout.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayout.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const SimpleFormLayout = (factory, { className, version }) => (
+    <div>
+        <div className={className} key={version}>
+            {factory.fields()}
+        </div>
+        {factory.toolbar()}
+    </div>
+);
+export default SimpleFormLayout;

--- a/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
@@ -21,7 +21,6 @@ class SimpleFormLayoutFactory extends React.Component {
     componentWillMount() {
         this.factories = {
             toolbar: this.createToolbar,
-            defaultLayout: this.createDefaultLayout,
         };
     }
 
@@ -35,12 +34,6 @@ class SimpleFormLayoutFactory extends React.Component {
             record={record}
         />
     );
-
-    createDefaultLayout = props =>
-        SimpleFormLayout(
-            this.props.factories,
-            props // Don't pass this.props, because the user is allowed to sanitize the props before rendering the default layout
-        );
 
     createToolbar = props => {
         const {
@@ -62,6 +55,7 @@ class SimpleFormLayoutFactory extends React.Component {
     render() {
         return (
             <BaseFactory
+                defaultLayout={SimpleFormLayout}
                 factories={this.factories}
                 childIdentifier={this.childIdentifier}
                 childFactoryProp="field"

--- a/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ChildFactory from './ChildFactory';
+import BaseFactory from './BaseFactory';
 import SimpleFormLayout from './SimpleFormLayout';
 import FormInput from './FormInput';
 import Toolbar from './Toolbar';
@@ -54,7 +54,7 @@ class SimpleFormLayoutFactory extends React.Component {
 
     render() {
         return (
-            <ChildFactory
+            <BaseFactory
                 factories={this.factories}
                 childIdentifier={this.childIdentifier}
                 childFactoryProp="field"

--- a/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
@@ -21,6 +21,7 @@ class SimpleFormLayoutFactory extends React.Component {
     componentWillMount() {
         this.factories = {
             toolbar: this.createToolbar,
+            defaultLayout: this.createDefaultLayout,
         };
     }
 
@@ -34,6 +35,12 @@ class SimpleFormLayoutFactory extends React.Component {
             record={record}
         />
     );
+
+    createDefaultLayout = props =>
+        SimpleFormLayout(
+            this.factories,
+            props ? { ...this.props, ...props } : this.props
+        );
 
     createToolbar = props => {
         const {

--- a/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ChildFactory from './ChildFactory';
+import SimpleFormLayout from './SimpleFormLayout';
+import FormInput from './FormInput';
+import Toolbar from './Toolbar';
+
+class SimpleFormLayoutFactory extends React.Component {
+    static propTypes = {
+        handleSubmitWithRedirect: PropTypes.func,
+        toolbar: PropTypes.element,
+        invalid: PropTypes.bool,
+        submitOnEnter: PropTypes.bool,
+    };
+    static defaultProps = {
+        render: SimpleFormLayout,
+        submitOnEnter: true,
+        toolbar: <Toolbar />,
+    };
+
+    componentWillMount() {
+        this.factories = {
+            toolbar: this.createToolbar,
+        };
+    }
+
+    childIdentifier = component => component.reference || component.source;
+
+    childRenderer = (component, { basePath, record, resource }) => (
+        <FormInput
+            input={component}
+            resource={resource}
+            basePath={basePath}
+            record={record}
+        />
+    );
+
+    createToolbar = props => {
+        const {
+            toolbar,
+            handleSubmitWithRedirect,
+            invalid,
+            submitOnEnter,
+        } = this.props;
+        return toolbar
+            ? React.cloneElement(toolbar, {
+                  handleSubmitWithRedirect,
+                  invalid,
+                  submitOnEnter,
+                  ...props,
+              })
+            : null;
+    };
+
+    render() {
+        return (
+            <ChildFactory
+                factories={this.factories}
+                childIdentifier={this.childIdentifier}
+                childFactoryProp="field"
+                childrenFactoryProp="fields"
+                childRenderer={this.childRenderer}
+                {...this.props}
+            />
+        );
+    }
+}
+export default SimpleFormLayoutFactory;

--- a/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
@@ -39,7 +39,7 @@ class SimpleFormLayoutFactory extends React.Component {
     createDefaultLayout = props =>
         SimpleFormLayout(
             this.factories,
-            props ? { ...this.props, ...props } : this.props
+            props // Don't pass this.props, because the user is allowed to sanitize the props before rendering the default layout
         );
 
     createToolbar = props => {

--- a/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.js
@@ -38,7 +38,7 @@ class SimpleFormLayoutFactory extends React.Component {
 
     createDefaultLayout = props =>
         SimpleFormLayout(
-            this.factories,
+            this.props.factories,
             props // Don't pass this.props, because the user is allowed to sanitize the props before rendering the default layout
         );
 

--- a/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.spec.js
+++ b/packages/react-admin/src/mui/form/SimpleFormLayoutFactory.spec.js
@@ -1,0 +1,55 @@
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import SimpleFormLayoutFactory from './SimpleFormLayoutFactory';
+import TextInput from '../input/TextInput';
+
+describe('<SimpleFormLayoutFactory />', () => {
+    it('should embed a layout with given component children', () => {
+        const wrapper = shallow(
+            <SimpleFormLayoutFactory>
+                <TextInput source="name" />
+                <TextInput source="city" />
+            </SimpleFormLayoutFactory>
+        ).dive();
+        const inputs = wrapper.find('WithStyles(FormInput)');
+        assert.deepEqual(inputs.map(i => i.prop('input').props.source), [
+            'name',
+            'city',
+        ]);
+    });
+    it('should display <Toolbar />', () => {
+        const wrapper = shallow(
+            <SimpleFormLayoutFactory>
+                <TextInput source="name" />
+            </SimpleFormLayoutFactory>
+        ).dive();
+        const button = wrapper.find('WithStyles(Toolbar)');
+        assert.equal(button.length, 1);
+    });
+    it('should pass submitOnEnter to <Toolbar />', () => {
+        const handleSubmit = () => {};
+        const wrapper1 = shallow(
+            <SimpleFormLayoutFactory
+                submitOnEnter={false}
+                handleSubmit={handleSubmit}
+            >
+                <TextInput source="name" />
+            </SimpleFormLayoutFactory>
+        ).dive();
+        const button1 = wrapper1.find('WithStyles(Toolbar)');
+        assert.equal(button1.prop('submitOnEnter'), false);
+
+        const wrapper2 = shallow(
+            <SimpleFormLayoutFactory
+                submitOnEnter={true}
+                handleSubmit={handleSubmit}
+            >
+                <TextInput source="name" />
+            </SimpleFormLayoutFactory>
+        ).dive();
+        const button2 = wrapper2.find('WithStyles(Toolbar)');
+        assert.equal(button2.prop('submitOnEnter'), true);
+    });
+});

--- a/packages/react-admin/src/mui/form/TabbedForm.js
+++ b/packages/react-admin/src/mui/form/TabbedForm.js
@@ -45,6 +45,7 @@ export class TabbedForm extends Component {
     render() {
         const {
             className,
+            renderWrapper,
             renderLayout,
             tabsWithErrors,
             toolbar,
@@ -54,7 +55,7 @@ export class TabbedForm extends Component {
         return (
             <FormWrapper
                 className={classnames('tabbed-form', className)}
-                render={renderLayout}
+                render={renderWrapper}
                 {...rest}
             >
                 <TabbedFormLayoutFactory
@@ -63,6 +64,7 @@ export class TabbedForm extends Component {
                     tabsWithErrors={tabsWithErrors}
                     handleSubmitWithRedirect={this.handleSubmitWithRedirect}
                     handleChange={this.handleChange}
+                    render={renderLayout}
                     {...rest}
                 />
             </FormWrapper>
@@ -80,6 +82,7 @@ TabbedForm.propTypes = {
     invalid: PropTypes.bool,
     record: PropTypes.object,
     renderLayout: PropTypes.func,
+    renderWrapper: PropTypes.func,
     redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     resource: PropTypes.string,
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission

--- a/packages/react-admin/src/mui/form/TabbedForm.js
+++ b/packages/react-admin/src/mui/form/TabbedForm.js
@@ -2,18 +2,17 @@ import React, { Children, Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
-    reduxForm,
     getFormAsyncErrors,
-    getFormSyncErrors,
     getFormSubmitErrors,
+    getFormSyncErrors,
+    reduxForm,
 } from 'redux-form';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-import Divider from 'material-ui/Divider';
-import Tabs, { Tab } from 'material-ui/Tabs';
 import { withStyles } from 'material-ui/styles';
 
-import Toolbar from './Toolbar';
+import TabbedFormLayoutFactory from './TabbedFormLayoutFactory';
+import FormWrapper from './FormWrapper';
 import getDefaultValues from './getDefaultValues';
 
 const styles = theme => ({
@@ -27,43 +26,6 @@ const styles = theme => ({
     },
     errorTabButton: { color: theme.palette.error[500] },
 });
-
-const sanitizeRestProps = ({
-    anyTouched,
-    asyncValidate,
-    asyncValidating,
-    clearSubmit,
-    dirty,
-    handleSubmit,
-    initialized,
-    initialValues,
-    pristine,
-    submitting,
-    submitFailed,
-    submitSucceeded,
-    valid,
-    pure,
-    triggerSubmit,
-    clearSubmitErrors,
-    clearAsyncError,
-    blur,
-    change,
-    destroy,
-    dispatch,
-    initialize,
-    reset,
-    touch,
-    untouch,
-    validate,
-    save,
-    translate,
-    autofill,
-    submit,
-    redirect,
-    array,
-    form,
-    ...props
-}) => props;
 
 export class TabbedForm extends Component {
     constructor(props) {
@@ -82,78 +44,28 @@ export class TabbedForm extends Component {
 
     render() {
         const {
-            basePath,
-            children,
             className,
-            classes = {},
-            invalid,
-            record,
-            resource,
-            submitOnEnter,
+            renderLayout,
             tabsWithErrors,
             toolbar,
-            translate,
-            version,
             ...rest
         } = this.props;
 
         return (
-            <form
+            <FormWrapper
                 className={classnames('tabbed-form', className)}
-                key={version}
-                {...sanitizeRestProps(rest)}
+                render={renderLayout}
+                {...rest}
             >
-                <Tabs
-                    scrollable
+                <TabbedFormLayoutFactory
                     value={this.state.value}
-                    onChange={this.handleChange}
-                >
-                    {Children.map(
-                        children,
-                        (tab, index) =>
-                            tab ? (
-                                <Tab
-                                    key={tab.props.label}
-                                    label={translate(tab.props.label, {
-                                        _: tab.props.label,
-                                    })}
-                                    value={index}
-                                    icon={tab.props.icon}
-                                    className={classnames(
-                                        'form-tab',
-                                        tabsWithErrors.includes(
-                                            tab.props.label
-                                        ) && this.state.value !== index
-                                            ? classes.errorTabButton
-                                            : null
-                                    )}
-                                />
-                            ) : null
-                    )}
-                </Tabs>
-                <Divider />
-                <div className={classes.form}>
-                    {Children.map(
-                        children,
-                        (tab, index) =>
-                            tab &&
-                            this.state.value === index &&
-                            React.cloneElement(tab, {
-                                resource,
-                                record,
-                                basePath,
-                            })
-                    )}
-                    {toolbar &&
-                        React.cloneElement(toolbar, {
-                            className: 'toolbar',
-                            handleSubmitWithRedirect: this
-                                .handleSubmitWithRedirect,
-                            invalid,
-                            submitOnEnter,
-                        })}
-                </div>
-            </form>
+                    toolbar={toolbar}
+                    tabsWithErrors={tabsWithErrors}
+                    handleSubmitWithRedirect={this.handleSubmitWithRedirect}
+                    handleChange={this.handleChange}
+                    {...rest}
+                />
+            </FormWrapper>
         );
     }
 }
@@ -167,20 +79,16 @@ TabbedForm.propTypes = {
     handleSubmit: PropTypes.func, // passed by redux-form
     invalid: PropTypes.bool,
     record: PropTypes.object,
+    renderLayout: PropTypes.func,
     redirect: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     resource: PropTypes.string,
     save: PropTypes.func, // the handler defined in the parent, which triggers the REST submission
     submitOnEnter: PropTypes.bool,
     tabsWithErrors: PropTypes.arrayOf(PropTypes.string),
     toolbar: PropTypes.element,
-    translate: PropTypes.func,
+    translate: PropTypes.func.isRequired,
     validate: PropTypes.func,
     version: PropTypes.number,
-};
-
-TabbedForm.defaultProps = {
-    submitOnEnter: true,
-    toolbar: <Toolbar />,
 };
 
 const collectErrors = state => {

--- a/packages/react-admin/src/mui/form/TabbedFormLayout.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayout.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import Divider from 'material-ui/Divider';
+
+const FormTabLayout = (factory, { classes = {} }) => (
+    <div>
+        {factory.tabs()}
+        <Divider />
+        <div className={classes.form}>
+            {factory.activeTab()}
+            {factory.toolbar()}
+        </div>
+    </div>
+);
+
+export default FormTabLayout;

--- a/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import ChildFactory from './ChildFactory';
+import TabbedFormLayout from './TabbedFormLayout';
+import Tabs, { Tab } from 'material-ui/Tabs';
+import Toolbar from './Toolbar';
+
+class TabbedFormLayoutFactory extends React.Component {
+    static propTypes = {
+        handleSubmitWithRedirect: PropTypes.func,
+        toolbar: PropTypes.element,
+        invalid: PropTypes.bool,
+        submitOnEnter: PropTypes.bool,
+    };
+    static defaultProps = {
+        render: TabbedFormLayout,
+        submitOnEnter: true,
+        toolbar: <Toolbar />,
+        value: 0,
+    };
+
+    componentWillMount() {
+        this.factories = {
+            activeTab: this.createActiveTab,
+            toolbar: this.createToolbar,
+            tabs: this.createTabs,
+            tab: this.createTab,
+        };
+    }
+
+    childIdentifier = component => component.label;
+
+    childRenderer = (component, { basePath, record, resource }) =>
+        React.cloneElement(component, { basePath, record, resource });
+
+    createTab = ({ label, icon, index }) => {
+        const { classes, translate, value, tabsWithErrors } = this.props;
+        return (
+            <Tab
+                key={label}
+                label={translate(label, {
+                    _: label,
+                })}
+                value={index}
+                icon={icon}
+                className={classnames(
+                    'form-tab',
+                    tabsWithErrors.includes(label) && value !== index
+                        ? classes.errorTabButton
+                        : null
+                )}
+            />
+        );
+    };
+
+    createTabs = props => {
+        const { value, handleChange, children } = this.props;
+        return (
+            <Tabs scrollable value={value} onChange={handleChange} {...props}>
+                {React.Children.map(
+                    children,
+                    (child, index) =>
+                        child
+                            ? this.createTab({
+                                  label: child.props.label,
+                                  icon: child.props.icon,
+                                  index,
+                              })
+                            : null
+                )}
+            </Tabs>
+        );
+    };
+
+    createActiveTab = props => {
+        const { children, value, ...rest } = this.props;
+        const tab = React.Children
+            .toArray(children)
+            .find((child, index) => value === index);
+        return tab ? this.childRenderer(tab, { ...props, ...rest }) : null;
+    };
+
+    createToolbar = props => {
+        const {
+            toolbar,
+            handleSubmitWithRedirect,
+            invalid,
+            submitOnEnter,
+        } = this.props;
+        return toolbar
+            ? React.cloneElement(toolbar, {
+                  handleSubmitWithRedirect,
+                  invalid,
+                  submitOnEnter,
+                  ...props,
+              })
+            : null;
+    };
+
+    render() {
+        return (
+            <ChildFactory
+                factories={this.factories}
+                childIdentifier={this.childIdentifier}
+                childRenderer={this.childRenderer}
+                {...this.props}
+            />
+        );
+    }
+}
+export default TabbedFormLayoutFactory;

--- a/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
@@ -76,7 +76,7 @@ class TabbedFormLayoutFactory extends React.Component {
     };
     createDefaultLayout = props =>
         TabbedFormLayout(
-            this.factories,
+            this.props.factories,
             props // Don't pass this.props, because the user is allowed to sanitize the props before rendering the default layout
         );
     createActiveTab = props => {

--- a/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
@@ -24,7 +24,6 @@ class TabbedFormLayoutFactory extends React.Component {
     componentWillMount() {
         this.factories = {
             activeTab: this.createActiveTab,
-            defaultLayout: this.createDefaultLayout,
             toolbar: this.createToolbar,
             tabs: this.createTabs,
             tab: this.createTab,
@@ -74,11 +73,6 @@ class TabbedFormLayoutFactory extends React.Component {
             </Tabs>
         );
     };
-    createDefaultLayout = props =>
-        TabbedFormLayout(
-            this.props.factories,
-            props // Don't pass this.props, because the user is allowed to sanitize the props before rendering the default layout
-        );
     createActiveTab = props => {
         const { children, value, ...rest } = this.props;
         const tab = React.Children
@@ -107,6 +101,7 @@ class TabbedFormLayoutFactory extends React.Component {
     render() {
         return (
             <BaseFactory
+                defaultLayout={TabbedFormLayout}
                 factories={this.factories}
                 childIdentifier={this.childIdentifier}
                 childRenderer={this.childRenderer}

--- a/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-import ChildFactory from './ChildFactory';
+import BaseFactory from './BaseFactory';
 import TabbedFormLayout from './TabbedFormLayout';
 import Tabs, { Tab } from 'material-ui/Tabs';
 import Toolbar from './Toolbar';
@@ -101,7 +101,7 @@ class TabbedFormLayoutFactory extends React.Component {
 
     render() {
         return (
-            <ChildFactory
+            <BaseFactory
                 factories={this.factories}
                 childIdentifier={this.childIdentifier}
                 childRenderer={this.childRenderer}

--- a/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
@@ -24,6 +24,7 @@ class TabbedFormLayoutFactory extends React.Component {
     componentWillMount() {
         this.factories = {
             activeTab: this.createActiveTab,
+            defaultLayout: this.createDefaultLayout,
             toolbar: this.createToolbar,
             tabs: this.createTabs,
             tab: this.createTab,
@@ -73,7 +74,11 @@ class TabbedFormLayoutFactory extends React.Component {
             </Tabs>
         );
     };
-
+    createDefaultLayout = props =>
+        TabbedFormLayout(
+            this.factories,
+            props ? { ...this.props, ...props } : this.props
+        );
     createActiveTab = props => {
         const { children, value, ...rest } = this.props;
         const tab = React.Children

--- a/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.js
@@ -77,7 +77,7 @@ class TabbedFormLayoutFactory extends React.Component {
     createDefaultLayout = props =>
         TabbedFormLayout(
             this.factories,
-            props ? { ...this.props, ...props } : this.props
+            props // Don't pass this.props, because the user is allowed to sanitize the props before rendering the default layout
         );
     createActiveTab = props => {
         const { children, value, ...rest } = this.props;

--- a/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.spec.js
+++ b/packages/react-admin/src/mui/form/TabbedFormLayoutFactory.spec.js
@@ -2,24 +2,25 @@ import assert from 'assert';
 import { shallow } from 'enzyme';
 import React, { createElement } from 'react';
 
-import { TabbedForm, findTabsWithErrors } from './TabbedForm';
+import { findTabsWithErrors } from './TabbedForm';
+import TabbedFormLayoutFactory from './TabbedFormLayoutFactory';
 import FormTab from './FormTab';
 
 const translate = label => label;
 const muiTheme = { textField: { errorColor: 'red' } };
 
-describe('<TabbedForm />', () => {
+describe('<TabbedFormLayoutFactory />', () => {
     it('should render tabs', () => {
         const wrapper = shallow(
-            <TabbedForm
+            <TabbedFormLayoutFactory
                 translate={translate}
                 muiTheme={muiTheme}
                 tabsWithErrors={[]}
             >
                 <FormTab />
                 <FormTab />
-            </TabbedForm>
-        );
+            </TabbedFormLayoutFactory>
+        ).dive();
         const tabsContainer = wrapper.find('WithStyles(Tabs)');
         assert.equal(tabsContainer.length, 1);
         const tabs = wrapper.find('FormTab');
@@ -28,15 +29,15 @@ describe('<TabbedForm />', () => {
 
     it('should display <Toolbar />', () => {
         const wrapper = shallow(
-            <TabbedForm
+            <TabbedFormLayoutFactory
                 translate={translate}
                 muiTheme={muiTheme}
                 tabsWithErrors={[]}
             >
                 <FormTab />
                 <FormTab />
-            </TabbedForm>
-        );
+            </TabbedFormLayoutFactory>
+        ).dive();
 
         const toolbar = wrapper.find('WithStyles(Toolbar)');
         assert.equal(toolbar.length, 1);
@@ -45,33 +46,33 @@ describe('<TabbedForm />', () => {
     it('should pass submitOnEnter to <Toolbar />', () => {
         const handleSubmit = () => {};
         const wrapper1 = shallow(
-            <TabbedForm
+            <TabbedFormLayoutFactory
                 translate={translate}
                 submitOnEnter={false}
                 handleSubmit={handleSubmit}
                 muiTheme={muiTheme}
                 tabsWithErrors={[]}
             />
-        );
+        ).dive();
         const button1 = wrapper1.find('WithStyles(Toolbar)');
         assert.equal(button1.prop('submitOnEnter'), false);
 
         const wrapper2 = shallow(
-            <TabbedForm
+            <TabbedFormLayoutFactory
                 translate={translate}
                 submitOnEnter
                 handleSubmit={handleSubmit}
                 muiTheme={muiTheme}
                 tabsWithErrors={[]}
             />
-        );
+        ).dive();
         const button2 = wrapper2.find('WithStyles(Toolbar)');
         assert.strictEqual(button2.prop('submitOnEnter'), true);
     });
 
     it('should set the style of an inactive Tab button with errors', () => {
         const wrapper = shallow(
-            <TabbedForm
+            <TabbedFormLayoutFactory
                 translate={translate}
                 muiTheme={muiTheme}
                 tabsWithErrors={['tab2']}
@@ -79,8 +80,8 @@ describe('<TabbedForm />', () => {
             >
                 <FormTab label="tab1" />
                 <FormTab label="tab2" />
-            </TabbedForm>
-        );
+            </TabbedFormLayoutFactory>
+        ).dive();
         const tabs = wrapper.find('WithStyles(Tab)');
         const tab1 = tabs.at(0);
         const tab2 = tabs.at(1);
@@ -91,7 +92,7 @@ describe('<TabbedForm />', () => {
 
     it('should not set the style of an active Tab button with errors', () => {
         const wrapper = shallow(
-            <TabbedForm
+            <TabbedFormLayoutFactory
                 translate={translate}
                 muiTheme={muiTheme}
                 tabsWithErrors={['tab1']}
@@ -99,8 +100,8 @@ describe('<TabbedForm />', () => {
             >
                 <FormTab label="tab1" />
                 <FormTab label="tab2" />
-            </TabbedForm>
-        );
+            </TabbedFormLayoutFactory>
+        ).dive();
         const tabs = wrapper.find('WithStyles(Tab)');
         const tab1 = tabs.at(0);
         const tab2 = tabs.at(1);

--- a/packages/react-admin/src/mui/form/sanitizers.js
+++ b/packages/react-admin/src/mui/form/sanitizers.js
@@ -1,0 +1,47 @@
+export const resourceSanitizer = ({ basePath, resource, ...rest }) => rest;
+
+export const translateSanitizer = ({ locale, translate, ...rest }) => rest;
+
+export const formSanitizer = ({
+    clearSubmitErrors,
+    defaultRenderer,
+    submitOnEnter,
+    save,
+    validate,
+    ...rest
+}) => rest;
+
+export const reduxFormSanitizer = ({
+    anyTouched,
+    array,
+    asyncValidate,
+    asyncValidating,
+    autofill,
+    blur,
+    change,
+    clearAsyncError,
+    clearSubmit,
+    destroy,
+    dirty,
+    dispatch,
+    error,
+    form,
+    handleSubmit,
+    initialize,
+    initialized,
+    initialValues,
+    invalid,
+    pristine,
+    pure,
+    reset,
+    submit,
+    submitFailed,
+    submitSucceeded,
+    submitting,
+    touch,
+    triggerSubmit,
+    untouch,
+    valid,
+    warning,
+    ...rest
+}) => rest;


### PR DESCRIPTION
This PR allows layout modification of the `SimpleForm` and `TabbedForm` components to create a complete customized layout (instead of single line per item). It allows a `Wrapper` component and a `Layout`(Template) component. This template receives a factory to create the fields of the form. 

```
const MyFormWrapper = (defaultRenderer,props) => 
  <div>
      <div>Informational text</div>
      {defaultRenderer(props)} // The defaultRenderer simple renders a sanitized <form> component
  </div>
  
const MyFormLayout = (factory,props) => // factory supplied by SimpleFormLayoutFactory
  <div>
    <div>{factory.field('title')</div>
    <div>{factory.field('body')</div>
    <div>{factory.field('teaser')</div>
    <div>{factory.field('published_at')</div>
  </div>

<SimpleForm renderLayout={MyFormLayout} renderWrapper={MyFormWrapper}>
    <TextInput source="title" />
    <TextInput source="teaser" options={{ multiLine: true }} />
    <RichTextInput source="body" />
    <DateInput label="Publication date" source="published_at" defaultValue={new Date()} />
</SimpleForm>
```

For TabbedForm this would be: 
```
const MyTabbedFormWrapper = (defaultRenderer,props) => 
  <div>
      <div>Informational text</div>
      {defaultRenderer(props)} // The defaultRenderer simple renders a sanitized <form> component
  </div>
  
const MainTabLayout= (factory,props) => // factory supplied by SimpleFormLayoutFactory
  <div>
    <div>{factory.field('title')</div>
    <div>{factory.field('body')</div>
    <div>{factory.field('teaser')</div>
    <div>{factory.field('published_at')</div>
  </div>

const MyTabLayout = (factory,props) => // factory supplied by TabbedFormLayoutFactory
    <div>
        {factory.tabs()}
        <Divider />
        <div className={classes.form}>
            {factory.activeTab()}
            {factory.toolbar()}
        </div>
    </div>

<TabbedForm renderWrapper={MyTabbedFormWrapper} renderLayout={MyTabLayout} >
    <FormTab label="main" render={MainTabLayout}>
        <TextInput source="title" />
        <TextInput source="teaser" options={{ multiLine: true }} />
        <RichTextInput source="body" />
        <DateInput label="Publication date" source="published_at" defaultValue={new Date()} />
     </FormTab>
</SimpleForm>
```

Each component has it's own factory which supplies the factory methods allowed. `FormTab` simply uses the `SimpleFormLayoutFactory`. 

By default everything is rendered as expected, only an additional `<div>` is added to the `TabbedFormLayout` component. 

Maybe `SimpleFormLayout` and `TabbedFormLayout` should be named `SimpleFormTemplate` and `TabbedFormTemplate` and the `renderLayout` prop `renderTemplate`. 
