### PR TITLE
Add 'options' to DisabledInput too

### DIFF
--- a/src/mui/input/DisabledInput.js
+++ b/src/mui/input/DisabledInput.js
@@ -9,6 +9,7 @@ const DisabledInput = ({
     resource,
     source,
     elStyle,
+    options,
 }) => (
     <TextField
         value={value}
@@ -17,6 +18,7 @@ const DisabledInput = ({
         }
         style={elStyle}
         disabled
+        {...options}
     />
 );
 


### PR DESCRIPTION
I needed to use the following code to stretch the field in full width and I could not.

````
                    options={{
                       fullWidth: true,
                     }}
````