### PR TITLE
[RFR] Decoupling allowEmpty prop from reference selectors

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -581,7 +581,7 @@ import { ReferenceInput, SelectInput } from 'admin-on-rest'
 ```
 
 Set the `allowEmpty` prop when you want to add an empty choice with a value of null in the choices list.
-Be careful, disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.html#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
+Disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.html#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
 
 ```jsx
 import { ReferenceInput, SelectInput } from 'admin-on-rest'
@@ -697,7 +697,7 @@ import { ReferenceArrayInput, SelectArrayInput } from 'admin-on-rest'
 ```
 
 Set the `allowEmpty` prop when you want to add an empty choice with a value of null in the choices list.
-Be careful, disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.html#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
+Disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.html#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
 
 ```js
 import { ReferenceArrayInput, SelectArrayInput } from 'admin-on-rest'

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -30,7 +30,7 @@ All input components accept the following attributes:
 
 * `source`: Property name of your entity to view/edit. This attribute is required.
 * `defaultValue`: Value to be set when the property is `null` or `undefined`.
-* `validate`: Validation rules for the current property (see the [Validation Documentation](./CreateEdit.md#validation))
+* `validate`: Validation rules for the current property (see the [Validation Documentation](./CreateEdit.html#validation))
 * `label`: Used as a table header of an input label. Defaults to the `source` when omitted.
 * `style`: A style object to customize the look and feel of the field container (e.g. the `<div>` in a form).
 * `elStyle`: A style object to customize the look and feel of the field element itself
@@ -580,7 +580,8 @@ import { ReferenceInput, SelectInput } from 'admin-on-rest'
 </Admin>
 ```
 
-Set the `allowEmpty` prop when the empty value is allowed.
+Set the `allowEmpty` prop when you want to add an empty choice with a value of null in the choices list.
+Be careful, disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.html#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
 
 ```jsx
 import { ReferenceInput, SelectInput } from 'admin-on-rest'
@@ -695,7 +696,8 @@ import { ReferenceArrayInput, SelectArrayInput } from 'admin-on-rest'
 </Admin>
 ```
 
-Set the `allowEmpty` prop when the empty value is allowed.
+Set the `allowEmpty` prop when you want to add an empty choice with a value of null in the choices list.
+Be careful, disabling `allowEmpty` does not mean that the input will be required. If you want to make the input required, you must add a validator as indicated in [Validation Documentation](./CreateEdit.html#validation). Enabling the `allowEmpty` props just adds an empty choice (with `null` value) on top of the options, and makes the value nullable.
 
 ```js
 import { ReferenceArrayInput, SelectArrayInput } from 'admin-on-rest'

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -254,7 +254,7 @@ export const PostEdit = (props) => (
     <Edit title={<PostTitle />} {...props}>
         <SimpleForm>
             <DisabledInput source="id" />
-            <ReferenceInput label="User" source="userId" reference="users" validate={[required]}>
+            <ReferenceInput label="User" source="userId" reference="users" validate={required}>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="title" />
@@ -266,7 +266,7 @@ export const PostEdit = (props) => (
 export const PostCreate = (props) => (
     <Create {...props}>
         <SimpleForm>
-            <ReferenceInput label="User" source="userId" reference="users" validate={[required]}>
+            <ReferenceInput label="User" source="userId" reference="users" validate={required}>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="title" />

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -249,11 +249,12 @@ const PostTitle = ({ record }) => {
     return <span>Post {record ? `"${record.title}"` : ''}</span>;
 };
 
+const required = value => (value ? undefined : 'Required');
 export const PostEdit = (props) => (
     <Edit title={<PostTitle />} {...props}>
         <SimpleForm>
             <DisabledInput source="id" />
-            <ReferenceInput label="User" source="userId" reference="users">
+            <ReferenceInput label="User" source="userId" reference="users" validate={[required]}>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="title" />
@@ -265,7 +266,7 @@ export const PostEdit = (props) => (
 export const PostCreate = (props) => (
     <Create {...props}>
         <SimpleForm>
-            <ReferenceInput label="User" source="userId" reference="users" allowEmpty>
+            <ReferenceInput label="User" source="userId" reference="users" validate={[required]}>
                 <SelectInput optionText="name" />
             </ReferenceInput>
             <TextInput source="title" />
@@ -281,7 +282,6 @@ If you've understood the `<List>` component, the `<Edit>` and `<Create>` compone
 
 As for the `<ReferenceInput>`, it takes the same props as the `<ReferenceField>` (used earlier in the list page). `<ReferenceInput>` uses these props to fetch the API for possible references related to the current record (in this case, possible `users` for the current `post`). It then passes these possible references to the child component (`<SelectInput>`), which is responsible for displaying them (via their `name` in that case), and letting the user select one. `<SelectInput>` renders as a `<select>` tag in HTML.
 
-**Tip**: The `<Edit>` and the `<Create>` components use the same `<ReferenceInput>` configuration, except for the `allowEmpty` attribute, which is required in `<Create>`.
 
 To use the new `<PostEdit>` and `<PostCreate>` components in the posts resource, just add them as `edit` and `create` attributes in the `<Resource>` component:
 
@@ -341,7 +341,7 @@ import { Filter, ReferenceInput, SelectInput, TextInput } from 'admin-on-rest';
 const PostFilter = (props) => (
     <Filter {...props}>
         <TextInput label="Search" source="q" alwaysOn />
-        <ReferenceInput label="User" source="userId" reference="users" allowEmpty>
+        <ReferenceInput label="User" source="userId" reference="users">
             <SelectInput optionText="name" />
         </ReferenceInput>
     </Filter>

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -229,7 +229,7 @@ An admin interface is about displaying remote data, but also about editing and c
 ```jsx
 // in src/posts.js
 import React from 'react';
-import { List, Edit, Create, Datagrid, ReferenceField, TextField, EditButton, DisabledInput, LongTextInput, ReferenceInput, SelectInput, SimpleForm, TextInput } from 'admin-on-rest';
+import { List, Edit, Create, Datagrid, ReferenceField, TextField, EditButton, DisabledInput, LongTextInput, ReferenceInput, required, SelectInput, SimpleForm, TextInput } from 'admin-on-rest';
 
 export const PostList = (props) => (
     <List {...props}>
@@ -249,7 +249,6 @@ const PostTitle = ({ record }) => {
     return <span>Post {record ? `"${record.title}"` : ''}</span>;
 };
 
-const required = value => (value ? undefined : 'Required');
 export const PostEdit = (props) => (
     <Edit title={<PostTitle />} {...props}>
         <SimpleForm>

--- a/example/comments.js
+++ b/example/comments.js
@@ -162,6 +162,7 @@ export const CommentEdit = props => (
         <SimpleForm>
             <DisabledInput source="id" />
             <ReferenceInput
+                label="Post"
                 source="post_id"
                 reference="posts"
                 perPage={5}
@@ -177,19 +178,20 @@ export const CommentEdit = props => (
 );
 
 const defaultValue = { created_at: new Date() };
+const required = value => (value ? undefined : 'Required');
 export const CommentCreate = props => (
     <Create {...props}>
         <SimpleForm defaultValue={defaultValue}>
             <ReferenceInput
+                label="Post"
                 source="post_id"
                 reference="posts"
-                allowEmpty
-                validation={{ required: true }}
+                validate={[required]}
             >
                 <SelectInput optionText="title" />
             </ReferenceInput>
             <DateInput source="created_at" />
-            <LongTextInput source="body" />
+            <LongTextInput source="body" validate={[required]} />
         </SimpleForm>
     </Create>
 );

--- a/example/comments.js
+++ b/example/comments.js
@@ -19,6 +19,7 @@ import {
     TextField,
     TextInput,
     minLength,
+    required,
     translate,
     Show,
     ShowButton,
@@ -178,7 +179,6 @@ export const CommentEdit = props => (
 );
 
 const defaultValue = { created_at: new Date() };
-const required = value => (value ? undefined : 'Required');
 export const CommentCreate = props => (
     <Create {...props}>
         <SimpleForm defaultValue={defaultValue}>

--- a/example/comments.js
+++ b/example/comments.js
@@ -186,12 +186,12 @@ export const CommentCreate = props => (
                 label="Post"
                 source="post_id"
                 reference="posts"
-                validate={[required]}
+                validate={required}
             >
                 <SelectInput optionText="title" />
             </ReferenceInput>
             <DateInput source="created_at" />
-            <LongTextInput source="body" validate={[required]} />
+            <LongTextInput source="body" validate={required} />
         </SimpleForm>
     </Create>
 );

--- a/example/posts.js
+++ b/example/posts.js
@@ -180,25 +180,27 @@ const PostCreateToolbar = props => (
 
 const getDefaultDate = () => new Date();
 
+const validate = values => {
+    const errors = {};
+    ['title', 'teaser'].forEach(field => {
+        if (!values[field]) {
+            errors[field] = ['Required field'];
+        }
+    });
+
+    if (values.average_note < 0 || values.average_note > 5) {
+        errors.average_note = ['Should be between 0 and 5'];
+    }
+
+    return errors;
+};
+
 export const PostCreate = props => (
     <Create {...props}>
         <SimpleForm
             toolbar={<PostCreateToolbar />}
             defaultValue={{ average_note: 0 }}
-            validate={values => {
-                const errors = {};
-                ['title', 'teaser'].forEach(field => {
-                    if (!values[field]) {
-                        errors[field] = ['Required field'];
-                    }
-                });
-
-                if (values.average_note < 0 || values.average_note > 5) {
-                    errors.average_note = ['Should be between 0 and 5'];
-                }
-
-                return errors;
-            }}
+            validate={validate}
         >
             <TextInput source="title" />
             <TextInput source="password" type="password" />

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -38,6 +38,9 @@ export default {
                 upload_single:
                     'Drop a picture to upload, or click to select it.',
             },
+            references: {
+                missing: 'Unable to find reference data.',
+            },
         },
         message: {
             yes: 'Yes',

--- a/src/i18n/messages.js
+++ b/src/i18n/messages.js
@@ -39,7 +39,11 @@ export default {
                     'Drop a picture to upload, or click to select it.',
             },
             references: {
-                missing: 'Unable to find reference data.',
+                all_missing: 'Unable to find references data.',
+                many_missing:
+                    'At least one of the associated references no longer appears to be available.',
+                single_missing:
+                    'Associated reference no longer appears to be available',
             },
         },
         message: {

--- a/src/mui/input/ReferenceArrayInput.js
+++ b/src/mui/input/ReferenceArrayInput.js
@@ -2,16 +2,15 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
-import LinearProgress from 'material-ui/LinearProgress';
-import TextField from 'material-ui/TextField';
 
-import Labeled from '../input/Labeled';
 import {
     crudGetMany as crudGetManyAction,
     crudGetMatching as crudGetMatchingAction,
 } from '../../actions/dataActions';
 import { getPossibleReferences } from '../../reducer/admin/references/possibleValues';
-import { progessStyle, progessContainerStyle } from './ReferenceInput';
+import ReferenceLoadingProgress from './ReferenceLoadingProgress';
+import ReferenceError from './ReferenceError';
+import translate from '../../i18n/translate';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 
@@ -167,6 +166,7 @@ export class ReferenceArrayInput extends Component {
             onChange,
             children,
             meta,
+            translate,
         } = this.props;
 
         if (React.Children.count(children) !== 1) {
@@ -175,39 +175,26 @@ export class ReferenceArrayInput extends Component {
             );
         }
 
+        const finalLabel =
+            typeof label === 'undefined'
+                ? `resources.${resource}.fields.${source}`
+                : label;
+
         if (matchingReferences === null) {
             return (
-                <Labeled
-                    label={
-                        typeof label === 'undefined' ? (
-                            `resources.${resource}.fields.${source}`
-                        ) : (
-                            label
-                        )
-                    }
-                >
-                    <span style={progessContainerStyle}>
-                        <LinearProgress
-                            mode="indeterminate"
-                            style={progessStyle}
-                        />
-                    </span>
-                </Labeled>
+                <ReferenceLoadingProgress
+                    label={translate(finalLabel, { _: finalLabel })}
+                />
             );
         }
 
         if (matchingReferences.error) {
             return (
-                <TextField
-                    disabled={true}
-                    hintText={
-                        typeof label === 'undefined' ? (
-                            `resources.${resource}.fields.${source}`
-                        ) : (
-                            label
-                        )
-                    }
-                    errorText={matchingReferences.error}
+                <ReferenceError
+                    label={translate(finalLabel, { _: finalLabel })}
+                    error={translate(matchingReferences.error, {
+                        _: matchingReferences.error,
+                    })}
                 />
             );
         }
@@ -255,6 +242,7 @@ ReferenceArrayInput.propTypes = {
         order: PropTypes.oneOf(['ASC', 'DESC']),
     }),
     source: PropTypes.string,
+    translate: PropTypes.func.isRequired,
 };
 
 ReferenceArrayInput.defaultProps = {
@@ -278,13 +266,13 @@ function mapStateToProps(state, props) {
     };
 }
 
-const ConnectedReferenceInput = connect(mapStateToProps, {
+const ConnectedReferenceArrayInput = connect(mapStateToProps, {
     crudGetMany: crudGetManyAction,
     crudGetMatching: crudGetMatchingAction,
 })(ReferenceArrayInput);
 
-ConnectedReferenceInput.defaultProps = {
+ConnectedReferenceArrayInput.defaultProps = {
     addField: true,
 };
 
-export default ConnectedReferenceInput;
+export default translate(ConnectedReferenceArrayInput);

--- a/src/mui/input/ReferenceArrayInput.js
+++ b/src/mui/input/ReferenceArrayInput.js
@@ -2,12 +2,16 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
+import LinearProgress from 'material-ui/LinearProgress';
+import TextField from 'material-ui/TextField';
+
 import Labeled from '../input/Labeled';
 import {
     crudGetMany as crudGetManyAction,
     crudGetMatching as crudGetMatchingAction,
 } from '../../actions/dataActions';
 import { getPossibleReferences } from '../../reducer/admin/references/possibleValues';
+import { progessStyle, progessContainerStyle } from './ReferenceInput';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 
@@ -172,6 +176,43 @@ export class ReferenceArrayInput extends Component {
             );
         }
 
+        if (matchingReferences === null) {
+            return (
+                <Labeled
+                    label={
+                        typeof label === 'undefined' ? (
+                            `resources.${resource}.fields.${source}`
+                        ) : (
+                            label
+                        )
+                    }
+                >
+                    <span style={progessContainerStyle}>
+                        <LinearProgress
+                            mode="indeterminate"
+                            style={progessStyle}
+                        />
+                    </span>
+                </Labeled>
+            );
+        }
+
+        if (matchingReferences.error) {
+            return (
+                <TextField
+                    disabled={true}
+                    hintText={
+                        typeof label === 'undefined' ? (
+                            `resources.${resource}.fields.${source}`
+                        ) : (
+                            label
+                        )
+                    }
+                    errorText={matchingReferences.error}
+                />
+            );
+        }
+
         if (!(referenceRecords && referenceRecords.length > 0) && !allowEmpty) {
             return (
                 <Labeled
@@ -238,7 +279,7 @@ ReferenceArrayInput.defaultProps = {
     allowEmpty: false,
     filter: {},
     filterToQuery: searchText => ({ q: searchText }),
-    matchingReferences: [],
+    matchingReferences: null,
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecords: [],

--- a/src/mui/input/ReferenceArrayInput.js
+++ b/src/mui/input/ReferenceArrayInput.js
@@ -161,7 +161,6 @@ export class ReferenceArrayInput extends Component {
             resource,
             label,
             source,
-            referenceRecords,
             allowEmpty,
             matchingReferences,
             basePath,
@@ -213,22 +212,6 @@ export class ReferenceArrayInput extends Component {
             );
         }
 
-        if (!(referenceRecords && referenceRecords.length > 0) && !allowEmpty) {
-            return (
-                <Labeled
-                    label={
-                        typeof label === 'undefined' ? (
-                            `resources.${resource}.fields.${source}`
-                        ) : (
-                            label
-                        )
-                    }
-                    source={source}
-                    resource={resource}
-                />
-            );
-        }
-
         return React.cloneElement(children, {
             allowEmpty,
             input,
@@ -266,7 +249,6 @@ ReferenceArrayInput.propTypes = {
     onChange: PropTypes.func,
     perPage: PropTypes.number,
     reference: PropTypes.string.isRequired,
-    referenceRecords: PropTypes.array,
     resource: PropTypes.string.isRequired,
     sort: PropTypes.shape({
         field: PropTypes.string,
@@ -282,19 +264,11 @@ ReferenceArrayInput.defaultProps = {
     matchingReferences: null,
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
-    referenceRecords: [],
 };
 
 function mapStateToProps(state, props) {
     const referenceIds = props.input.value || [];
-    const data = state.admin.resources[props.reference].data;
     return {
-        referenceRecords: referenceIds.reduce((references, referenceId) => {
-            if (data[referenceId]) {
-                references.push(data[referenceId]);
-            }
-            return references;
-        }, []),
         matchingReferences: getPossibleReferences(
             state,
             referenceSource(props.resource, props.source),

--- a/src/mui/input/ReferenceArrayInput.js
+++ b/src/mui/input/ReferenceArrayInput.js
@@ -186,6 +186,9 @@ export class ReferenceArrayInput extends Component {
                 : label;
         const translatedLabel = translate(finalLabel, { _: finalLabel });
 
+        // selectedReferencesData can be "empty" (no data was found for references from input.value)
+        // or "incomplete" (Not all of the reference data was found)
+        // or "ready" (all references data was found or there is no references from input.value)
         const selectedReferencesData = getSelectedReferencesStatus(
             input,
             referenceRecords
@@ -215,12 +218,21 @@ export class ReferenceArrayInput extends Component {
             return (
                 <ReferenceError
                     label={translatedLabel}
-                    error={translate('aor.input.references.missing', {
-                        _: 'aor.input.references.missing',
+                    error={translate('aor.input.references.all_missing', {
+                        _: 'aor.input.references.all_missing',
                     })}
                 />
             );
         }
+
+        const childrenError =
+            matchingReferencesError ||
+            (input.value && selectedReferencesData !== 'ready')
+                ? matchingReferencesError ||
+                  translate('aor.input.references.many_missing', {
+                      _: 'aor.input.references.many_missing',
+                  })
+                : null;
 
         return React.cloneElement(children, {
             allowEmpty,
@@ -230,7 +242,11 @@ export class ReferenceArrayInput extends Component {
                     ? `resources.${resource}.fields.${source}`
                     : label,
             resource,
-            meta,
+            meta: {
+                ...meta,
+                error: childrenError,
+                touched: !!childrenError,
+            },
             source,
             choices: Array.isArray(matchingReferences)
                 ? matchingReferences

--- a/src/mui/input/ReferenceArrayInput.js
+++ b/src/mui/input/ReferenceArrayInput.js
@@ -13,10 +13,7 @@ import ReferenceError from './ReferenceError';
 import translate from '../../i18n/translate';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
-const getFinalLabel = (label, resource, source) =>
-    typeof label === 'undefined'
-        ? `resources.${resource}.fields.${source}`
-        : label;
+
 export const getSelectedReferencesStatus = (input, referenceRecords) =>
     !input.value || input.value.length === referenceRecords.length
         ? 'ready'
@@ -234,7 +231,7 @@ export class ReferenceArrayInput extends Component {
         }
 
         const translatedLabel = translate(
-            getFinalLabel(label, resource, source)
+            label || `resources.${resource}.fields.${source}`
         );
 
         const dataStatus = getDataStatus({

--- a/src/mui/input/ReferenceArrayInput.js
+++ b/src/mui/input/ReferenceArrayInput.js
@@ -14,10 +14,15 @@ import translate from '../../i18n/translate';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 
+export const REFERENCES_STATUS_READY = 'REFERENCES_STATUS_READY';
+export const REFERENCES_STATUS_INCOMPLETE = 'REFERENCES_STATUS_INCOMPLETE';
+export const REFERENCES_STATUS_EMPTY = 'REFERENCES_STATUS_EMPTY';
 export const getSelectedReferencesStatus = (input, referenceRecords) =>
     !input.value || input.value.length === referenceRecords.length
-        ? 'ready'
-        : referenceRecords.length > 0 ? 'incomplete' : 'empty';
+        ? REFERENCES_STATUS_READY
+        : referenceRecords.length > 0
+          ? REFERENCES_STATUS_INCOMPLETE
+          : REFERENCES_STATUS_EMPTY;
 
 export const getDataStatus = ({
     input,
@@ -44,19 +49,20 @@ export const getDataStatus = ({
         waiting:
             (!matchingReferences &&
                 input.value &&
-                selectedReferencesData === 'empty') ||
+                selectedReferencesData === REFERENCES_STATUS_EMPTY) ||
             (!matchingReferences && !input.value),
         error:
             matchingReferencesError &&
             (!input.value ||
-                (input.value && selectedReferencesData === 'empty'))
+                (input.value &&
+                    selectedReferencesData === REFERENCES_STATUS_EMPTY))
                 ? translate('aor.input.references.all_missing', {
                       _: 'aor.input.references.all_missing',
                   })
                 : null,
         warning:
             matchingReferencesError ||
-            (input.value && selectedReferencesData !== 'ready')
+            (input.value && selectedReferencesData !== REFERENCES_STATUS_READY)
                 ? matchingReferencesError ||
                   translate('aor.input.references.many_missing', {
                       _: 'aor.input.references.many_missing',
@@ -261,11 +267,13 @@ export class ReferenceArrayInput extends Component {
             input,
             label: translatedLabel,
             resource,
-            meta: {
-                ...meta,
-                error: dataStatus.warning,
-                touched: !!dataStatus.warning,
-            },
+            meta: dataStatus.warning
+                ? {
+                      ...meta,
+                      error: dataStatus.warning,
+                      touched: true,
+                  }
+                : meta,
             source,
             choices: dataStatus.choices,
             basePath,
@@ -336,10 +344,10 @@ function mapStateToProps(state, props) {
 const ConnectedReferenceArrayInput = connect(mapStateToProps, {
     crudGetMany: crudGetManyAction,
     crudGetMatching: crudGetMatchingAction,
-})(ReferenceArrayInput);
+})(translate(ReferenceArrayInput));
 
 ConnectedReferenceArrayInput.defaultProps = {
     addField: true,
 };
 
-export default translate(ConnectedReferenceArrayInput);
+export default ConnectedReferenceArrayInput;

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -15,6 +15,7 @@ describe('<ReferenceArrayInput />', () => {
         matchingReferences: [{ id: 1 }],
         allowEmpty: true,
         translate: x => `*${x}*`,
+        referenceRecords: [],
     };
     const MyComponent = () => <span id="mycomponent" />;
 
@@ -51,6 +52,45 @@ describe('<ReferenceArrayInput />', () => {
         const ErrorElement = wrapper.find('ReferenceError');
         assert.equal(ErrorElement.length, 1);
         assert.equal(ErrorElement.prop('error'), '*fetch error*');
+    });
+
+    it('should display an error if references present in input are not available in state', () => {
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...{
+                    ...defaultProps,
+                    input: { value: [1] },
+                }}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 1);
+        assert.equal(
+            ErrorElement.prop('error'),
+            '*aor.input.references.missing*'
+        );
+    });
+
+    it('should render enclosed component if references present in input are available in state', () => {
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...{
+                    ...defaultProps,
+                    input: { value: [1] },
+                    referenceRecords: [1],
+                }}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
     });
 
     it('should render enclosed component even if the references are empty', () => {

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -138,7 +138,7 @@ describe('Reference Array Input', () => {
             assert.equal(ErrorElement.length, 1);
             assert.equal(
                 ErrorElement.prop('error'),
-                '*aor.input.references.missing*'
+                '*aor.input.references.all_missing*'
             );
         });
 
@@ -161,7 +161,7 @@ describe('Reference Array Input', () => {
             assert.equal(ErrorElement.length, 1);
             assert.equal(
                 ErrorElement.prop('error'),
-                '*aor.input.references.missing*'
+                '*aor.input.references.all_missing*'
             );
         });
 
@@ -183,6 +183,98 @@ describe('Reference Array Input', () => {
             const MyComponentElement = wrapper.find('MyComponent');
             assert.equal(MyComponentElement.length, 1);
             assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 2 }]);
+        });
+
+        it('should send an error to the children if references fetch fails but selected references are not empty', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        input: { value: [1, 2] },
+                        referenceRecords: [{ id: 2 }],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('meta'), {
+                error: '*fetch error*',
+                touched: true,
+            });
+        });
+
+        it('should send an error to the children if references were found and but selected references are not complete', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [],
+                        input: { value: [1, 2] },
+                        referenceRecords: [{ id: 2 }],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('meta'), {
+                error: '*aor.input.references.many_missing*',
+                touched: true,
+            });
+        });
+
+        it('should send an error to the children if references were found and but selected references are empty', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [],
+                        input: { value: [1, 2] },
+                        referenceRecords: [],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('meta'), {
+                error: '*aor.input.references.many_missing*',
+                touched: true,
+            });
+        });
+
+        it('should not send an error to the children if all references were found', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [],
+                        input: { value: [1, 2] },
+                        referenceRecords: [{ id: 1 }, { id: 2 }],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('meta'), {
+                error: null,
+                touched: false,
+            });
         });
 
         it('should render enclosed component if references present in input are available in state', () => {

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -13,7 +13,6 @@ describe('<ReferenceArrayInput />', () => {
         resource: 'posts',
         source: 'tag_ids',
         matchingReferences: [{ id: 1 }],
-        referenceRecord: [{ id: 2 }],
         allowEmpty: true,
     };
     const MyComponent = () => <span id="mycomponent" />;
@@ -52,22 +51,6 @@ describe('<ReferenceArrayInput />', () => {
         assert.equal(ErrorElement.length, 1);
         assert.equal(ErrorElement.prop('disabled'), true);
         assert.equal(ErrorElement.prop('errorText'), 'fetch error');
-    });
-
-    it('should not render anything if there is no referenceRecord and allowEmpty is false', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...{
-                    ...defaultProps,
-                    referenceRecord: [],
-                    allowEmpty: false,
-                }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
     });
 
     it('should render enclosed component even if the references are empty', () => {

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -94,7 +94,7 @@ describe('Reference Array Input', () => {
             );
         });
 
-        it('should claim an error if needed', () => {
+        it('should return an error if needed', () => {
             const test = (data, error, explanation) => {
                 const status = getDataStatus(data);
                 assert.equal(status.waiting, false);
@@ -157,7 +157,7 @@ describe('Reference Array Input', () => {
             );
         });
 
-        it('should claim a warning if needed', () => {
+        it('should return a warning if needed', () => {
             const test = (data, warning, explanation) => {
                 const status = getDataStatus(data);
                 assert.equal(status.waiting, false);
@@ -417,7 +417,7 @@ describe('Reference Array Input', () => {
             });
         });
 
-        it('should send an error to the children if references were found and but selected references are not complete', () => {
+        it('should send an error to the children if references were found but selected references are not complete', () => {
             const wrapper = shallow(
                 <ReferenceArrayInput
                     {...{
@@ -440,7 +440,7 @@ describe('Reference Array Input', () => {
             });
         });
 
-        it('should send an error to the children if references were found and but selected references are empty', () => {
+        it('should send an error to the children if references were found but selected references are empty', () => {
             const wrapper = shallow(
                 <ReferenceArrayInput
                     {...{
@@ -523,7 +523,7 @@ describe('Reference Array Input', () => {
             assert.equal(MyComponentElement.length, 1);
         });
 
-        it('should not render enclosed component if allowEmpty is true', () => {
+        it('should render enclosed component if allowEmpty is true', () => {
             const wrapper = shallow(
                 <ReferenceArrayInput {...defaultProps} allowEmpty>
                     <MyComponent />
@@ -696,7 +696,10 @@ describe('Reference Array Input', () => {
             );
 
             const myComponent = wrapper.find('MyComponent');
-            assert.notEqual(myComponent.prop('meta', undefined));
+            assert.deepEqual(myComponent.prop('meta'), {
+                error: null,
+                touched: false,
+            });
         });
     });
 });

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -2,289 +2,400 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
-import { ReferenceArrayInput } from './ReferenceArrayInput';
+import {
+    getSelectedReferencesStatus,
+    ReferenceArrayInput,
+} from './ReferenceArrayInput';
 
-describe('<ReferenceArrayInput />', () => {
-    const defaultProps = {
-        crudGetMatching: () => true,
-        crudGetMany: () => true,
-        input: {},
-        reference: 'tags',
-        resource: 'posts',
-        source: 'tag_ids',
-        matchingReferences: [{ id: 1 }],
-        allowEmpty: true,
-        translate: x => `*${x}*`,
-        referenceRecords: [],
-    };
-    const MyComponent = () => <span id="mycomponent" />;
+describe('Reference Array Input', () => {
+    describe('<getSelectedReferencesStatus />', () => {
+        it('should return ready if input value has no references', () => {
+            const test = (input, referenceRecords) =>
+                assert.equal(
+                    getSelectedReferencesStatus(input, referenceRecords),
+                    'ready'
+                );
 
-    it('should only render a spinner as long as there are no references fetched', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: null,
-                }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
-        const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
-        assert.equal(SpinnerElement.length, 1);
+            test({}, []);
+            test({ value: null }, []);
+            test({ value: false }, []);
+            test({ value: [] }, []);
+        });
+
+        it('should return empty if there is some input values but the referenceRecords is empty', () => {
+            assert.equal(
+                getSelectedReferencesStatus({ value: [1, 2] }, []),
+                'empty'
+            );
+        });
+
+        it('should return incomplete if there is less data in the referenceRecords than values in the input value', () => {
+            assert.equal(
+                getSelectedReferencesStatus({ value: [1, 2] }, [{ id: 1 }]),
+                'incomplete'
+            );
+        });
+
+        it('should return ready if there is as much data in the referenceRecords as there are values in the input value', () => {
+            assert.equal(
+                getSelectedReferencesStatus({ value: [1, 2] }, [
+                    { id: 1 },
+                    { id: 2 },
+                ]),
+                'ready'
+            );
+        });
     });
+    describe('<ReferenceArrayInput />', () => {
+        const defaultProps = {
+            addField: true,
+            crudGetMatching: () => true,
+            crudGetMany: () => true,
+            input: {},
+            reference: 'tags',
+            resource: 'posts',
+            source: 'tag_ids',
+            matchingReferences: [{ id: 1 }],
+            allowEmpty: true,
+            translate: x => `*${x}*`,
+            referenceRecords: [],
+        };
+        const MyComponent = () => <span id="mycomponent" />;
 
-    it('should display an error in case of references fetch error', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: { error: 'fetch error' },
-                }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 1);
-        assert.equal(ErrorElement.prop('error'), '*fetch error*');
-    });
+        it('should render a spinner as long as there are no references fetched and no selected references', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: null,
+                        input: {},
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
+            assert.equal(SpinnerElement.length, 1);
+        });
 
-    it('should display an error if references present in input are not available in state', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...{
-                    ...defaultProps,
-                    input: { value: [1] },
-                }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 1);
-        assert.equal(
-            ErrorElement.prop('error'),
-            '*aor.input.references.missing*'
-        );
-    });
+        it('should render a spinner as long as there are no references fetched and there are no data found for the references already selected', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: null,
+                        input: { value: [1, 2] },
+                        referenceRecords: [],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
+            assert.equal(SpinnerElement.length, 1);
+        });
 
-    it('should render enclosed component if references present in input are available in state', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...{
-                    ...defaultProps,
-                    input: { value: [1] },
-                    referenceRecords: [1],
-                }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-    });
+        it('should not render a spinner if the references are being searched but data from at least one selected reference was found', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: null,
+                        input: { value: [1, 2] },
+                        referenceRecords: [{ id: 1 }],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
+            assert.equal(SpinnerElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 1 }]);
+        });
 
-    it('should render enclosed component even if the references are empty', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: [],
-                }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
-        assert.equal(SpinnerElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-    });
+        it('should display an error in case of references fetch error and there are no selected reference in the input value', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        input: {},
+                        referenceRecords: [],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 1);
+            assert.equal(
+                ErrorElement.prop('error'),
+                '*aor.input.references.missing*'
+            );
+        });
 
-    it('should not render enclosed component if allowEmpty is true', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput {...defaultProps} allowEmpty>
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-    });
+        it('should display an error in case of references fetch error and there are no data found for the references already selected', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        input: { value: [1] },
+                        referenceRecords: [],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 1);
+            assert.equal(
+                ErrorElement.prop('error'),
+                '*aor.input.references.missing*'
+            );
+        });
 
-    it('should call crudGetMatching on mount with default fetch values', () => {
-        const crudGetMatching = sinon.spy();
-        shallow(
-            <ReferenceArrayInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>,
-            { lifecycleExperimental: true }
-        );
-        assert.deepEqual(crudGetMatching.args[0], [
-            'tags',
-            'posts@tag_ids',
-            {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {},
-        ]);
-    });
+        it('should not display an error in case of references fetch error but data from at least one selected reference was found', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        input: { value: [1, 2] },
+                        referenceRecords: [{ id: 2 }],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 2 }]);
+        });
 
-    it('should allow to customize crudGetMatching arguments with perPage, sort, and filter props', () => {
-        const crudGetMatching = sinon.spy();
-        shallow(
-            <ReferenceArrayInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-                sort={{ field: 'foo', order: 'ASC' }}
-                perPage={5}
-                filter={{ q: 'foo' }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>,
-            { lifecycleExperimental: true }
-        );
-        assert.deepEqual(crudGetMatching.args[0], [
-            'tags',
-            'posts@tag_ids',
-            {
-                page: 1,
-                perPage: 5,
-            },
-            {
-                field: 'foo',
-                order: 'ASC',
-            },
-            {
-                q: 'foo',
-            },
-        ]);
-    });
+        it('should render enclosed component if references present in input are available in state', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        input: { value: [1] },
+                        referenceRecords: [1],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+        });
 
-    it('should call crudGetMatching when setFilter is called', () => {
-        const crudGetMatching = sinon.spy();
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>,
-            { lifecycleExperimental: true }
-        );
-        wrapper.instance().setFilter('bar');
-        assert.deepEqual(crudGetMatching.args[1], [
-            'tags',
-            'posts@tag_ids',
-            {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                q: 'bar',
-            },
-        ]);
-    });
+        it('should render enclosed component even if the references are empty', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
+            assert.equal(SpinnerElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+        });
 
-    it('should use custom filterToQuery function prop', () => {
-        const crudGetMatching = sinon.spy();
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-                filterToQuery={searchText => ({ foo: searchText })}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>,
-            { lifecycleExperimental: true }
-        );
-        wrapper.instance().setFilter('bar');
-        assert.deepEqual(crudGetMatching.args[1], [
-            'tags',
-            'posts@tag_ids',
-            {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                foo: 'bar',
-            },
-        ]);
-    });
+        it('should not render enclosed component if allowEmpty is true', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput {...defaultProps} allowEmpty>
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+        });
 
-    it('should call crudGetMany on mount if value is set', () => {
-        const crudGetMany = sinon.spy();
-        shallow(
-            <ReferenceArrayInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMany={crudGetMany}
-                input={{ value: [5, 6] }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>,
-            { lifecycleExperimental: true }
-        );
-        assert.deepEqual(crudGetMany.args[0], ['tags', [5, 6]]);
-    });
+        it('should call crudGetMatching on mount with default fetch values', () => {
+            const crudGetMatching = sinon.spy();
+            shallow(
+                <ReferenceArrayInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>,
+                { lifecycleExperimental: true }
+            );
+            assert.deepEqual(crudGetMatching.args[0], [
+                'tags',
+                'posts@tag_ids',
+                {
+                    page: 1,
+                    perPage: 25,
+                },
+                {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                {},
+            ]);
+        });
 
-    it('should pass onChange down to child component', () => {
-        const onChange = sinon.spy();
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...defaultProps}
-                allowEmpty
-                onChange={onChange}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
-        wrapper.find('MyComponent').simulate('change', 'foo');
-        assert.deepEqual(onChange.args[0], ['foo']);
-    });
+        it('should allow to customize crudGetMatching arguments with perPage, sort, and filter props', () => {
+            const crudGetMatching = sinon.spy();
+            shallow(
+                <ReferenceArrayInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                    sort={{ field: 'foo', order: 'ASC' }}
+                    perPage={5}
+                    filter={{ q: 'foo' }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>,
+                { lifecycleExperimental: true }
+            );
+            assert.deepEqual(crudGetMatching.args[0], [
+                'tags',
+                'posts@tag_ids',
+                {
+                    page: 1,
+                    perPage: 5,
+                },
+                {
+                    field: 'foo',
+                    order: 'ASC',
+                },
+                {
+                    q: 'foo',
+                },
+            ]);
+        });
 
-    it('should pass meta down to child component', () => {
-        const wrapper = shallow(
-            <ReferenceArrayInput
-                {...defaultProps}
-                allowEmpty
-                meta={{ touched: false }}
-            >
-                <MyComponent />
-            </ReferenceArrayInput>
-        );
+        it('should call crudGetMatching when setFilter is called', () => {
+            const crudGetMatching = sinon.spy();
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>,
+                { lifecycleExperimental: true }
+            );
+            wrapper.instance().setFilter('bar');
+            assert.deepEqual(crudGetMatching.args[1], [
+                'tags',
+                'posts@tag_ids',
+                {
+                    page: 1,
+                    perPage: 25,
+                },
+                {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                {
+                    q: 'bar',
+                },
+            ]);
+        });
 
-        const myComponent = wrapper.find('MyComponent');
-        assert.notEqual(myComponent.prop('meta', undefined));
+        it('should use custom filterToQuery function prop', () => {
+            const crudGetMatching = sinon.spy();
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                    filterToQuery={searchText => ({ foo: searchText })}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>,
+                { lifecycleExperimental: true }
+            );
+            wrapper.instance().setFilter('bar');
+            assert.deepEqual(crudGetMatching.args[1], [
+                'tags',
+                'posts@tag_ids',
+                {
+                    page: 1,
+                    perPage: 25,
+                },
+                {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                {
+                    foo: 'bar',
+                },
+            ]);
+        });
+
+        it('should call crudGetMany on mount if value is set', () => {
+            const crudGetMany = sinon.spy();
+            shallow(
+                <ReferenceArrayInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMany={crudGetMany}
+                    input={{ value: [5, 6] }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>,
+                { lifecycleExperimental: true }
+            );
+            assert.deepEqual(crudGetMany.args[0], ['tags', [5, 6]]);
+        });
+
+        it('should pass onChange down to child component', () => {
+            const onChange = sinon.spy();
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...defaultProps}
+                    allowEmpty
+                    onChange={onChange}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+            wrapper.find('MyComponent').simulate('change', 'foo');
+            assert.deepEqual(onChange.args[0], ['foo']);
+        });
+
+        it('should pass meta down to child component', () => {
+            const wrapper = shallow(
+                <ReferenceArrayInput
+                    {...defaultProps}
+                    allowEmpty
+                    meta={{ touched: false }}
+                >
+                    <MyComponent />
+                </ReferenceArrayInput>
+            );
+
+            const myComponent = wrapper.find('MyComponent');
+            assert.notEqual(myComponent.prop('meta', undefined));
+        });
     });
 });

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -12,17 +12,81 @@ describe('<ReferenceArrayInput />', () => {
         reference: 'tags',
         resource: 'posts',
         source: 'tag_ids',
+        matchingReferences: [{ id: 1 }],
+        referenceRecord: [{ id: 2 }],
+        allowEmpty: true,
     };
     const MyComponent = () => <span id="mycomponent" />;
 
-    it('should not render anything if there is no referenceRecord and allowEmpty is false', () => {
+    it('should only render a spinner as long as there are no references fetched', () => {
         const wrapper = shallow(
-            <ReferenceArrayInput {...defaultProps}>
+            <ReferenceArrayInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: null,
+                }}
+            >
                 <MyComponent />
             </ReferenceArrayInput>
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
+        const SpinnerElement = wrapper.find('LinearProgress');
+        assert.equal(SpinnerElement.length, 1);
+    });
+
+    it('should display an error in case of references fetch error', () => {
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: { error: 'fetch error' },
+                }}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 0);
+        const ErrorElement = wrapper.find('TextField');
+        assert.equal(ErrorElement.length, 1);
+        assert.equal(ErrorElement.prop('disabled'), true);
+        assert.equal(ErrorElement.prop('errorText'), 'fetch error');
+    });
+
+    it('should not render anything if there is no referenceRecord and allowEmpty is false', () => {
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...{
+                    ...defaultProps,
+                    referenceRecord: [],
+                    allowEmpty: false,
+                }}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 0);
+    });
+
+    it('should render enclosed component even if the references are empty', () => {
+        const wrapper = shallow(
+            <ReferenceArrayInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: [],
+                }}
+            >
+                <MyComponent />
+            </ReferenceArrayInput>
+        );
+        const SpinnerElement = wrapper.find('LinearProgress');
+        assert.equal(SpinnerElement.length, 0);
+        const ErrorElement = wrapper.find('TextField');
+        assert.equal(ErrorElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
     });
 
     it('should not render enclosed component if allowEmpty is true', () => {

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -6,6 +6,9 @@ import {
     getSelectedReferencesStatus,
     getDataStatus,
     ReferenceArrayInput,
+    REFERENCES_STATUS_READY,
+    REFERENCES_STATUS_INCOMPLETE,
+    REFERENCES_STATUS_EMPTY,
 } from './ReferenceArrayInput';
 
 describe('Reference Array Input', () => {
@@ -14,7 +17,7 @@ describe('Reference Array Input', () => {
             const test = (input, referenceRecords) =>
                 assert.equal(
                     getSelectedReferencesStatus(input, referenceRecords),
-                    'ready'
+                    REFERENCES_STATUS_READY
                 );
 
             test({}, []);
@@ -26,14 +29,14 @@ describe('Reference Array Input', () => {
         it('should return empty if there is some input values but the referenceRecords is empty', () => {
             assert.equal(
                 getSelectedReferencesStatus({ value: [1, 2] }, []),
-                'empty'
+                REFERENCES_STATUS_EMPTY
             );
         });
 
         it('should return incomplete if there is less data in the referenceRecords than values in the input value', () => {
             assert.equal(
                 getSelectedReferencesStatus({ value: [1, 2] }, [{ id: 1 }]),
-                'incomplete'
+                REFERENCES_STATUS_INCOMPLETE
             );
         });
 
@@ -43,7 +46,7 @@ describe('Reference Array Input', () => {
                     { id: 1 },
                     { id: 2 },
                 ]),
-                'ready'
+                REFERENCES_STATUS_READY
             );
         });
     });
@@ -268,6 +271,7 @@ describe('Reference Array Input', () => {
             allowEmpty: true,
             translate: x => `*${x}*`,
             referenceRecords: [],
+            meta: {},
         };
         const MyComponent = () => <span id="mycomponent" />;
 
@@ -480,10 +484,7 @@ describe('Reference Array Input', () => {
             assert.equal(ErrorElement.length, 0);
             const MyComponentElement = wrapper.find('MyComponent');
             assert.equal(MyComponentElement.length, 1);
-            assert.deepEqual(MyComponentElement.prop('meta'), {
-                error: null,
-                touched: false,
-            });
+            assert.deepEqual(MyComponentElement.prop('meta'), {});
         });
 
         it('should render enclosed component if references present in input are available in state', () => {
@@ -696,10 +697,7 @@ describe('Reference Array Input', () => {
             );
 
             const myComponent = wrapper.find('MyComponent');
-            assert.deepEqual(myComponent.prop('meta'), {
-                error: null,
-                touched: false,
-            });
+            assert.deepEqual(myComponent.prop('meta'), { touched: false });
         });
     });
 });

--- a/src/mui/input/ReferenceArrayInput.spec.js
+++ b/src/mui/input/ReferenceArrayInput.spec.js
@@ -14,6 +14,7 @@ describe('<ReferenceArrayInput />', () => {
         source: 'tag_ids',
         matchingReferences: [{ id: 1 }],
         allowEmpty: true,
+        translate: x => `*${x}*`,
     };
     const MyComponent = () => <span id="mycomponent" />;
 
@@ -30,7 +31,7 @@ describe('<ReferenceArrayInput />', () => {
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
-        const SpinnerElement = wrapper.find('LinearProgress');
+        const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
         assert.equal(SpinnerElement.length, 1);
     });
 
@@ -47,10 +48,9 @@ describe('<ReferenceArrayInput />', () => {
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
-        const ErrorElement = wrapper.find('TextField');
+        const ErrorElement = wrapper.find('ReferenceError');
         assert.equal(ErrorElement.length, 1);
-        assert.equal(ErrorElement.prop('disabled'), true);
-        assert.equal(ErrorElement.prop('errorText'), 'fetch error');
+        assert.equal(ErrorElement.prop('error'), '*fetch error*');
     });
 
     it('should render enclosed component even if the references are empty', () => {
@@ -64,9 +64,9 @@ describe('<ReferenceArrayInput />', () => {
                 <MyComponent />
             </ReferenceArrayInput>
         );
-        const SpinnerElement = wrapper.find('LinearProgress');
+        const SpinnerElement = wrapper.find('ReferenceLoadingProgress');
         assert.equal(SpinnerElement.length, 0);
-        const ErrorElement = wrapper.find('TextField');
+        const ErrorElement = wrapper.find('ReferenceError');
         assert.equal(ErrorElement.length, 0);
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 1);

--- a/src/mui/input/ReferenceError.js
+++ b/src/mui/input/ReferenceError.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextField from 'material-ui/TextField';
+
+const ReferenceError = ({ label, error }) => (
+    <TextField disabled={true} hintText={label} errorText={error} />
+);
+
+ReferenceError.propTypes = {
+    error: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+};
+
+export default ReferenceError;

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -186,17 +186,25 @@ export class ReferenceInput extends Component {
                   })
                 : null;
         const selectedReferenceError =
-            !input.value || (input.value && !referenceRecord)
-                ? translate('aor.input.references.missing', {
-                      _: 'aor.input.references.missing',
+            input.value && !referenceRecord
+                ? translate('aor.input.references.single_missing', {
+                      _: 'aor.input.references.single_missing',
                   })
                 : null;
 
-        if (selectedReferenceError && !matchingReferences) {
+        if (
+            (input.value && selectedReferenceError && !matchingReferences) ||
+            (!input.value && !matchingReferences)
+        ) {
             return <ReferenceLoadingProgress label={translatedLabel} />;
         }
 
-        if (selectedReferenceError && matchingReferencesError) {
+        if (
+            (input.value &&
+                selectedReferenceError &&
+                matchingReferencesError) ||
+            (!input.value && matchingReferencesError)
+        ) {
             return (
                 <ReferenceError
                     label={translatedLabel}
@@ -219,9 +227,15 @@ export class ReferenceInput extends Component {
                     ? `resources.${resource}.fields.${source}`
                     : label,
             resource,
-            meta,
+            meta: {
+                ...meta,
+                error: selectedReferenceError || matchingReferencesError,
+                touched: !!(selectedReferenceError || matchingReferencesError),
+            },
             source,
-            choices: matchingReferences || [referenceRecord],
+            choices: Array.isArray(matchingReferences)
+                ? matchingReferences
+                : [referenceRecord],
             basePath,
             onChange,
             filter: noFilter, // for AutocompleteInput
@@ -229,6 +243,7 @@ export class ReferenceInput extends Component {
             setPagination: this.setPagination,
             setSort: this.setSort,
             translateChoice: false,
+            errorText: 'plop',
         });
     }
 }

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -14,10 +14,6 @@ import translate from '../../i18n/translate';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 const noFilter = () => true;
-const getFinalLabel = (label, resource, source) =>
-    typeof label === 'undefined'
-        ? `resources.${resource}.fields.${source}`
-        : label;
 
 export const getDataStatus = ({
     input,
@@ -216,7 +212,7 @@ export class ReferenceInput extends Component {
         }
 
         const translatedLabel = translate(
-            getFinalLabel(label, resource, source)
+            label || `resources.${resource}.fields.${source}`
         );
         const dataStatus = getDataStatus({
             input,
@@ -257,7 +253,6 @@ export class ReferenceInput extends Component {
             setPagination: this.setPagination,
             setSort: this.setSort,
             translateChoice: false,
-            errorText: 'plop',
         });
     }
 }

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -274,14 +274,11 @@ ReferenceInput.defaultProps = {
     matchingReferences: null,
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
-    referenceRecord: null,
 };
 
 function mapStateToProps(state, props) {
     const referenceId = props.input.value;
     return {
-        referenceRecord:
-            state.admin.resources[props.reference].data[referenceId],
         matchingReferences: getPossibleReferences(
             state,
             referenceSource(props.resource, props.source),

--- a/src/mui/input/ReferenceInput.js
+++ b/src/mui/input/ReferenceInput.js
@@ -239,11 +239,13 @@ export class ReferenceInput extends Component {
             input,
             label: translatedLabel,
             resource,
-            meta: {
-                ...meta,
-                error: dataStatus.warning,
-                touched: !!dataStatus.warning,
-            },
+            meta: dataStatus.warning
+                ? {
+                      ...meta,
+                      error: dataStatus.warning,
+                      touched: true,
+                  }
+                : meta,
             source,
             choices: dataStatus.choices,
             basePath,

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -213,6 +213,7 @@ describe('Reference Input', () => {
             source: 'post_id',
             matchingReferences: [{ id: 1 }],
             translate: x => `*${x}*`,
+            meta: {},
         };
         const MyComponent = () => <span id="mycomponent" />;
 
@@ -466,10 +467,7 @@ describe('Reference Input', () => {
             assert.equal(ErrorElement.length, 0);
             const MyComponentElement = wrapper.find('MyComponent');
             assert.equal(MyComponentElement.length, 1);
-            assert.deepEqual(MyComponentElement.prop('meta'), {
-                error: null,
-                touched: false,
-            });
+            assert.deepEqual(MyComponentElement.prop('meta'), {});
         });
 
         it('should render enclosed component even if the references are empty', () => {

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { ReferenceInput } from './ReferenceInput';
 
-describe.only('<ReferenceInput />', () => {
+describe('<ReferenceInput />', () => {
     const defaultProps = {
         crudGetMatching: () => true,
         crudGetOne: () => true,

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -121,7 +121,7 @@ describe('<ReferenceInput />', () => {
         assert.equal(ErrorElement.length, 1);
         assert.equal(
             ErrorElement.prop('error'),
-            '*aor.input.references.missing*'
+            '*aor.input.references.single_missing*'
         );
     });
 
@@ -190,6 +190,87 @@ describe('<ReferenceInput />', () => {
         assert.equal(ErrorElement.length, 0);
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 1);
+    });
+
+    it('should send an error to the children in case of references fetch error and there selected reference with data', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: { error: 'fetch error' },
+                    referenceRecord: [{ id: 1 }],
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
+        assert.deepEqual(MyComponentElement.prop('meta'), {
+            error: '*fetch error*',
+            touched: true,
+        });
+    });
+
+    it('should send an error to the children if references were found but not the already selected one', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: [],
+                    referenceRecord: null,
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
+        assert.deepEqual(MyComponentElement.prop('meta'), {
+            error: '*aor.input.references.single_missing*',
+            touched: true,
+        });
+    });
+
+    it('should not send an error to the children if all references were found', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: [{ id: 1 }, { id: 2 }],
+                    referenceRecord: { id: 1 },
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
+        assert.deepEqual(MyComponentElement.prop('meta'), {
+            error: null,
+            touched: false,
+        });
     });
 
     it('should render enclosed component even if the references are empty', () => {

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -12,25 +12,61 @@ describe('<ReferenceInput />', () => {
         reference: 'posts',
         resource: 'comments',
         source: 'post_id',
+        matchingReferences: [{ id: 1 }],
     };
     const MyComponent = () => <span id="mycomponent" />;
 
-    it('should not render anything if there is no referenceRecord and allowEmpty is false', () => {
+    it('should only render a spinner as long as there are no references fetched', () => {
         const wrapper = shallow(
-            <ReferenceInput {...defaultProps}>
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: null,
+                }}
+            >
                 <MyComponent />
             </ReferenceInput>
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
+        const SpinnerElement = wrapper.find('LinearProgress');
+        assert.equal(SpinnerElement.length, 1);
     });
 
-    it('should not render enclosed component if allowEmpty is true', () => {
+    it('should display an error in case of references fetch error', () => {
         const wrapper = shallow(
-            <ReferenceInput {...defaultProps} allowEmpty>
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: { error: 'fetch error' },
+                }}
+            >
                 <MyComponent />
             </ReferenceInput>
         );
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 0);
+        const ErrorElement = wrapper.find('TextField');
+        assert.equal(ErrorElement.length, 1);
+        assert.equal(ErrorElement.prop('disabled'), true);
+        assert.equal(ErrorElement.prop('errorText'), 'fetch error');
+    });
+
+    it('should render enclosed component even if the references are empty', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: [],
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const SpinnerElement = wrapper.find('LinearProgress');
+        assert.equal(SpinnerElement.length, 0);
+        const ErrorElement = wrapper.find('TextField');
+        assert.equal(ErrorElement.length, 0);
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 1);
     });

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -2,377 +2,540 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
-import { ReferenceInput } from './ReferenceInput';
+import { getDataStatus, ReferenceInput } from './ReferenceInput';
 
-describe('<ReferenceInput />', () => {
-    const defaultProps = {
-        crudGetMatching: () => true,
-        crudGetOne: () => true,
-        input: {},
-        reference: 'posts',
-        resource: 'comments',
-        source: 'post_id',
-        matchingReferences: [{ id: 1 }],
-        translate: x => `*${x}*`,
-    };
-    const MyComponent = () => <span id="mycomponent" />;
+describe('Reference Input', () => {
+    describe('getDataStatus', () => {
+        const data = {
+            input: {},
+            matchingReferences: null,
+            referenceRecord: null,
+            translate: x => `*${x}*`,
+        };
 
-    it('should render a ReferenceLoadingProgress if the references are being searched and a selected reference does not have data', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: null,
-                    referenceRecord: null,
+        it('should indicate whether the data are ready or not', () => {
+            const test = (data, waiting, explanation) =>
+                assert.equal(getDataStatus(data).waiting, waiting, explanation);
+            test(
+                data,
+                true,
+                'we must wait until the references fetch is finished and there is no reference already associated with the resource.'
+            );
+            test(
+                { ...data, input: { value: 1 } },
+                true,
+                'we must wait until the references fetch is finished and linked reference data are not found.'
+            );
+            test(
+                { ...data, input: { value: 1 }, referenceRecord: [{ id: 1 }] },
+                false,
+                'it is ready if the references fetch is not finished but linked reference data are found.'
+            );
+            test(
+                { ...data, input: { value: 1 }, matchingReferences: [] },
+                false,
+                'it is ready if linked reference data are not found, but the references fetch is finished.'
+            );
+            test(
+                {
+                    ...data,
                     input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 1);
-    });
+                    matchingReferences: { error: 'error' },
+                },
+                false,
+                'it is ready if linked reference data are not found, but the references fetch is finished with error.'
+            );
+        });
 
-    it('should render a ReferenceLoadingProgress if the references are being searched and there is no reference already selected', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: null,
-                    referenceRecord: null,
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 1);
-    });
-
-    it('should not render a ReferenceLoadingProgress if the references are being searched but a selected reference have data', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: null,
-                    referenceRecord: { id: 1 },
+        it('should claim an error if needed', () => {
+            const test = (data, error, explanation) => {
+                const status = getDataStatus(data);
+                assert.equal(status.waiting, false);
+                assert.equal(status.error, error, explanation);
+            };
+            test(
+                {
+                    ...data,
+                    matchingReferences: { error: 'error' },
+                },
+                '*error*',
+                'there is an error if the references fetch fails and there is no linked reference'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: { error: 'error' },
                     input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-        assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 1 }]);
-    });
-
-    it('should not render a ReferenceLoadingProgress if the references were found but a selected reference does not have data', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: [{ id: 2 }],
-                    referenceRecord: null,
+                },
+                '*aor.input.references.single_missing*',
+                'there is an error if the references fetch fails and there is a linked reference without data'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: { error: 'error' },
                     input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-        assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 2 }]);
-    });
-
-    it('should display an error in case of references fetch error and selected reference does not have data', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: { error: 'fetch error' },
-                    referenceRecord: null,
-                    input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 1);
-        assert.equal(
-            ErrorElement.prop('error'),
-            '*aor.input.references.single_missing*'
-        );
-    });
-
-    it('should display an error in case of references fetch error and there is no reference already selected', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: { error: 'fetch error' },
-                    referenceRecord: null,
-                    input: {},
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 1);
-        assert.equal(ErrorElement.prop('error'), '*fetch error*');
-    });
-
-    it('should not display an error in case of references fetch error but selected reference have data', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: { error: 'fetch error' },
-                    referenceRecord: { id: 1 },
-                    input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-    });
-
-    it('should not render an error if the references are empty (but fetched without error) and a selected reference does not have data', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: [],
-                    referenceRecord: null,
-                    input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-    });
-
-    it('should send an error to the children in case of references fetch error and there selected reference with data', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: { error: 'fetch error' },
                     referenceRecord: [{ id: 1 }],
+                },
+                null,
+                'there is no error if the references fetch fails but there is a linked reference with data'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: [{ id: 2 }],
                     input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-        assert.deepEqual(MyComponentElement.prop('meta'), {
-            error: '*fetch error*',
-            touched: true,
-        });
-    });
-
-    it('should send an error to the children if references were found but not the already selected one', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: [],
                     referenceRecord: null,
-                    input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-        assert.deepEqual(MyComponentElement.prop('meta'), {
-            error: '*aor.input.references.single_missing*',
-            touched: true,
-        });
-    });
-
-    it('should not send an error to the children if all references were found', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
-                    matchingReferences: [{ id: 1 }, { id: 2 }],
-                    referenceRecord: { id: 1 },
-                    input: { value: 1 },
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
-        assert.deepEqual(MyComponentElement.prop('meta'), {
-            error: null,
-            touched: false,
-        });
-    });
-
-    it('should render enclosed component even if the references are empty', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...{
-                    ...defaultProps,
+                },
+                null,
+                'there is no error if there is a linked reference without data but the references fetch succeeds'
+            );
+            test(
+                {
+                    ...data,
                     matchingReferences: [],
-                }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-        const ReferenceLoadingProgressElement = wrapper.find(
-            'ReferenceLoadingProgress'
-        );
-        assert.equal(ReferenceLoadingProgressElement.length, 0);
-        const ErrorElement = wrapper.find('ReferenceError');
-        assert.equal(ErrorElement.length, 0);
-        const MyComponentElement = wrapper.find('MyComponent');
-        assert.equal(MyComponentElement.length, 1);
+                    input: { value: 1 },
+                    referenceRecord: null,
+                },
+                null,
+                'there is no error if there is a linked reference without data but the references fetch succeeds  even empty'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: [{ id: 1 }],
+                },
+                null,
+                'there is no error if the references fetch succeeds and there is no linked reference'
+            );
+        });
+
+        it('should claim a warning if needed', () => {
+            const test = (data, warning, explanation) => {
+                const status = getDataStatus(data);
+                assert.equal(status.waiting, false);
+                assert.equal(status.error, null);
+                assert.equal(status.warning, warning, explanation);
+            };
+
+            test(
+                {
+                    ...data,
+                    matchingReferences: { error: 'error on fetch' },
+                    input: { value: 1 },
+                    referenceRecord: [{ id: 1 }],
+                },
+                '*error on fetch*',
+                'there is a warning if the references fetch fails but there is a linked reference with data'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: [{ id: 2 }],
+                    input: { value: 1 },
+                    referenceRecord: null,
+                },
+                '*aor.input.references.single_missing*',
+                'there is a warning if there is a linked reference without data but the references fetch succeeds'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: [],
+                    input: { value: 1 },
+                    referenceRecord: [{ value: 1 }],
+                },
+                null,
+                'there is no warning if there is a linked reference with data and the references fetch succeeds even empty'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: [],
+                },
+                null,
+                'there is no warning if the references fetch succeeds and there is no linked reference'
+            );
+        });
+
+        it('should return choices consistent with the data status', () => {
+            const test = (data, warning, choices, explanation) => {
+                const status = getDataStatus(data);
+                assert.equal(status.waiting, false);
+                assert.equal(status.error, null);
+                assert.equal(status.warning, warning);
+                assert.deepEqual(status.choices, choices, explanation);
+            };
+
+            test(
+                {
+                    ...data,
+                    matchingReferences: { error: 'error on fetch' },
+                    input: { value: 1 },
+                    referenceRecord: { id: 1 },
+                },
+                '*error on fetch*',
+                [{ id: 1 }],
+                'if the references fetch fails the single choice is the linked reference'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: [{ id: 2 }],
+                    input: { value: 1 },
+                    referenceRecord: null,
+                },
+                '*aor.input.references.single_missing*',
+                [{ id: 2 }],
+                'if there is no data for the linked reference, the choices are those returned by fetch'
+            );
+            test(
+                {
+                    ...data,
+                    matchingReferences: [{ id: 1 }, { id: 2 }],
+                    input: { value: 1 },
+                    referenceRecord: { id: 1 },
+                },
+                null,
+                [{ id: 1 }, { id: 2 }],
+                'if there is data for the linked reference and the references fetch succeeds, we use the choices returned by fetch (that will include the linked reference, but this is not managed at getDataStatus method level.)'
+            );
+        });
     });
 
-    it('should call crudGetMatching on mount with default fetch values', () => {
-        const crudGetMatching = sinon.spy();
-        shallow(
-            <ReferenceInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-            >
-                <MyComponent />
-            </ReferenceInput>,
-            { lifecycleExperimental: true }
-        );
-        assert.deepEqual(crudGetMatching.args[0], [
-            'posts',
-            'comments@post_id',
-            {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {},
-        ]);
-    });
+    describe('<ReferenceInput />', () => {
+        const defaultProps = {
+            crudGetMatching: () => true,
+            crudGetOne: () => true,
+            input: {},
+            reference: 'posts',
+            resource: 'comments',
+            source: 'post_id',
+            matchingReferences: [{ id: 1 }],
+            translate: x => `*${x}*`,
+        };
+        const MyComponent = () => <span id="mycomponent" />;
 
-    it('should allow to customize crudGetMatching arguments with perPage, sort, and filter props', () => {
-        const crudGetMatching = sinon.spy();
-        shallow(
-            <ReferenceInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-                sort={{ field: 'foo', order: 'ASC' }}
-                perPage={5}
-                filter={{ q: 'foo' }}
-            >
-                <MyComponent />
-            </ReferenceInput>,
-            { lifecycleExperimental: true }
-        );
-        assert.deepEqual(crudGetMatching.args[0], [
-            'posts',
-            'comments@post_id',
-            {
-                page: 1,
-                perPage: 5,
-            },
-            {
-                field: 'foo',
-                order: 'ASC',
-            },
-            {
-                q: 'foo',
-            },
-        ]);
-    });
+        it('should render a ReferenceLoadingProgress if the references are being searched and a selected reference does not have data', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: null,
+                        referenceRecord: null,
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 1);
+        });
 
-    it('should allow to customize crudGetMatching arguments with perPage, sort, and filter props without loosing original default filter', () => {
-        const crudGetMatching = sinon.spy();
-        const wrapper = shallow(
-            <ReferenceInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-                sort={{ field: 'foo', order: 'ASC' }}
-                perPage={5}
-                filter={{ foo: 'bar' }}
-            >
-                <MyComponent />
-            </ReferenceInput>,
-            { lifecycleExperimental: true }
-        );
+        it('should render a ReferenceLoadingProgress if the references are being searched and there is no reference already selected', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: null,
+                        referenceRecord: null,
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 1);
+        });
 
-        wrapper.instance().setFilter('search_me');
+        it('should not render a ReferenceLoadingProgress if the references are being searched but a selected reference have data', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: null,
+                        referenceRecord: { id: 1 },
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 1 }]);
+        });
 
-        assert(
-            crudGetMatching.calledWith(
+        it('should not render a ReferenceLoadingProgress if the references were found but a selected reference does not have data', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [{ id: 2 }],
+                        referenceRecord: null,
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 2 }]);
+        });
+
+        it('should display an error in case of references fetch error and selected reference does not have data', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        referenceRecord: null,
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 1);
+            assert.equal(
+                ErrorElement.prop('error'),
+                '*aor.input.references.single_missing*'
+            );
+        });
+
+        it('should display an error in case of references fetch error and there is no reference already selected', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        referenceRecord: null,
+                        input: {},
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 1);
+            assert.equal(ErrorElement.prop('error'), '*fetch error*');
+        });
+
+        it('should not display an error in case of references fetch error but selected reference have data', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        referenceRecord: { id: 1 },
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+        });
+
+        it('should not render an error if the references are empty (but fetched without error) and a selected reference does not have data', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [],
+                        referenceRecord: null,
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+        });
+
+        it('should send an error to the children in case of references fetch error and there selected reference with data', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: { error: 'fetch error' },
+                        referenceRecord: [{ id: 1 }],
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('meta'), {
+                error: '*fetch error*',
+                touched: true,
+            });
+        });
+
+        it('should send an error to the children if references were found but not the already selected one', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [],
+                        referenceRecord: null,
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('meta'), {
+                error: '*aor.input.references.single_missing*',
+                touched: true,
+            });
+        });
+
+        it('should not send an error to the children if all references were found', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [{ id: 1 }, { id: 2 }],
+                        referenceRecord: { id: 1 },
+                        input: { value: 1 },
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+            assert.deepEqual(MyComponentElement.prop('meta'), {
+                error: null,
+                touched: false,
+            });
+        });
+
+        it('should render enclosed component even if the references are empty', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...{
+                        ...defaultProps,
+                        matchingReferences: [],
+                    }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            const ReferenceLoadingProgressElement = wrapper.find(
+                'ReferenceLoadingProgress'
+            );
+            assert.equal(ReferenceLoadingProgressElement.length, 0);
+            const ErrorElement = wrapper.find('ReferenceError');
+            assert.equal(ErrorElement.length, 0);
+            const MyComponentElement = wrapper.find('MyComponent');
+            assert.equal(MyComponentElement.length, 1);
+        });
+
+        it('should call crudGetMatching on mount with default fetch values', () => {
+            const crudGetMatching = sinon.spy();
+            shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                >
+                    <MyComponent />
+                </ReferenceInput>,
+                { lifecycleExperimental: true }
+            );
+            assert.deepEqual(crudGetMatching.args[0], [
+                'posts',
+                'comments@post_id',
+                {
+                    page: 1,
+                    perPage: 25,
+                },
+                {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                {},
+            ]);
+        });
+
+        it('should allow to customize crudGetMatching arguments with perPage, sort, and filter props', () => {
+            const crudGetMatching = sinon.spy();
+            shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                    sort={{ field: 'foo', order: 'ASC' }}
+                    perPage={5}
+                    filter={{ q: 'foo' }}
+                >
+                    <MyComponent />
+                </ReferenceInput>,
+                { lifecycleExperimental: true }
+            );
+            assert.deepEqual(crudGetMatching.args[0], [
                 'posts',
                 'comments@post_id',
                 {
@@ -384,113 +547,154 @@ describe('<ReferenceInput />', () => {
                     order: 'ASC',
                 },
                 {
+                    q: 'foo',
+                },
+            ]);
+        });
+
+        it('should allow to customize crudGetMatching arguments with perPage, sort, and filter props without loosing original default filter', () => {
+            const crudGetMatching = sinon.spy();
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                    sort={{ field: 'foo', order: 'ASC' }}
+                    perPage={5}
+                    filter={{ foo: 'bar' }}
+                >
+                    <MyComponent />
+                </ReferenceInput>,
+                { lifecycleExperimental: true }
+            );
+
+            wrapper.instance().setFilter('search_me');
+
+            assert(
+                crudGetMatching.calledWith(
+                    'posts',
+                    'comments@post_id',
+                    {
+                        page: 1,
+                        perPage: 5,
+                    },
+                    {
+                        field: 'foo',
+                        order: 'ASC',
+                    },
+                    {
+                        foo: 'bar',
+                        q: 'search_me',
+                    }
+                )
+            );
+        });
+
+        it('should call crudGetMatching when setFilter is called', () => {
+            const crudGetMatching = sinon.spy();
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                >
+                    <MyComponent />
+                </ReferenceInput>,
+                { lifecycleExperimental: true }
+            );
+            wrapper.instance().setFilter('bar');
+            assert.deepEqual(crudGetMatching.args[1], [
+                'posts',
+                'comments@post_id',
+                {
+                    page: 1,
+                    perPage: 25,
+                },
+                {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                {
+                    q: 'bar',
+                },
+            ]);
+        });
+
+        it('should use custom filterToQuery function prop', () => {
+            const crudGetMatching = sinon.spy();
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetMatching={crudGetMatching}
+                    filterToQuery={searchText => ({ foo: searchText })}
+                >
+                    <MyComponent />
+                </ReferenceInput>,
+                { lifecycleExperimental: true }
+            );
+            wrapper.instance().setFilter('bar');
+            assert.deepEqual(crudGetMatching.args[1], [
+                'posts',
+                'comments@post_id',
+                {
+                    page: 1,
+                    perPage: 25,
+                },
+                {
+                    field: 'id',
+                    order: 'DESC',
+                },
+                {
                     foo: 'bar',
-                    q: 'search_me',
-                }
-            )
-        );
-    });
+                },
+            ]);
+        });
 
-    it('should call crudGetMatching when setFilter is called', () => {
-        const crudGetMatching = sinon.spy();
-        const wrapper = shallow(
-            <ReferenceInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-            >
-                <MyComponent />
-            </ReferenceInput>,
-            { lifecycleExperimental: true }
-        );
-        wrapper.instance().setFilter('bar');
-        assert.deepEqual(crudGetMatching.args[1], [
-            'posts',
-            'comments@post_id',
-            {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                q: 'bar',
-            },
-        ]);
-    });
+        it('should call crudGetOne on mount if value is set', () => {
+            const crudGetOne = sinon.spy();
+            shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    crudGetOne={crudGetOne}
+                    input={{ value: 5 }}
+                >
+                    <MyComponent />
+                </ReferenceInput>,
+                { lifecycleExperimental: true }
+            );
+            assert.deepEqual(crudGetOne.args[0], ['posts', 5, null, false]);
+        });
 
-    it('should use custom filterToQuery function prop', () => {
-        const crudGetMatching = sinon.spy();
-        const wrapper = shallow(
-            <ReferenceInput
-                {...defaultProps}
-                allowEmpty
-                crudGetMatching={crudGetMatching}
-                filterToQuery={searchText => ({ foo: searchText })}
-            >
-                <MyComponent />
-            </ReferenceInput>,
-            { lifecycleExperimental: true }
-        );
-        wrapper.instance().setFilter('bar');
-        assert.deepEqual(crudGetMatching.args[1], [
-            'posts',
-            'comments@post_id',
-            {
-                page: 1,
-                perPage: 25,
-            },
-            {
-                field: 'id',
-                order: 'DESC',
-            },
-            {
-                foo: 'bar',
-            },
-        ]);
-    });
+        it('should pass onChange down to child component', () => {
+            const onChange = sinon.spy();
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    onChange={onChange}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
+            wrapper.find('MyComponent').simulate('change', 'foo');
+            assert.deepEqual(onChange.args[0], ['foo']);
+        });
 
-    it('should call crudGetOne on mount if value is set', () => {
-        const crudGetOne = sinon.spy();
-        shallow(
-            <ReferenceInput
-                {...defaultProps}
-                allowEmpty
-                crudGetOne={crudGetOne}
-                input={{ value: 5 }}
-            >
-                <MyComponent />
-            </ReferenceInput>,
-            { lifecycleExperimental: true }
-        );
-        assert.deepEqual(crudGetOne.args[0], ['posts', 5, null, false]);
-    });
+        it('should pass meta down to child component', () => {
+            const wrapper = shallow(
+                <ReferenceInput
+                    {...defaultProps}
+                    allowEmpty
+                    meta={{ touched: false }}
+                >
+                    <MyComponent />
+                </ReferenceInput>
+            );
 
-    it('should pass onChange down to child component', () => {
-        const onChange = sinon.spy();
-        const wrapper = shallow(
-            <ReferenceInput {...defaultProps} allowEmpty onChange={onChange}>
-                <MyComponent />
-            </ReferenceInput>
-        );
-        wrapper.find('MyComponent').simulate('change', 'foo');
-        assert.deepEqual(onChange.args[0], ['foo']);
-    });
-
-    it('should pass meta down to child component', () => {
-        const wrapper = shallow(
-            <ReferenceInput
-                {...defaultProps}
-                allowEmpty
-                meta={{ touched: false }}
-            >
-                <MyComponent />
-            </ReferenceInput>
-        );
-
-        const myComponent = wrapper.find('MyComponent');
-        assert.notEqual(myComponent.prop('meta', undefined));
+            const myComponent = wrapper.find('MyComponent');
+            assert.notEqual(myComponent.prop('meta', undefined));
+        });
     });
 });

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -13,10 +13,11 @@ describe('<ReferenceInput />', () => {
         resource: 'comments',
         source: 'post_id',
         matchingReferences: [{ id: 1 }],
+        translate: x => `*${x}*`,
     };
     const MyComponent = () => <span id="mycomponent" />;
 
-    it('should only render a spinner as long as there are no references fetched', () => {
+    it('should only render a ReferenceLoadingProgress as long as there are no references fetched', () => {
         const wrapper = shallow(
             <ReferenceInput
                 {...{
@@ -29,8 +30,10 @@ describe('<ReferenceInput />', () => {
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
-        const SpinnerElement = wrapper.find('LinearProgress');
-        assert.equal(SpinnerElement.length, 1);
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 1);
     });
 
     it('should display an error in case of references fetch error', () => {
@@ -46,10 +49,9 @@ describe('<ReferenceInput />', () => {
         );
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 0);
-        const ErrorElement = wrapper.find('TextField');
+        const ErrorElement = wrapper.find('ReferenceError');
         assert.equal(ErrorElement.length, 1);
-        assert.equal(ErrorElement.prop('disabled'), true);
-        assert.equal(ErrorElement.prop('errorText'), 'fetch error');
+        assert.equal(ErrorElement.prop('error'), '*fetch error*');
     });
 
     it('should render enclosed component even if the references are empty', () => {
@@ -63,9 +65,11 @@ describe('<ReferenceInput />', () => {
                 <MyComponent />
             </ReferenceInput>
         );
-        const SpinnerElement = wrapper.find('LinearProgress');
-        assert.equal(SpinnerElement.length, 0);
-        const ErrorElement = wrapper.find('TextField');
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
         assert.equal(ErrorElement.length, 0);
         const MyComponentElement = wrapper.find('MyComponent');
         assert.equal(MyComponentElement.length, 1);

--- a/src/mui/input/ReferenceInput.spec.js
+++ b/src/mui/input/ReferenceInput.spec.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { ReferenceInput } from './ReferenceInput';
 
-describe('<ReferenceInput />', () => {
+describe.only('<ReferenceInput />', () => {
     const defaultProps = {
         crudGetMatching: () => true,
         crudGetOne: () => true,
@@ -17,12 +17,14 @@ describe('<ReferenceInput />', () => {
     };
     const MyComponent = () => <span id="mycomponent" />;
 
-    it('should only render a ReferenceLoadingProgress as long as there are no references fetched', () => {
+    it('should render a ReferenceLoadingProgress if the references are being searched and a selected reference does not have data', () => {
         const wrapper = shallow(
             <ReferenceInput
                 {...{
                     ...defaultProps,
                     matchingReferences: null,
+                    referenceRecord: null,
+                    input: { value: 1 },
                 }}
             >
                 <MyComponent />
@@ -36,12 +38,101 @@ describe('<ReferenceInput />', () => {
         assert.equal(ReferenceLoadingProgressElement.length, 1);
     });
 
-    it('should display an error in case of references fetch error', () => {
+    it('should render a ReferenceLoadingProgress if the references are being searched and there is no reference already selected', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: null,
+                    referenceRecord: null,
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 0);
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 1);
+    });
+
+    it('should not render a ReferenceLoadingProgress if the references are being searched but a selected reference have data', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: null,
+                    referenceRecord: { id: 1 },
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
+        assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 1 }]);
+    });
+
+    it('should not render a ReferenceLoadingProgress if the references were found but a selected reference does not have data', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: [{ id: 2 }],
+                    referenceRecord: null,
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
+        assert.deepEqual(MyComponentElement.prop('choices'), [{ id: 2 }]);
+    });
+
+    it('should display an error in case of references fetch error and selected reference does not have data', () => {
         const wrapper = shallow(
             <ReferenceInput
                 {...{
                     ...defaultProps,
                     matchingReferences: { error: 'fetch error' },
+                    referenceRecord: null,
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 1);
+        assert.equal(
+            ErrorElement.prop('error'),
+            '*aor.input.references.missing*'
+        );
+    });
+
+    it('should display an error in case of references fetch error and there is no reference already selected', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: { error: 'fetch error' },
+                    referenceRecord: null,
+                    input: {},
                 }}
             >
                 <MyComponent />
@@ -52,6 +143,53 @@ describe('<ReferenceInput />', () => {
         const ErrorElement = wrapper.find('ReferenceError');
         assert.equal(ErrorElement.length, 1);
         assert.equal(ErrorElement.prop('error'), '*fetch error*');
+    });
+
+    it('should not display an error in case of references fetch error but selected reference have data', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: { error: 'fetch error' },
+                    referenceRecord: { id: 1 },
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
+    });
+
+    it('should not render an error if the references are empty (but fetched without error) and a selected reference does not have data', () => {
+        const wrapper = shallow(
+            <ReferenceInput
+                {...{
+                    ...defaultProps,
+                    matchingReferences: [],
+                    referenceRecord: null,
+                    input: { value: 1 },
+                }}
+            >
+                <MyComponent />
+            </ReferenceInput>
+        );
+        const ReferenceLoadingProgressElement = wrapper.find(
+            'ReferenceLoadingProgress'
+        );
+        assert.equal(ReferenceLoadingProgressElement.length, 0);
+        const ErrorElement = wrapper.find('ReferenceError');
+        assert.equal(ErrorElement.length, 0);
+        const MyComponentElement = wrapper.find('MyComponent');
+        assert.equal(MyComponentElement.length, 1);
     });
 
     it('should render enclosed component even if the references are empty', () => {

--- a/src/mui/input/ReferenceLoadingProgress.js
+++ b/src/mui/input/ReferenceLoadingProgress.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import LinearProgress from 'material-ui/LinearProgress';
+
+import Labeled from './Labeled';
+
+const progessContainerStyle = {
+    padding: '2em 0',
+    height: 'auto',
+};
+const progessStyle = {
+    width: '16em',
+    margin: '1em 0',
+};
+
+const ReferenceLoadingProgress = ({ label }) => (
+    <Labeled label={label}>
+        <span style={progessContainerStyle}>
+            <LinearProgress mode="indeterminate" style={progessStyle} />
+        </span>
+    </Labeled>
+);
+
+ReferenceLoadingProgress.propTypes = {
+    label: PropTypes.string.isRequired,
+};
+
+export default ReferenceLoadingProgress;

--- a/src/reducer/admin/references/possibleValues.js
+++ b/src/reducer/admin/references/possibleValues.js
@@ -1,4 +1,7 @@
-import { CRUD_GET_MATCHING_SUCCESS } from '../../../actions/dataActions';
+import {
+    CRUD_GET_MATCHING_SUCCESS,
+    CRUD_GET_MATCHING_FAILURE,
+} from '../../../actions/dataActions';
 
 const initialState = {};
 
@@ -8,6 +11,11 @@ export default (previousState = initialState, { type, payload, meta }) => {
             return {
                 ...previousState,
                 [meta.relatedTo]: payload.data.map(record => record.id),
+            };
+        case CRUD_GET_MATCHING_FAILURE:
+            return {
+                ...previousState,
+                [meta.relatedTo]: { error: payload.error },
             };
         default:
             return previousState;
@@ -20,17 +28,23 @@ export const getPossibleReferences = (
     reference,
     selectedIds = []
 ) => {
-    const possibleValues = state.admin.references.possibleValues[
-        referenceSource
-    ]
-        ? Array.from(state.admin.references.possibleValues[referenceSource])
-        : [];
+    if (!state.admin.references.possibleValues[referenceSource]) {
+        return null;
+    }
+
+    if (state.admin.references.possibleValues[referenceSource].error) {
+        return state.admin.references.possibleValues[referenceSource];
+    }
+
+    const possibleValues = Array.from(
+        state.admin.references.possibleValues[referenceSource]
+    );
+
     selectedIds.forEach(
         id =>
             possibleValues.some(value => value == id) ||
             possibleValues.unshift(id)
     );
-
     return possibleValues
         .map(id => state.admin.resources[reference].data[id])
         .filter(r => typeof r !== 'undefined');

--- a/src/reducer/admin/references/possibleValues.spec.js
+++ b/src/reducer/admin/references/possibleValues.spec.js
@@ -1,0 +1,98 @@
+import assert from 'assert';
+
+import { getPossibleReferences } from './possibleValues';
+
+describe('possibleValues', () => {
+    describe('getPossibleReferences', () => {
+        const state = {
+            admin: {
+                references: {
+                    possibleValues: {
+                        'ressourceInError@source': { error: 'error message' },
+                        'ressourceEmpty@source': [],
+                        'ressource@source': [1, 2, 4],
+                    },
+                },
+                resources: {
+                    objects: {
+                        data: {
+                            1: { name: 'object name 1' },
+                            2: { name: 'object name 2' },
+                            3: { name: 'object name 3' },
+                            4: { name: 'object name 4' },
+                            5: { name: 'object name 5' },
+                        },
+                    },
+                },
+            },
+        };
+        it('should return null if there is no referenceSource available in state', () => {
+            const possibleReferences = getPossibleReferences(
+                state,
+                'missingRessource@source',
+                'objects'
+            );
+            assert.equal(possibleReferences, null);
+        });
+
+        it('should return an object with error if the referenceSource in state is an error', () => {
+            const possibleReferences = getPossibleReferences(
+                state,
+                'ressourceInError@source',
+                'objects'
+            );
+            assert.deepEqual(possibleReferences, { error: 'error message' });
+        });
+
+        it('should return a empty array if the referenceSource in state is empty', () => {
+            const possibleReferences = getPossibleReferences(
+                state,
+                'ressourceEmpty@source',
+                'objects'
+            );
+            assert.deepEqual(possibleReferences, []);
+        });
+
+        it('should return all formated referenceSource in state if selectedIds param is not set', () => {
+            const possibleReferences = getPossibleReferences(
+                state,
+                'ressource@source',
+                'objects'
+            );
+            assert.deepEqual(possibleReferences, [
+                { name: 'object name 1' },
+                { name: 'object name 2' },
+                { name: 'object name 4' },
+            ]);
+        });
+
+        it('should return all formated referenceSource in state if selectedIds param is an empty array', () => {
+            const possibleReferences = getPossibleReferences(
+                state,
+                'ressource@source',
+                'objects',
+                []
+            );
+            assert.deepEqual(possibleReferences, [
+                { name: 'object name 1' },
+                { name: 'object name 2' },
+                { name: 'object name 4' },
+            ]);
+        });
+
+        it("should add selectedIds to the formated referenceSource in state if it's not already in", () => {
+            const possibleReferences = getPossibleReferences(
+                state,
+                'ressource@source',
+                'objects',
+                [1, 5]
+            );
+            assert.deepEqual(possibleReferences, [
+                { name: 'object name 5' },
+                { name: 'object name 1' },
+                { name: 'object name 2' },
+                { name: 'object name 4' },
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
Fix #953 
Fix #1153 

`allowEmpty` should only be used to add or not an empty choice in the choices list, with a value of null.
It must not interfere with the fetch of references.

The reference selectors must indicate either that the reference fetch is in progress, that the reference fetch has failed, or display the *choice component* with choices based on the fetched references.

### todo
- [x] Display of a spinner during references fetch
![fetchok](https://user-images.githubusercontent.com/547706/35847513-f6b23512-0b1a-11e8-9420-73cdab32cb30.gif)

- [x] Display fetch error if it exists
![fetchko](https://user-images.githubusercontent.com/547706/35847559-113381de-0b1b-11e8-8692-479e78ffdb77.gif)


- [x] Render children component after fetch with allowEmpty prop binded
- [x] Update documentation about `allowEmpty`
