### PR TITLE
[RFR] Refactor reference selectors

### DIFF
--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.js
@@ -34,6 +34,7 @@ const sanitizeRestProps = ({
     optionText,
     optionValue,
     record,
+    referenceSource,
     resource,
     allowEmpty,
     source,
@@ -175,9 +176,16 @@ export class ReferenceArrayInput extends Component {
         }
     };
 
-    fetchOptions = ({ reference, source, resource } = this.props) => {
+    fetchOptions = (props = this.props) => {
+        const {
+            crudGetMatching,
+            reference,
+            source,
+            resource,
+            referenceSource,
+        } = props;
         const { pagination, sort, filter } = this.params;
-        this.props.crudGetMatching(
+        crudGetMatching(
             reference,
             referenceSource(resource, source),
             pagination,
@@ -273,6 +281,7 @@ ReferenceArrayInput.propTypes = {
     perPage: PropTypes.number,
     reference: PropTypes.string.isRequired,
     referenceRecords: PropTypes.array,
+    referenceSource: PropTypes.func.isRequired,
     resource: PropTypes.string.isRequired,
     sort: PropTypes.shape({
         field: PropTypes.string,
@@ -289,13 +298,13 @@ ReferenceArrayInput.defaultProps = {
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecords: [],
+    referenceSource,
 };
 
 const mapStateToProps = createSelector(
     (_, { input: { value: referenceIds } }) => referenceIds || [],
     getReferenceResource,
-    (state, { resource, source }) =>
-        getPossibleReferenceValues(state, referenceSource(resource, source)),
+    getPossibleReferenceValues,
     (inputIds, referenceState, possibleValues) => ({
         referenceRecords:
             referenceState &&

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.js
@@ -17,6 +17,8 @@ import {
     getReferenceResource,
 } from '../../reducer';
 
+const referenceSource = (resource, source) => `${resource}@${source}`;
+
 const sanitizeRestProps = ({
     alwaysOn,
     basePath,
@@ -297,6 +299,7 @@ ReferenceArrayInput.defaultProps = {
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecords: [],
+    referenceSource, // used in unit tests
 };
 
 const makeMapStateToProps = () =>
@@ -332,7 +335,7 @@ const ConnectedReferenceArrayInput = compose(
 )(ReferenceArrayInput);
 
 ConnectedReferenceArrayInput.defaultProps = {
-    referenceSource: (resource, source) => `${resource}@${source}`,
+    referenceSource, // used in real apps
 };
 
 export default ConnectedReferenceArrayInput;

--- a/packages/react-admin/src/mui/input/ReferenceArrayInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceArrayInput.js
@@ -14,8 +14,8 @@ import {
 import {
     getPossibleReferences,
     getPossibleReferenceValues,
-    getResource,
-} from '../../reducer/admin';
+    getReferenceResource,
+} from '../../reducer';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 
@@ -290,9 +290,10 @@ ReferenceArrayInput.defaultProps = {
     sort: { field: 'id', order: 'DESC' },
     referenceRecords: [],
 };
+
 const mapStateToProps = createSelector(
     (_, { input: { value: referenceIds } }) => referenceIds || [],
-    (state, { reference }) => getResource(state, reference),
+    getReferenceResource,
     (state, { resource, source }) =>
         getPossibleReferenceValues(state, referenceSource(resource, source)),
     (inputIds, referenceState, possibleValues) => ({

--- a/packages/react-admin/src/mui/input/ReferenceInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.js
@@ -15,8 +15,8 @@ import {
 import {
     getPossibleReferences,
     getPossibleReferenceValues,
-    getResource,
-} from '../../reducer/';
+    getReferenceResource,
+} from '../../reducer';
 
 const referenceSource = (resource, source) => `${resource}@${source}`;
 
@@ -306,7 +306,7 @@ ReferenceInput.defaultProps = {
 
 const mapStateToProps = createSelector(
     (_, props) => props.input.value,
-    (state, { reference }) => getResource(state, reference),
+    getReferenceResource,
     (state, { resource, source }) =>
         getPossibleReferenceValues(state, referenceSource(resource, source)),
     (inputId, referenceState, possibleValues) => ({

--- a/packages/react-admin/src/mui/input/ReferenceInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.js
@@ -15,6 +15,8 @@ import {
     getReferenceResource,
 } from '../../reducer';
 
+const referenceSource = (resource, source) => `${resource}@${source}`;
+
 const sanitizeRestProps = ({
     allowEmpty,
     basePath,
@@ -306,6 +308,7 @@ ReferenceInput.defaultProps = {
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecord: null,
+    referenceSource, // used in tests
 };
 
 const makeMapStateToProps = () =>
@@ -334,7 +337,7 @@ const ConnectedReferenceInput = compose(
 )(ReferenceInput);
 
 ConnectedReferenceInput.defaultProps = {
-    referenceSource: (resource, source) => `${resource}@${source}`,
+    referenceSource, // used in real apps
 };
 
 export default ConnectedReferenceInput;

--- a/packages/react-admin/src/mui/input/ReferenceInput.js
+++ b/packages/react-admin/src/mui/input/ReferenceInput.js
@@ -45,6 +45,7 @@ const sanitizeRestProps = ({
     perPage,
     record,
     reference,
+    referenceSource,
     resource,
     setFilter,
     setPagination,
@@ -186,23 +187,29 @@ export class ReferenceInput extends Component {
         }
     };
 
-    fetchOptions = ({ reference, source, resource } = this.props) => {
-        const { filter: filterFromProps } = this.props;
+    fetchOptions = (props = this.props) => {
+        const {
+            crudGetMatching,
+            filter: filterFromProps,
+            reference,
+            referenceSource,
+            resource,
+            source,
+        } = props;
         const { pagination, sort, filter } = this.params;
 
-        const finalFilter = { ...filterFromProps, ...filter };
-        this.props.crudGetMatching(
+        crudGetMatching(
             reference,
             referenceSource(resource, source),
             pagination,
             sort,
-            finalFilter
+            { ...filterFromProps, ...filter }
         );
     };
 
-    fetchReferenceAndOptions(nextProps) {
-        this.fetchReference(nextProps);
-        this.fetchOptions(nextProps);
+    fetchReferenceAndOptions(props) {
+        this.fetchReference(props);
+        this.fetchOptions(props);
     }
 
     render() {
@@ -286,6 +293,7 @@ ReferenceInput.propTypes = {
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
+    referenceSource: PropTypes.func.isRequired,
     resource: PropTypes.string.isRequired,
     sort: PropTypes.shape({
         field: PropTypes.string,
@@ -302,13 +310,13 @@ ReferenceInput.defaultProps = {
     perPage: 25,
     sort: { field: 'id', order: 'DESC' },
     referenceRecord: null,
+    referenceSource,
 };
 
 const mapStateToProps = createSelector(
     (_, props) => props.input.value,
     getReferenceResource,
-    (state, { resource, source }) =>
-        getPossibleReferenceValues(state, referenceSource(resource, source)),
+    getPossibleReferenceValues,
     (inputId, referenceState, possibleValues) => ({
         referenceRecord: referenceState && referenceState.data[inputId],
         matchingReferences: getPossibleReferences(

--- a/packages/react-admin/src/reducer/admin/index.js
+++ b/packages/react-admin/src/reducer/admin/index.js
@@ -1,12 +1,12 @@
 import { combineReducers } from 'redux';
-import resources, {
-    getResources as innerGetResources,
-    getResource as innerGetResource,
-} from './resource';
+import resources, { getResources as innerGetResources } from './resource';
 import loading from './loading';
 import notifications from './notifications';
 import record from './record';
-import references, { getPossibleValues } from './references';
+import references, {
+    getPossibleValues,
+    getReferenceResource as innerGetReferenceResource,
+} from './references';
 import saving from './saving';
 import ui from './ui';
 import auth, { isLoggedIn as innerIsLoggedIn } from './auth';
@@ -24,9 +24,12 @@ export default combineReducers({
 
 export const getPossibleReferenceValues = (state, resource) =>
     getPossibleValues(state.references, resource);
-export const getResource = (state, resource) =>
-    innerGetResource(state.resources, resource);
+
 export const getResources = state => innerGetResources(state.resources);
+
+export const getReferenceResource = (state, props) =>
+    innerGetReferenceResource(state.resources, props);
+
 export const isLoggedIn = state => innerIsLoggedIn(state.auth);
 
 export { getPossibleReferences } from './references';

--- a/packages/react-admin/src/reducer/admin/index.js
+++ b/packages/react-admin/src/reducer/admin/index.js
@@ -1,15 +1,15 @@
 import { combineReducers } from 'redux';
-import resources, { getResources as innerGetResources } from './resource';
+import resources, { getResources as resourcesGetResources } from './resource';
 import loading from './loading';
 import notifications from './notifications';
 import record from './record';
 import references, {
-    getPossibleValues,
-    getReferenceResource as innerGetReferenceResource,
+    getPossibleReferenceValues as referencesGetPossibleReferenceValues,
+    getReferenceResource as referencesGetReferenceResource,
 } from './references';
 import saving from './saving';
 import ui from './ui';
-import auth, { isLoggedIn as innerIsLoggedIn } from './auth';
+import auth, { isLoggedIn as authIsLoggedIn } from './auth';
 
 export default combineReducers({
     resources,
@@ -22,14 +22,14 @@ export default combineReducers({
     auth,
 });
 
-export const getPossibleReferenceValues = (state, resource) =>
-    getPossibleValues(state.references, resource);
+export const getPossibleReferenceValues = (state, props) =>
+    referencesGetPossibleReferenceValues(state.references, props);
 
-export const getResources = state => innerGetResources(state.resources);
+export const getResources = state => resourcesGetResources(state.resources);
 
 export const getReferenceResource = (state, props) =>
-    innerGetReferenceResource(state.resources, props);
+    referencesGetReferenceResource(state.resources, props);
 
-export const isLoggedIn = state => innerIsLoggedIn(state.auth);
+export const isLoggedIn = state => authIsLoggedIn(state.auth);
 
 export { getPossibleReferences } from './references';

--- a/packages/react-admin/src/reducer/admin/index.js
+++ b/packages/react-admin/src/reducer/admin/index.js
@@ -1,11 +1,13 @@
 import { combineReducers } from 'redux';
-import resources, { getResources as resourcesGetResources } from './resource';
+import resources, {
+    getResources as resourceGetResources,
+    getReferenceResource as resourceGetReferenceResource,
+} from './resource';
 import loading from './loading';
 import notifications from './notifications';
 import record from './record';
 import references, {
     getPossibleReferenceValues as referencesGetPossibleReferenceValues,
-    getReferenceResource as referencesGetReferenceResource,
 } from './references';
 import saving from './saving';
 import ui from './ui';
@@ -25,10 +27,10 @@ export default combineReducers({
 export const getPossibleReferenceValues = (state, props) =>
     referencesGetPossibleReferenceValues(state.references, props);
 
-export const getResources = state => resourcesGetResources(state.resources);
+export const getResources = state => resourceGetResources(state.resources);
 
 export const getReferenceResource = (state, props) =>
-    referencesGetReferenceResource(state.resources, props);
+    resourceGetReferenceResource(state.resources, props);
 
 export const isLoggedIn = state => authIsLoggedIn(state.auth);
 

--- a/packages/react-admin/src/reducer/admin/references/index.js
+++ b/packages/react-admin/src/reducer/admin/references/index.js
@@ -1,15 +1,16 @@
 import { combineReducers } from 'redux';
 import oneToMany from './oneToMany';
-import possibleValues from './possibleValues';
+import possibleValues, {
+    getPossibleReferences as pvGetPossibleReferences,
+    getPossibleReferenceValues as pvGetPossibleReferenceValues,
+} from './possibleValues';
 
 export default combineReducers({
     oneToMany,
     possibleValues,
 });
 
-export const getReferenceResource = (state, props) => state[props.reference];
-
 export const getPossibleReferenceValues = (state, props) =>
-    state.possibleValues[props.referenceSource(props.resource, props.source)];
+    pvGetPossibleReferenceValues(state.possibleValues, props);
 
-export { getPossibleReferences } from './possibleValues';
+export const getPossibleReferences = pvGetPossibleReferences;

--- a/packages/react-admin/src/reducer/admin/references/index.js
+++ b/packages/react-admin/src/reducer/admin/references/index.js
@@ -7,6 +7,8 @@ export default combineReducers({
     possibleValues,
 });
 
+export const getReferenceResource = (state, props) => state[props.reference];
+
 export const getPossibleValues = (state, referenceSource) =>
     state.possibleValues[referenceSource];
 

--- a/packages/react-admin/src/reducer/admin/references/index.js
+++ b/packages/react-admin/src/reducer/admin/references/index.js
@@ -9,7 +9,7 @@ export default combineReducers({
 
 export const getReferenceResource = (state, props) => state[props.reference];
 
-export const getPossibleValues = (state, referenceSource) =>
-    state.possibleValues[referenceSource];
+export const getPossibleReferenceValues = (state, props) =>
+    state.possibleValues[props.referenceSource(props.resource, props.source)];
 
 export { getPossibleReferences } from './possibleValues';

--- a/packages/react-admin/src/reducer/admin/references/possibleValues.js
+++ b/packages/react-admin/src/reducer/admin/references/possibleValues.js
@@ -14,6 +14,9 @@ export default (previousState = initialState, { type, payload, meta }) => {
     }
 };
 
+export const getPossibleReferenceValues = (state, props) =>
+    state[props.referenceSource(props.resource, props.source)];
+
 export const getPossibleReferences = (
     referenceState,
     possibleValues,

--- a/packages/react-admin/src/reducer/admin/references/possibleValues.spec.js
+++ b/packages/react-admin/src/reducer/admin/references/possibleValues.spec.js
@@ -1,0 +1,17 @@
+import { getPossibleReferenceValues } from './possibleValues';
+
+describe('possibleValues reducer', () => {
+    describe('getPossibleReferenceValues selector', () => {
+        it('should return references', () => {
+            const state = {
+                'foo@bar': [1, 2, 3],
+            };
+            const props = {
+                resource: 'foo',
+                source: 'bar',
+                referenceSource: (resource, source) => `${resource}@${source}`,
+            };
+            expect(getPossibleReferenceValues(state, props)).toEqual([1, 2, 3]);
+        });
+    });
+});

--- a/packages/react-admin/src/reducer/admin/resource/index.js
+++ b/packages/react-admin/src/reducer/admin/resource/index.js
@@ -66,7 +66,5 @@ export default (
     return newState;
 };
 
-export const getResource = (state, resource) => state[resource];
-
 export const getResources = state =>
     Object.keys(state).map(key => state[key].props);

--- a/packages/react-admin/src/reducer/admin/resource/index.js
+++ b/packages/react-admin/src/reducer/admin/resource/index.js
@@ -68,3 +68,5 @@ export default (
 
 export const getResources = state =>
     Object.keys(state).map(key => state[key].props);
+
+export const getReferenceResource = (state, props) => state[props.reference];

--- a/packages/react-admin/src/reducer/admin/resource/index.spec.js
+++ b/packages/react-admin/src/reducer/admin/resource/index.spec.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import reducer from './index';
+import reducer, { getReferenceResource } from './index';
 import { REGISTER_RESOURCE, UNREGISTER_RESOURCE } from '../../../actions';
 
 describe('Resources Reducer', () => {
@@ -133,5 +133,18 @@ describe('Resources Reducer', () => {
 
         assert.equal(dataReducer.mock.calls[0][0], 'posts');
         assert.equal(listReducer.mock.calls[0][0], 'posts');
+    });
+
+    describe('getReferenceResource selector', () => {
+        it('should return the reference resource', () => {
+            const state = {
+                posts: 'POSTS',
+                comments: 'COMMENTS',
+            };
+            const props = {
+                reference: 'comments',
+            };
+            expect(getReferenceResource(state, props)).toEqual('COMMENTS');
+        });
     });
 });

--- a/packages/react-admin/src/reducer/index.js
+++ b/packages/react-admin/src/reducer/index.js
@@ -2,8 +2,8 @@ import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { routerReducer } from 'react-router-redux';
 import admin, {
-    getResource as getAdminResource,
     getResources as getAdminResources,
+    getReferenceResource as getAdminReferenceResource,
     getPossibleReferenceValues as getAdminPossibleReferenceValues,
     isLoggedIn as adminIsLoggedIn,
 } from './admin';
@@ -20,9 +20,9 @@ export default (customReducers, locale, messages) =>
 
 export const getPossibleReferenceValues = (state, resource) =>
     getAdminPossibleReferenceValues(state.admin, resource);
-export const getResource = (state, resource) =>
-    getAdminResource(state.admin, resource);
 export const getResources = state => getAdminResources(state.admin);
+export const getReferenceResource = (state, props) =>
+    getAdminReferenceResource(state.admin, props);
 export const isLoggedIn = state => adminIsLoggedIn(state.admin);
 export const getLocale = state => adminGetLocale(state.i18n);
 export { getPossibleReferences } from './admin';

--- a/packages/react-admin/src/reducer/index.js
+++ b/packages/react-admin/src/reducer/index.js
@@ -2,9 +2,9 @@ import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { routerReducer } from 'react-router-redux';
 import admin, {
-    getResources as getAdminResources,
-    getReferenceResource as getAdminReferenceResource,
-    getPossibleReferenceValues as getAdminPossibleReferenceValues,
+    getResources as adminGetResources,
+    getReferenceResource as adminGetReferenceResource,
+    getPossibleReferenceValues as adminGetPossibleReferenceValues,
     isLoggedIn as adminIsLoggedIn,
 } from './admin';
 import i18nReducer, { getLocale as adminGetLocale } from './i18n';
@@ -18,11 +18,11 @@ export default (customReducers, locale, messages) =>
         ...customReducers,
     });
 
-export const getPossibleReferenceValues = (state, resource) =>
-    getAdminPossibleReferenceValues(state.admin, resource);
-export const getResources = state => getAdminResources(state.admin);
+export const getPossibleReferenceValues = (state, props) =>
+    adminGetPossibleReferenceValues(state.admin, props);
+export const getResources = state => adminGetResources(state.admin);
 export const getReferenceResource = (state, props) =>
-    getAdminReferenceResource(state.admin, props);
+    adminGetReferenceResource(state.admin, props);
 export const isLoggedIn = state => adminIsLoggedIn(state.admin);
 export const getLocale = state => adminGetLocale(state.i18n);
 export { getPossibleReferences } from './admin';


### PR DESCRIPTION
- [x] Change selectors signature to be `(state, store)` as much as possible
- [x] Moved selectors to the right reducer
- [x] Fix memoization not working when there are several ReferenceInputs on a page (cf https://github.com/reactjs/reselect#sharing-selectors-with-props-across-multiple-component-instances)
- [x] Added unit tests

Follows #1420