### PR TITLE
Update SimpleShowLayout.js

### DIFF
--- a/src/mui/detail/SimpleShowLayout.js
+++ b/src/mui/detail/SimpleShowLayout.js
@@ -12,36 +12,38 @@ const SimpleShowLayout = ({
     version,
 }) => (
     <div style={style} key={version}>
-        {Children.map(children, field => 
-        field ? (
-            <div
-                key={field.props.source}
-                style={field.props.style}
-                className={`aor-field aor-field-${field.props.source}`}
-            >
-                {field.props.addLabel ? (
-                    <Labeled
-                        record={record}
-                        resource={resource}
-                        basePath={basePath}
-                        label={field.props.label}
-                        source={field.props.source}
-                        disabled={false}
+        {Children.map(
+            children,
+            field =>
+                field ? (
+                    <div
+                        key={field.props.source}
+                        style={field.props.style}
+                        className={`aor-field aor-field-${field.props.source}`}
                     >
-                        {field}
-                    </Labeled>
-                ) : typeof field.type === 'string' ? (
-                    field
-                ) : (
-                    React.cloneElement(field, {
-                        record,
-                        resource,
-                        basePath,
-                    })
-                )}
-            </div>
-        ) : null
-     )}
+                        {field.props.addLabel ? (
+                            <Labeled
+                                record={record}
+                                resource={resource}
+                                basePath={basePath}
+                                label={field.props.label}
+                                source={field.props.source}
+                                disabled={false}
+                            >
+                                {field}
+                            </Labeled>
+                        ) : typeof field.type === 'string' ? (
+                            field
+                        ) : (
+                            React.cloneElement(field, {
+                                record,
+                                resource,
+                                basePath,
+                            })
+                        )}
+                    </div>
+                ) : null
+        )}
     </div>
 );
 

--- a/src/mui/detail/SimpleShowLayout.js
+++ b/src/mui/detail/SimpleShowLayout.js
@@ -12,7 +12,8 @@ const SimpleShowLayout = ({
     version,
 }) => (
     <div style={style} key={version}>
-        {Children.map(children, field => (
+        {Children.map(children, field => 
+        field ? (
             <div
                 key={field.props.source}
                 style={field.props.style}
@@ -39,7 +40,8 @@ const SimpleShowLayout = ({
                     })
                 )}
             </div>
-        ))}
+        ) : null
+     )}
     </div>
 );
 


### PR DESCRIPTION
Contrary to the DatagridBody, we could not have conditional rendering of fields. This was failing because of a missing check in this file.