### PR TITLE
[RFR]: Reference input issues

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -509,7 +509,7 @@ import { RadioButtonGroupInput, ReferenceInput } from 'react-admin'
 
 ## `<ReferenceInput>`
 
-Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `GET_LIST` REST method), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
+Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `GET_LIST` REST method) and the referenced record (using the `GET_ONE` REST method), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute and the referenced record as `selectedItem`.
 
 This means you can use `<ReferenceInput>` with any of [`<SelectInput>`](#selectinput), [`<AutocompleteInput>`](#autocompleteinput), or [`<RadioButtonGroupInput>`](#radiobuttongroupinput), or even with the component of your choice, provided it supports the `choices` attribute.
 
@@ -600,6 +600,7 @@ The enclosed component may further filter results (that's the case, for instance
     <SelectInput optionText="title" />
 </ReferenceInput>
 ```
+  
 
 ## `<RichTextInput>`
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -509,7 +509,7 @@ import { RadioButtonGroupInput, ReferenceInput } from 'react-admin'
 
 ## `<ReferenceInput>`
 
-Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `GET_LIST` REST method) and the referenced record (using the `GET_ONE` REST method), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute and the referenced record as `selectedItem`.
+Use `<ReferenceInput>` for foreign-key values, i.e. to let users choose a value from another REST endpoint. This component fetches the possible values in the reference resource (using the `GET_LIST` REST method) and the referenced record (using the `GET_ONE` REST method), then delegates rendering to a subcomponent, to which it passes the possible choices as the `choices` attribute.
 
 This means you can use `<ReferenceInput>` with any of [`<SelectInput>`](#selectinput), [`<AutocompleteInput>`](#autocompleteinput), or [`<RadioButtonGroupInput>`](#radiobuttongroupinput), or even with the component of your choice, provided it supports the `choices` attribute.
 

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.js
@@ -141,21 +141,21 @@ export class ReferenceArrayInput extends Component {
     setFilter = filter => {
         if (filter !== this.params.filter) {
             this.params.filter = this.props.filterToQuery(filter);
-            this.fetchReferencesAndOptions();
+            this.fetchOptions();
         }
     };
 
     setPagination = pagination => {
         if (pagination !== this.param.pagination) {
             this.param.pagination = pagination;
-            this.fetchReferencesAndOptions();
+            this.fetchOptions();
         }
     };
 
     setSort = sort => {
         if (sort !== this.params.sort) {
             this.params.sort = sort;
-            this.fetchReferencesAndOptions();
+            this.fetchOptions();
         }
     };
 

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.js
@@ -289,7 +289,6 @@ ReferenceArrayInput.defaultProps = {
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecords: [],
-    record: {},
 };
 const mapStateToProps = createSelector(
     (_, { input: { value: referenceIds } }) => referenceIds || [],

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.js
@@ -11,7 +11,11 @@ import {
     crudGetMany as crudGetManyAction,
     crudGetMatching as crudGetMatchingAction,
 } from '../../actions/dataActions';
-import { getPossibleReferences } from '../../reducer/admin/references/possibleValues';
+import {
+    getPossibleReferences,
+    getPossibleReferenceValues,
+    getResource,
+} from '../../reducer/admin';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 
@@ -239,7 +243,6 @@ export class ReferenceArrayInput extends Component {
             resource,
             meta,
             source,
-            selectedItems: referenceRecords,
             choices: matchingReferences,
             basePath,
             onChange,
@@ -290,11 +293,9 @@ ReferenceArrayInput.defaultProps = {
 };
 const mapStateToProps = createSelector(
     (_, { input: { value: referenceIds } }) => referenceIds || [],
-    (state, { reference }) => state.admin.resources[reference],
+    (state, { reference }) => getResource(state, reference),
     (state, { resource, source }) =>
-        state.admin.references.possibleValues[
-            referenceSource(resource, source)
-        ],
+        getPossibleReferenceValues(state, referenceSource(resource, source)),
     (inputIds, referenceState, possibleValues) => ({
         referenceRecords:
             referenceState &&

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
@@ -8,6 +8,7 @@ describe('<ReferenceArrayInput />', () => {
         crudGetMatching: () => true,
         crudGetMany: () => true,
         input: {},
+        record: {},
         reference: 'tags',
         resource: 'posts',
         source: 'tag_ids',

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
@@ -201,18 +201,19 @@ describe('<ReferenceArrayInput />', () => {
         const wrapper = shallow(
             <ReferenceArrayInput
                 {...defaultProps}
-                allowEmpty
+                input={{ value: [5] }}
                 crudGetMany={crudGetMany}
                 crudGetMatching={crudGetMatching}
             >
                 <MyComponent />
             </ReferenceArrayInput>
         );
-        expect(crudGetMatching.mock.calls.length).toBe(1);
+        expect(crudGetMatching).toHaveBeenCalledTimes(1);
+        expect(crudGetMany).toHaveBeenCalledTimes(1);
 
         wrapper.instance().setFilter('bar');
-        expect(crudGetMany.mock.calls.length).toBe(0);
-        expect(crudGetMatching.mock.calls.length).toBe(2);
+        expect(crudGetMatching).toHaveBeenCalledTimes(2);
+        expect(crudGetMany).toHaveBeenCalledTimes(1);
     });
 
     it('should call crudGetMany when input value changes', () => {

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.spec.js
@@ -194,4 +194,62 @@ describe('<ReferenceArrayInput />', () => {
         const myComponent = wrapper.find('MyComponent');
         assert.notEqual(myComponent.prop('meta', undefined));
     });
+
+    it('should only call crudGetMatching when calling setFilter', () => {
+        const crudGetMatching = jest.fn();
+        const crudGetMany = jest.fn();
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...defaultProps}
+                allowEmpty
+                crudGetMany={crudGetMany}
+                crudGetMatching={crudGetMatching}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        expect(crudGetMatching.mock.calls.length).toBe(1);
+
+        wrapper.instance().setFilter('bar');
+        expect(crudGetMany.mock.calls.length).toBe(0);
+        expect(crudGetMatching.mock.calls.length).toBe(2);
+    });
+
+    it('should call crudGetMany when input value changes', () => {
+        const crudGetMany = jest.fn();
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...defaultProps}
+                input={{ value: [5] }}
+                allowEmpty
+                crudGetMany={crudGetMany}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        expect(crudGetMany.mock.calls.length).toBe(1);
+        wrapper.setProps({ input: { value: [6] } });
+        expect(crudGetMany.mock.calls.length).toBe(2);
+    });
+
+    it('should call crudGetOne and crudGetMatching when record changes', () => {
+        const crudGetMany = jest.fn();
+        const crudGetMatching = jest.fn();
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...defaultProps}
+                allowEmpty
+                input={{ value: [5] }}
+                crudGetMany={crudGetMany}
+                crudGetMatching={crudGetMatching}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        expect(crudGetMany.mock.calls.length).toBe(1);
+        expect(crudGetMatching.mock.calls.length).toBe(1);
+        wrapper.setProps({ record: { id: 1 } });
+        expect(crudGetMany.mock.calls.length).toBe(2);
+        expect(crudGetMatching.mock.calls.length).toBe(2);
+    });
 });

--- a/packages/react-admin/src/mui/input/ReferenceInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
 import compose from 'recompose/compose';
+import { createSelector } from 'reselect';
 
 import LinearProgress from '../layout/LinearProgress';
 import Labeled from './Labeled';
@@ -148,40 +149,43 @@ export class ReferenceInput extends Component {
     componentWillReceiveProps(nextProps) {
         if (this.props.record.id !== nextProps.record.id) {
             this.fetchReferenceAndOptions(nextProps);
+        } else if (this.props.input.value !== nextProps.input.value) {
+            this.fetchReference(nextProps);
         }
     }
 
     setFilter = filter => {
         if (filter !== this.params.filter) {
             this.params.filter = this.props.filterToQuery(filter);
-            this.fetchReferenceAndOptions();
+            this.fetchOptions();
         }
     };
 
     setPagination = pagination => {
         if (pagination !== this.param.pagination) {
             this.param.pagination = pagination;
-            this.fetchReferenceAndOptions();
+            this.fetchOptions();
         }
     };
 
     setSort = sort => {
         if (sort !== this.params.sort) {
             this.params.sort = sort;
-            this.fetchReferenceAndOptions();
+            this.fetchOptions();
         }
     };
 
-    fetchReferenceAndOptions(
-        { input, reference, source, resource } = this.props
-    ) {
-        const { filter: filterFromProps } = this.props;
-        const { pagination, sort, filter } = this.params;
-
+    fetchReference = ({ input, reference } = this.props) => {
         const id = input.value;
         if (id) {
             this.props.crudGetOne(reference, id, null, false);
         }
+    };
+
+    fetchOptions = ({ reference, source, resource } = this.props) => {
+        const { filter: filterFromProps } = this.props;
+        const { pagination, sort, filter } = this.params;
+
         const finalFilter = { ...filterFromProps, ...filter };
         this.props.crudGetMatching(
             reference,
@@ -190,6 +194,11 @@ export class ReferenceInput extends Component {
             sort,
             finalFilter
         );
+    };
+
+    fetchReferenceAndOptions(nextProps) {
+        this.fetchReference(nextProps);
+        this.fetchOptions(nextProps);
     }
 
     render() {
@@ -241,6 +250,7 @@ export class ReferenceInput extends Component {
             resource,
             meta,
             source,
+            selectedItem: referenceRecord,
             choices: matchingReferences,
             basePath,
             onChange,
@@ -270,6 +280,7 @@ ReferenceInput.propTypes = {
     meta: PropTypes.object,
     onChange: PropTypes.func,
     perPage: PropTypes.number,
+    record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
     resource: PropTypes.string.isRequired,
@@ -288,21 +299,25 @@ ReferenceInput.defaultProps = {
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecord: null,
+    record: {},
 };
 
-function mapStateToProps(state, props) {
-    const referenceId = props.input.value;
-    return {
-        referenceRecord:
-            state.admin.resources[props.reference].data[referenceId],
+const mapStateToProps = createSelector(
+    (_, props) => props.input.value,
+    (state, { reference }) => state.admin.resources[reference],
+    (state, { resource, source }) =>
+        state.admin.references.possibleValues[
+            referenceSource(resource, source)
+        ],
+    (inputId, referenceState, possibleValues) => ({
+        referenceRecord: referenceState && referenceState.data[inputId],
         matchingReferences: getPossibleReferences(
-            state,
-            referenceSource(props.resource, props.source),
-            props.reference,
-            [referenceId]
+            referenceState,
+            possibleValues,
+            [inputId]
         ),
-    };
-}
+    })
+);
 
 export default compose(
     addField,

--- a/packages/react-admin/src/mui/input/ReferenceInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.js
@@ -12,7 +12,11 @@ import {
     crudGetOne as crudGetOneAction,
     crudGetMatching as crudGetMatchingAction,
 } from '../../actions/dataActions';
-import { getPossibleReferences } from '../../reducer/admin/references/possibleValues';
+import {
+    getPossibleReferences,
+    getPossibleReferenceValues,
+    getResource,
+} from '../../reducer/';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 
@@ -250,7 +254,6 @@ export class ReferenceInput extends Component {
             resource,
             meta,
             source,
-            selectedItem: referenceRecord,
             choices: matchingReferences,
             basePath,
             onChange,
@@ -304,11 +307,9 @@ ReferenceInput.defaultProps = {
 
 const mapStateToProps = createSelector(
     (_, props) => props.input.value,
-    (state, { reference }) => state.admin.resources[reference],
+    (state, { reference }) => getResource(state, reference),
     (state, { resource, source }) =>
-        state.admin.references.possibleValues[
-            referenceSource(resource, source)
-        ],
+        getPossibleReferenceValues(state, referenceSource(resource, source)),
     (inputId, referenceState, possibleValues) => ({
         referenceRecord: referenceState && referenceState.data[inputId],
         matchingReferences: getPossibleReferences(

--- a/packages/react-admin/src/mui/input/ReferenceInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.js
@@ -302,7 +302,6 @@ ReferenceInput.defaultProps = {
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecord: null,
-    record: {},
 };
 
 const mapStateToProps = createSelector(

--- a/packages/react-admin/src/mui/input/ReferenceInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.spec.js
@@ -8,6 +8,7 @@ describe('<ReferenceInput />', () => {
         crudGetMatching: () => true,
         crudGetOne: () => true,
         input: {},
+        record: {},
         reference: 'posts',
         resource: 'comments',
         source: 'post_id',

--- a/packages/react-admin/src/mui/input/ReferenceInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.spec.js
@@ -233,17 +233,19 @@ describe('<ReferenceInput />', () => {
             <ReferenceInput
                 {...defaultProps}
                 allowEmpty
+                input={{ value: 5 }}
                 crudGetOne={crudGetOne}
                 crudGetMatching={crudGetMatching}
             >
                 <MyComponent />
             </ReferenceInput>
         );
-        expect(crudGetMatching.mock.calls.length).toBe(1);
+        expect(crudGetMatching).toHaveBeenCalledTimes(1);
+        expect(crudGetOne).toHaveBeenCalledTimes(1);
 
         wrapper.instance().setFilter('bar');
-        expect(crudGetOne.mock.calls.length).toBe(0);
         expect(crudGetMatching.mock.calls.length).toBe(2);
+        expect(crudGetOne).toHaveBeenCalledTimes(1);
     });
 
     it('should call crudGetOne when input value changes', () => {

--- a/packages/react-admin/src/mui/input/ReferenceInput.spec.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.spec.js
@@ -225,4 +225,62 @@ describe('<ReferenceInput />', () => {
         const myComponent = wrapper.find('MyComponent');
         assert.notEqual(myComponent.prop('meta', undefined));
     });
+
+    it('should only call crudGetMatching when calling setFilter', () => {
+        const crudGetMatching = jest.fn();
+        const crudGetOne = jest.fn();
+        const wrapper = shallow(
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                crudGetOne={crudGetOne}
+                crudGetMatching={crudGetMatching}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        expect(crudGetMatching.mock.calls.length).toBe(1);
+
+        wrapper.instance().setFilter('bar');
+        expect(crudGetOne.mock.calls.length).toBe(0);
+        expect(crudGetMatching.mock.calls.length).toBe(2);
+    });
+
+    it('should call crudGetOne when input value changes', () => {
+        const crudGetOne = jest.fn();
+        const wrapper = shallow(
+            <ReferenceInput
+                {...defaultProps}
+                input={{ value: 5 }}
+                allowEmpty
+                crudGetOne={crudGetOne}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        expect(crudGetOne.mock.calls.length).toBe(1);
+        wrapper.setProps({ input: { value: 6 } });
+        expect(crudGetOne.mock.calls.length).toBe(2);
+    });
+
+    it('should call crudGetOne and crudGetMatching when record changes', () => {
+        const crudGetOne = jest.fn();
+        const crudGetMatching = jest.fn();
+        const wrapper = shallow(
+            <ReferenceInput
+                {...defaultProps}
+                allowEmpty
+                input={{ value: 5 }}
+                crudGetOne={crudGetOne}
+                crudGetMatching={crudGetMatching}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        expect(crudGetOne.mock.calls.length).toBe(1);
+        expect(crudGetMatching.mock.calls.length).toBe(1);
+        wrapper.setProps({ record: { id: 1 } });
+        expect(crudGetOne.mock.calls.length).toBe(2);
+        expect(crudGetMatching.mock.calls.length).toBe(2);
+    });
 });

--- a/packages/react-admin/src/mui/input/SelectInput.js
+++ b/packages/react-admin/src/mui/input/SelectInput.js
@@ -37,7 +37,6 @@ const sanitizeRestProps = ({
     reference,
     resource,
     setFilter,
-    selectedItem, // Passed on from ReferenceInput
     setPagination,
     setSort,
     sort,

--- a/packages/react-admin/src/mui/input/SelectInput.js
+++ b/packages/react-admin/src/mui/input/SelectInput.js
@@ -37,6 +37,7 @@ const sanitizeRestProps = ({
     reference,
     resource,
     setFilter,
+    selectedItem, // Passed on from ReferenceInput
     setPagination,
     setSort,
     sort,

--- a/packages/react-admin/src/reducer/admin/index.js
+++ b/packages/react-admin/src/reducer/admin/index.js
@@ -1,9 +1,12 @@
 import { combineReducers } from 'redux';
-import resources, { getResources as innerGetResources } from './resource';
+import resources, {
+    getResources as innerGetResources,
+    getResource as innerGetResource,
+} from './resource';
 import loading from './loading';
 import notifications from './notifications';
 import record from './record';
-import references from './references';
+import references, { getPossibleValues } from './references';
 import saving from './saving';
 import ui from './ui';
 import auth, { isLoggedIn as innerIsLoggedIn } from './auth';
@@ -19,5 +22,11 @@ export default combineReducers({
     auth,
 });
 
+export const getPossibleReferenceValues = (state, resource) =>
+    getPossibleValues(state.references, resource);
+export const getResource = (state, resource) =>
+    innerGetResource(state.resources, resource);
 export const getResources = state => innerGetResources(state.resources);
 export const isLoggedIn = state => innerIsLoggedIn(state.auth);
+
+export { getPossibleReferences } from './references';

--- a/packages/react-admin/src/reducer/admin/references/index.js
+++ b/packages/react-admin/src/reducer/admin/references/index.js
@@ -6,3 +6,8 @@ export default combineReducers({
     oneToMany,
     possibleValues,
 });
+
+export const getPossibleValues = (state, referenceSource) =>
+    state.possibleValues[referenceSource];
+
+export { getPossibleReferences } from './possibleValues';

--- a/packages/react-admin/src/reducer/admin/references/possibleValues.js
+++ b/packages/react-admin/src/reducer/admin/references/possibleValues.js
@@ -15,7 +15,7 @@ export default (previousState = initialState, { type, payload, meta }) => {
 };
 
 export const getPossibleReferences = (
-    state,
+    referenceState,
     possibleValues,
     selectedIds = []
 ) => {
@@ -26,6 +26,6 @@ export const getPossibleReferences = (
             possibleValues.unshift(id)
     );
     return possibleValues
-        .map(id => state.data[id])
+        .map(id => referenceState.data[id])
         .filter(r => typeof r !== 'undefined');
 };

--- a/packages/react-admin/src/reducer/admin/references/possibleValues.js
+++ b/packages/react-admin/src/reducer/admin/references/possibleValues.js
@@ -16,22 +16,16 @@ export default (previousState = initialState, { type, payload, meta }) => {
 
 export const getPossibleReferences = (
     state,
-    referenceSource,
-    reference,
+    possibleValues,
     selectedIds = []
 ) => {
-    const possibleValues = state.admin.references.possibleValues[
-        referenceSource
-    ]
-        ? Array.from(state.admin.references.possibleValues[referenceSource])
-        : [];
+    possibleValues = possibleValues ? Array.from(possibleValues) : [];
     selectedIds.forEach(
         id =>
             possibleValues.some(value => value == id) ||
             possibleValues.unshift(id)
     );
-
     return possibleValues
-        .map(id => state.admin.resources[reference].data[id])
+        .map(id => state.data[id])
         .filter(r => typeof r !== 'undefined');
 };

--- a/packages/react-admin/src/reducer/admin/resource/index.js
+++ b/packages/react-admin/src/reducer/admin/resource/index.js
@@ -66,5 +66,7 @@ export default (
     return newState;
 };
 
+export const getResource = (state, resource) => state[resource];
+
 export const getResources = state =>
     Object.keys(state).map(key => state[key].props);

--- a/packages/react-admin/src/reducer/index.js
+++ b/packages/react-admin/src/reducer/index.js
@@ -2,7 +2,9 @@ import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { routerReducer } from 'react-router-redux';
 import admin, {
+    getResource as getAdminResource,
     getResources as getAdminResources,
+    getPossibleReferenceValues as getAdminPossibleReferenceValues,
     isLoggedIn as adminIsLoggedIn,
 } from './admin';
 import i18nReducer, { getLocale as adminGetLocale } from './i18n';
@@ -16,6 +18,11 @@ export default (customReducers, locale, messages) =>
         ...customReducers,
     });
 
+export const getPossibleReferenceValues = (state, resource) =>
+    getAdminPossibleReferenceValues(state.admin, resource);
+export const getResource = (state, resource) =>
+    getAdminResource(state.admin, resource);
 export const getResources = state => getAdminResources(state.admin);
 export const isLoggedIn = state => adminIsLoggedIn(state.admin);
 export const getLocale = state => adminGetLocale(state.i18n);
+export { getPossibleReferences } from './admin';


### PR DESCRIPTION
When working with the autosuggest item I encountered several issues with the `ReferenceInput` components, I separated them in this dedicated PR: 
- [X] When setFilter is triggered from child component, the reference and options were retrieved. Only the options should be retrieved (save one roundtrip)
- [X] When the input value of the item is changed, the reference record should be fetched.
- [X] There were alot of rerenders, introduced selector to memoize the referenced records
- [X] The referenced records weren't passed on to the child component, I really think they should be passed on. Introduced `selectedItem` prop in `ReferenceInput` and `selectedItems` prop in `ReferenceArrayInput`. 
- [x] Add tests for new behaviour