### PR TITLE
[RFR] Redirect to correct page after Delete

### DIFF
--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -49,6 +49,8 @@ export default {
         },
         navigation: {
             no_results: 'No results found',
+            no_more_results:
+                'The page number %{page} is now out of boundaries. Try the previous page.',
             page_out_of_boundaries: 'Page number %{page} out of boundaries',
             page_out_from_end: 'Cannot go after last page',
             page_out_from_begin: 'Cannot go before page 1',

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -50,7 +50,7 @@ export default {
         navigation: {
             no_results: 'No results found',
             no_more_results:
-                'The page number %{page} is now out of boundaries. Try the previous page.',
+                'The page number %{page} is out of boundaries. Try the previous page.',
             page_out_of_boundaries: 'Page number %{page} out of boundaries',
             page_out_from_end: 'Cannot go after last page',
             page_out_from_begin: 'Cannot go before page 1',

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -81,11 +81,14 @@ export class List extends Component {
     state = {};
 
     componentDidMount() {
-        const currentPage = this.props.query.page
-            ? parseInt(this.props.query.page, 10)
-            : parseInt(this.props.params.page, 10);
-        if (!this.props.ids.length && currentPage > 1 && this.props.total > 0) {
-            this.setPage(currentPage - 1);
+        if (
+            !this.props.query.page &&
+            !this.props.ids.length &&
+            this.props.params.page > 1 &&
+            this.props.total > 0
+        ) {
+            this.setPage(this.props.params.page - 1);
+            return;
         }
 
         this.updateData();
@@ -110,17 +113,6 @@ export class List extends Component {
         }
         if (nextProps.version !== this.props.version) {
             this.updateData();
-        }
-        const currentPage = nextProps.query.page
-            ? parseInt(nextProps.query.page, 10)
-            : parseInt(nextProps.params.page, 10);
-        if (
-            !nextProps.ids.length &&
-            currentPage > 1 &&
-            nextProps.total > 0 &&
-            nextProps.ids.length !== this.props.ids.length
-        ) {
-            this.setPage(currentPage - 1);
         }
     }
 

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -81,6 +81,13 @@ export class List extends Component {
     state = {};
 
     componentDidMount() {
+        const currentPage = this.props.query.page
+            ? parseInt(this.props.query.page, 10)
+            : parseInt(this.props.params.page, 10);
+        if (!this.props.ids.length && currentPage > 1 && this.props.total > 0) {
+            this.setPage(currentPage - 1);
+        }
+
         this.updateData();
         if (Object.keys(this.props.query).length > 0) {
             this.props.changeListParams(this.props.resource, this.props.query);
@@ -103,6 +110,17 @@ export class List extends Component {
         }
         if (nextProps.version !== this.props.version) {
             this.updateData();
+        }
+        const currentPage = nextProps.query.page
+            ? parseInt(nextProps.query.page, 10)
+            : parseInt(nextProps.params.page, 10);
+        if (
+            !nextProps.ids.length &&
+            currentPage > 1 &&
+            nextProps.total > 0 &&
+            nextProps.ids.length !== this.props.ids.length
+        ) {
+            this.setPage(currentPage - 1);
         }
     }
 
@@ -284,16 +302,16 @@ export class List extends Component {
                                     setSort: this.setSort,
                                 })}
                             {!isLoading &&
-                                !ids.length && (
-                                    <CardText style={styles.noResults}>
-                                        {translate(
-                                            'aor.navigation.no_more_results',
-                                            {
-                                                page: query.page,
-                                            }
-                                        )}
-                                    </CardText>
-                                )}
+                            !ids.length && (
+                                <CardText style={styles.noResults}>
+                                    {translate(
+                                        'aor.navigation.no_more_results',
+                                        {
+                                            page: query.page,
+                                        }
+                                    )}
+                                </CardText>
+                            )}
                             {pagination &&
                                 React.cloneElement(pagination, {
                                     total,

--- a/src/mui/list/List.js
+++ b/src/mui/list/List.js
@@ -1,3 +1,4 @@
+/* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -110,7 +111,8 @@ export class List extends Component {
             nextProps.isLoading === this.props.isLoading &&
             nextProps.width === this.props.width &&
             nextProps.version === this.props.version &&
-            nextState === this.state
+            nextState === this.state &&
+            nextProps.data === this.props.data
         ) {
             return false;
         }
@@ -195,7 +197,7 @@ export class List extends Component {
 
     refresh = () => {
         if (process.env !== 'production') {
-            console.warn( // eslint-disable-line
+            console.warn(
                 'Deprecation warning: The preferred way to refresh the List view is to connect your custom button with redux and dispatch the `refreshView` action.'
             );
         }
@@ -220,6 +222,7 @@ export class List extends Component {
             theme,
             version,
         } = this.props;
+
         const query = this.getQuery();
         const filterValues = query.filter;
         const basePath = this.getBasePath();
@@ -266,7 +269,8 @@ export class List extends Component {
                         })}
                     {isLoading || total > 0 ? (
                         <div key={version}>
-                            {children &&
+                            {ids.length > 0 &&
+                                children &&
                                 React.cloneElement(children, {
                                     resource,
                                     ids,
@@ -279,6 +283,17 @@ export class List extends Component {
                                     isLoading,
                                     setSort: this.setSort,
                                 })}
+                            {!isLoading &&
+                                !ids.length && (
+                                    <CardText style={styles.noResults}>
+                                        {translate(
+                                            'aor.navigation.no_more_results',
+                                            {
+                                                page: query.page,
+                                            }
+                                        )}
+                                    </CardText>
+                                )}
                             {pagination &&
                                 React.cloneElement(pagination, {
                                     total,

--- a/src/mui/list/List.spec.js
+++ b/src/mui/list/List.spec.js
@@ -18,6 +18,8 @@ describe('<List />', () => {
         crudGetList: () => {},
         push: () => {},
         translate: () => {},
+        refreshView: () => {},
+        version: 1,
     };
 
     it('should display a no results text when there is no result', () => {
@@ -42,6 +44,7 @@ describe('<List />', () => {
                 {...defaultProps}
                 translate={x => x}
                 total={1}
+                ids={[1]}
                 changeFormValue={() => true}
                 changeListParams={() => true}
             >
@@ -50,5 +53,24 @@ describe('<List />', () => {
         );
         const textElement = wrapper.find('CardText');
         assert.equal(textElement.length, 0);
+    });
+
+    it('should display a no more results text on an empty paginated page', () => {
+        const wrapper = shallow(
+            <List
+                {...defaultProps}
+                translate={x => x}
+                total={10}
+                ids={[]}
+                page={2}
+                perPage={10}
+                changeFormValue={() => true}
+                changeListParams={() => true}
+            >
+                <div />
+            </List>
+        );
+        const textElement = wrapper.find('CardText').children();
+        assert.equal(textElement.text(), 'aor.navigation.no_more_results');
     });
 });


### PR DESCRIPTION
Fix #1370 

From a paginated list, if user delete the last item of the current page, he is redirected to that same empty page.

This PR allows to redirect to the previous page a paginated list when it is displayed after a redirection caused by aor.

If the empty page is explicitly displayed by the user (i.e. with query params), a warning message will now be displayed.

![capture d ecran de 2018-02-01 08-30-45](https://user-images.githubusercontent.com/547706/35666430-5cb62764-072a-11e8-836c-c90f5857beb0.png)


