### PR TITLE
[RFR] SingleFieldList now accepts a linkType prop

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -458,6 +458,21 @@ When you want to display only one property of a list of records, instead of usin
 
 ![ReferenceManyFieldSingleFieldList](./img/reference-many-field-single-field-list.png)
 
+**Tip**: The `<SingleFieldList>` items link to the edition page by default. You can set the `linkType` prop to `show` to link to the `<Show>` page instead.
+
+```jsx
+// Display all the tags for the current post
+<ReferenceArrayField
+    label="Tags"
+    reference="tags"
+    source="tags"
+>
+    <SingleFieldList linkType="show">
+        <ChipField source="name" />
+    </SingleFieldList>
+</ReferenceArrayField>
+```
+
 ## Using a Custom Iterator
 
 A `<List>` can delegate to any iterator component - `<Datagrid>` is just one example. An iterator component must accept at least two props:

--- a/packages/react-admin/src/mui/field/ReferenceField.js
+++ b/packages/react-admin/src/mui/field/ReferenceField.js
@@ -67,16 +67,17 @@ export class ReferenceField extends Component {
 
     render() {
         const {
+            allowEmpty,
             basePath,
-            classes,
+            children,
             className,
+            classes,
+            linkType,
             record,
-            source,
             reference,
             referenceRecord,
-            allowEmpty,
-            children,
-            linkType,
+            resource,
+            source,
             translateChoice,
             ...rest
         } = this.props;
@@ -86,36 +87,23 @@ export class ReferenceField extends Component {
         if (!referenceRecord && !allowEmpty) {
             return <LinearProgress />;
         }
-        const rootPath = basePath
-            .split('/')
-            .slice(0, -1)
-            .join('/');
+        const rootPath = basePath.replace(`/${resource}`, '');
+
         const href = linkToRecord(
             `${rootPath}/${reference}`,
             get(record, source)
         );
-        if (linkType === 'edit' || linkType === true) {
+
+        let resourceLinkPath =
+            linkType === 'edit' || linkType === true
+                ? href
+                : linkType === 'show' ? `${href}/show` : false;
+
+        if (linkType === 'edit' || linkType === true || linkType === 'show') {
             return (
                 <Link
                     className={classnames(classes.link, className)}
-                    to={href}
-                    {...sanitizeRestProps(rest)}
-                >
-                    {React.cloneElement(children, {
-                        record: referenceRecord,
-                        resource: reference,
-                        allowEmpty,
-                        basePath,
-                        translateChoice: false,
-                    })}
-                </Link>
-            );
-        }
-        if (linkType === 'show') {
-            return (
-                <Link
-                    className={classnames(classes.link, className)}
-                    to={`${href}/show`}
+                    to={resourceLinkPath}
                     {...sanitizeRestProps(rest)}
                 >
                     {React.cloneElement(children, {
@@ -154,6 +142,7 @@ ReferenceField.propTypes = {
     record: PropTypes.object,
     reference: PropTypes.string.isRequired,
     referenceRecord: PropTypes.object,
+    resource: PropTypes.string,
     source: PropTypes.string.isRequired,
     translateChoice: PropTypes.func,
     linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])

--- a/packages/react-admin/src/mui/field/ReferenceField.js
+++ b/packages/react-admin/src/mui/field/ReferenceField.js
@@ -87,19 +87,12 @@ export class ReferenceField extends Component {
         if (!referenceRecord && !allowEmpty) {
             return <LinearProgress />;
         }
-        const rootPath = basePath.replace(`/${resource}`, '');
+        const rootPath = basePath.replace(resource, reference);
+        const resourceLinkPath = !linkType
+            ? false
+            : linkToRecord(rootPath, get(record, source), linkType);
 
-        const href = linkToRecord(
-            `${rootPath}/${reference}`,
-            get(record, source)
-        );
-
-        let resourceLinkPath =
-            linkType === 'edit' || linkType === true
-                ? href
-                : linkType === 'show' ? `${href}/show` : false;
-
-        if (linkType === 'edit' || linkType === true || linkType === 'show') {
+        if (resourceLinkPath) {
             return (
                 <Link
                     className={classnames(classes.link, className)}

--- a/packages/react-admin/src/mui/field/ReferenceField.spec.js
+++ b/packages/react-admin/src/mui/field/ReferenceField.spec.js
@@ -10,10 +10,10 @@ describe('<ReferenceField />', () => {
         const crudGetManyAccumulate = jest.fn();
         shallow(
             <ReferenceField
-                record={{ fooId: 123 }}
-                source="fooId"
+                record={{ postId: 123 }}
+                source="postId"
                 referenceRecord={{ id: 123, title: 'foo' }}
-                reference="bar"
+                reference="posts"
                 basePath=""
                 crudGetManyAccumulate={crudGetManyAccumulate}
             >
@@ -26,10 +26,10 @@ describe('<ReferenceField />', () => {
         const crudGetManyAccumulate = jest.fn();
         shallow(
             <ReferenceField
-                record={{ fooId: null }}
-                source="fooId"
+                record={{ postId: null }}
+                source="postId"
                 referenceRecord={{ id: 123, title: 'foo' }}
-                reference="bar"
+                reference="posts"
                 basePath=""
                 crudGetManyAccumulate={crudGetManyAccumulate}
             >
@@ -41,36 +41,36 @@ describe('<ReferenceField />', () => {
     it('should render a link to the Edit page of the related record by default', () => {
         const wrapper = shallow(
             <ReferenceField
-                record={{ fooId: 123 }}
-                source="fooId"
+                record={{ postId: 123 }}
+                source="postId"
                 referenceRecord={{ id: 123, title: 'foo' }}
-                reference="bar"
-                resource="foo"
-                basePath="/foo"
+                reference="posts"
+                resource="comments"
+                basePath="/comments"
                 crudGetManyAccumulate={() => {}}
             >
                 <TextField source="title" />
             </ReferenceField>
         );
         const linkElement = wrapper.find('WithStyles(Link)');
-        assert.equal(linkElement.prop('to'), '/bar/123');
+        assert.equal(linkElement.prop('to'), '/posts/123');
     });
     it('should render a link to the Edit page of the related record when the resource contains slashes', () => {
         const wrapper = shallow(
             <ReferenceField
-                record={{ fooId: 123 }}
-                source="fooId"
+                record={{ postId: 123 }}
+                source="postId"
                 referenceRecord={{ id: 123, title: 'foo' }}
-                reference="prefix/bar"
-                resource="prefix/foo"
-                basePath="/prefix/foo"
+                reference="prefix/posts"
+                resource="prefix/comments"
+                basePath="/prefix/comments"
                 crudGetManyAccumulate={() => {}}
             >
                 <TextField source="title" />
             </ReferenceField>
         );
         const linkElement = wrapper.find('WithStyles(Link)');
-        assert.equal(linkElement.prop('to'), '/prefix/bar/123');
+        assert.equal(linkElement.prop('to'), '/prefix/posts/123');
     });
     it('should render a link to the Edit page of the related record when the resource is named edit or show', () => {
         let wrapper = shallow(
@@ -80,7 +80,7 @@ describe('<ReferenceField />', () => {
                 referenceRecord={{ id: 123, title: 'foo' }}
                 reference="edit"
                 resource="show"
-                basePath="/edit"
+                basePath="/show"
                 crudGetManyAccumulate={() => {}}
             >
                 <TextField source="title" />
@@ -108,12 +108,12 @@ describe('<ReferenceField />', () => {
     it('should render a link to the Show page of the related record when the linkType is show', () => {
         const wrapper = shallow(
             <ReferenceField
-                record={{ fooId: 123 }}
-                source="fooId"
+                record={{ postId: 123 }}
+                source="postId"
                 referenceRecord={{ id: 123, title: 'foo' }}
-                resource="foo"
-                reference="bar"
-                basePath="/foo"
+                resource="comments"
+                reference="posts"
+                basePath="/comments"
                 linkType="show"
                 crudGetManyAccumulate={() => {}}
             >
@@ -121,7 +121,7 @@ describe('<ReferenceField />', () => {
             </ReferenceField>
         );
         const linkElement = wrapper.find('WithStyles(Link)');
-        assert.equal(linkElement.prop('to'), '/bar/123/show');
+        assert.equal(linkElement.prop('to'), '/posts/123/show');
     });
     it('should render a link to the Show page of the related record when the resource is named edit or show and linkType is show', () => {
         let wrapper = shallow(
@@ -131,7 +131,7 @@ describe('<ReferenceField />', () => {
                 referenceRecord={{ id: 123, title: 'foo' }}
                 reference="edit"
                 resource="show"
-                basePath="/edit"
+                basePath="/show"
                 linkType="show"
                 crudGetManyAccumulate={() => {}}
             >

--- a/packages/react-admin/src/mui/field/ReferenceField.spec.js
+++ b/packages/react-admin/src/mui/field/ReferenceField.spec.js
@@ -54,7 +54,7 @@ describe('<ReferenceField />', () => {
         const linkElement = wrapper.find('WithStyles(Link)');
         assert.equal(linkElement.prop('to'), '/bar/123');
     });
-    it('should render a link to the Edit page of the related record even if the resouce contains slashes', () => {
+    it('should render a link to the Edit page of the related record even if the resource contains slashes', () => {
         const wrapper = shallow(
             <ReferenceField
                 record={{ fooId: 123 }}

--- a/packages/react-admin/src/mui/field/ReferenceField.spec.js
+++ b/packages/react-admin/src/mui/field/ReferenceField.spec.js
@@ -45,7 +45,8 @@ describe('<ReferenceField />', () => {
                 source="fooId"
                 referenceRecord={{ id: 123, title: 'foo' }}
                 reference="bar"
-                basePath=""
+                resource="foo"
+                basePath="/foo"
                 crudGetManyAccumulate={() => {}}
             >
                 <TextField source="title" />
@@ -54,7 +55,7 @@ describe('<ReferenceField />', () => {
         const linkElement = wrapper.find('WithStyles(Link)');
         assert.equal(linkElement.prop('to'), '/bar/123');
     });
-    it('should render a link to the Edit page of the related record even if the resource contains slashes', () => {
+    it('should render a link to the Edit page of the related record when the resource contains slashes', () => {
         const wrapper = shallow(
             <ReferenceField
                 record={{ fooId: 123 }}
@@ -71,14 +72,48 @@ describe('<ReferenceField />', () => {
         const linkElement = wrapper.find('WithStyles(Link)');
         assert.equal(linkElement.prop('to'), '/prefix/bar/123');
     });
+    it('should render a link to the Edit page of the related record when the resource is named edit or show', () => {
+        let wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="edit"
+                resource="show"
+                basePath="/edit"
+                crudGetManyAccumulate={() => {}}
+            >
+                <TextField source="title" />
+            </ReferenceField>
+        );
+        let linkElement = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElement.prop('to'), '/edit/123');
+
+        wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="show"
+                resource="edit"
+                basePath="/edit"
+                crudGetManyAccumulate={() => {}}
+            >
+                <TextField source="title" />
+            </ReferenceField>
+        );
+        linkElement = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElement.prop('to'), '/show/123');
+    });
     it('should render a link to the Show page of the related record when the linkType is show', () => {
         const wrapper = shallow(
             <ReferenceField
                 record={{ fooId: 123 }}
                 source="fooId"
                 referenceRecord={{ id: 123, title: 'foo' }}
+                resource="foo"
                 reference="bar"
-                basePath=""
+                basePath="/foo"
                 linkType="show"
                 crudGetManyAccumulate={() => {}}
             >
@@ -88,6 +123,41 @@ describe('<ReferenceField />', () => {
         const linkElement = wrapper.find('WithStyles(Link)');
         assert.equal(linkElement.prop('to'), '/bar/123/show');
     });
+    it('should render a link to the Show page of the related record when the resource is named edit or show and linkType is show', () => {
+        let wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="edit"
+                resource="show"
+                basePath="/edit"
+                linkType="show"
+                crudGetManyAccumulate={() => {}}
+            >
+                <TextField source="title" />
+            </ReferenceField>
+        );
+        let linkElement = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElement.prop('to'), '/edit/123/show');
+
+        wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="show"
+                resource="edit"
+                basePath="/edit"
+                linkType="show"
+                crudGetManyAccumulate={() => {}}
+            >
+                <TextField source="title" />
+            </ReferenceField>
+        );
+        linkElement = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElement.prop('to'), '/show/123/show');
+    });
     it('should render no link when the linkType is false', () => {
         const wrapper = shallow(
             <ReferenceField
@@ -95,7 +165,7 @@ describe('<ReferenceField />', () => {
                 source="fooId"
                 referenceRecord={{ id: 123, title: 'foo' }}
                 reference="bar"
-                basePath=""
+                basePath="/foo"
                 linkType={false}
                 crudGetManyAccumulate={() => {}}
             >

--- a/packages/react-admin/src/mui/field/ReferenceField.spec.js
+++ b/packages/react-admin/src/mui/field/ReferenceField.spec.js
@@ -54,6 +54,23 @@ describe('<ReferenceField />', () => {
         const linkElement = wrapper.find('WithStyles(Link)');
         assert.equal(linkElement.prop('to'), '/bar/123');
     });
+    it('should render a link to the Edit page of the related record even if the resouce contains slashes', () => {
+        const wrapper = shallow(
+            <ReferenceField
+                record={{ fooId: 123 }}
+                source="fooId"
+                referenceRecord={{ id: 123, title: 'foo' }}
+                reference="prefix/bar"
+                resource="prefix/foo"
+                basePath="/prefix/foo"
+                crudGetManyAccumulate={() => {}}
+            >
+                <TextField source="title" />
+            </ReferenceField>
+        );
+        const linkElement = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElement.prop('to'), '/prefix/bar/123');
+    });
     it('should render a link to the Show page of the related record when the linkType is show', () => {
         const wrapper = shallow(
             <ReferenceField

--- a/packages/react-admin/src/mui/list/SingleFieldList.js
+++ b/packages/react-admin/src/mui/list/SingleFieldList.js
@@ -69,18 +69,11 @@ export class SingleFieldList extends Component {
                 {...sanitizeRestProps(rest)}
             >
                 {ids.map(id => {
-                    const href = linkToRecord(basePath, id);
+                    const resourceLinkPath = !linkType
+                        ? false
+                        : linkToRecord(basePath, id, linkType);
 
-                    let resourceLinkPath =
-                        linkType === 'edit' || linkType === true
-                            ? href
-                            : linkType === 'show' ? `${href}/show` : false;
-
-                    if (
-                        linkType === 'edit' ||
-                        linkType === true ||
-                        linkType === 'show'
-                    ) {
+                    if (resourceLinkPath) {
                         return (
                             <Link
                                 className={classnames(classes.link, className)}

--- a/packages/react-admin/src/mui/list/SingleFieldList.js
+++ b/packages/react-admin/src/mui/list/SingleFieldList.js
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { withStyles } from 'material-ui/styles';
 
+import linkToRecord from '../../util/linkToRecord';
+import Link from '../Link';
+
 const styles = {
     root: { display: 'flex', flexWrap: 'wrap' },
 };
+
+const sanitizeRestProps = ({ currentSort, isLoading, ...props }) => props;
 
 /**
  * Iterator component to be used to display a list of entities, using a single field
@@ -16,35 +21,106 @@ const styles = {
  *         <ChipField source="title" />
  *     </SingleFieldList>
  * </ReferenceManyField>
+ * 
+ * By default, it includes a link to the <Edit> page of the related record
+ * (`/books/:id` in the previous example).
+ *
+ * Set the linkType prop to "show" to link to the <Show> page instead.
+ *
+ * @example
+ * <ReferenceManyField reference="books" target="author_id" linkType="show">
+ *     <SingleFieldList>
+ *         <ChipField source="title" />
+ *     </SingleFieldList>
+ * </ReferenceManyField>
+ *
+ * You can also prevent `<SingleFieldList>` from adding link to children by setting
+ * `linkType` to false.
+ *
+ * @example
+ * <ReferenceManyField reference="books" target="author_id" linkType={false}>
+ *     <SingleFieldList>
+ *         <ChipField source="title" />
+ *     </SingleFieldList>
+ * </ReferenceManyField>
+
  */
-const SingleFieldList = ({
-    classes = {},
-    className,
-    currentSort,
-    ids,
-    isLoading,
-    data,
-    resource,
-    basePath,
-    children,
-    ...rest
-}) => (
-    <div className={classnames(classes.root, className)} {...rest}>
-        {ids.map(id =>
-            React.cloneElement(children, {
-                key: id,
-                record: data[id],
-                resource,
-                basePath,
-            })
-        )}
-    </div>
-);
+export class SingleFieldList extends Component {
+    // Our handleClick does nothing as we wrap the children inside a Link but it is
+    // required fo ChipField which uses a Chip from material-ui.
+    // The material-ui Chip requires an onClick handler to behave like a clickable element
+    handleClick = () => {};
+    render() {
+        const {
+            classes = {},
+            className,
+            ids,
+            data,
+            resource,
+            basePath,
+            children,
+            linkType,
+            ...rest
+        } = this.props;
+
+        return (
+            <div
+                className={classnames(classes.root, className)}
+                {...sanitizeRestProps(rest)}
+            >
+                {ids.map(id => {
+                    const href = linkToRecord(basePath, id);
+
+                    let resourceLinkPath =
+                        linkType === 'edit' || linkType === true
+                            ? href
+                            : linkType === 'show' ? `${href}/show` : false;
+
+                    if (
+                        linkType === 'edit' ||
+                        linkType === true ||
+                        linkType === 'show'
+                    ) {
+                        return (
+                            <Link
+                                className={classnames(classes.link, className)}
+                                key={id}
+                                to={resourceLinkPath}
+                            >
+                                {cloneElement(children, {
+                                    record: data[id],
+                                    resource,
+                                    basePath,
+                                    // Workaround to force ChipField to be clickable
+                                    onClick: this.handleClick,
+                                })}
+                            </Link>
+                        );
+                    }
+
+                    return cloneElement(children, {
+                        key: id,
+                        record: data[id],
+                        resource,
+                        basePath,
+                    });
+                })}
+            </div>
+        );
+    }
+}
 
 SingleFieldList.propTypes = {
     children: PropTypes.element.isRequired,
     classes: PropTypes.object,
     className: PropTypes.string,
+    linkType: PropTypes.oneOfType([PropTypes.string, PropTypes.bool])
+        .isRequired,
+};
+
+SingleFieldList.defaultProps = {
+    classes: {},
+    linkType: 'edit',
 };
 
 export default withStyles(styles)(SingleFieldList);

--- a/packages/react-admin/src/mui/list/SingleFieldList.spec.js
+++ b/packages/react-admin/src/mui/list/SingleFieldList.spec.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+
+import { SingleFieldList } from './SingleFieldList';
+import ChipField from '../field/ChipField';
+
+describe('<SingleFieldList />', () => {
+    it('should render a link to the Edit page of the related record by default', () => {
+        const wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
+                resource="bar"
+                basePath=""
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+        const linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 2);
+        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+            '/bar/1',
+            '/bar/2',
+        ]);
+    });
+
+    it('should render a link to the Show page of the related record when the linkType is show', () => {
+        const wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={{
+                    1: { id: 1, title: 'foo' },
+                    2: { id: 2, title: 'bar' },
+                }}
+                resource="bar"
+                basePath=""
+                linkType="show"
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+
+        const linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 2);
+        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+            '/bar/1/show',
+            '/bar/2/show',
+        ]);
+    });
+
+    it('should render no link when the linkType is false', () => {
+        const wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
+                resource="bar"
+                basePath=""
+                linkType={false}
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+
+        const linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 0);
+        const chipElements = wrapper.find('WithStyles(pure(ChipField))');
+        assert.equal(chipElements.length, 2);
+    });
+});

--- a/packages/react-admin/src/mui/list/SingleFieldList.spec.js
+++ b/packages/react-admin/src/mui/list/SingleFieldList.spec.js
@@ -12,7 +12,26 @@ describe('<SingleFieldList />', () => {
                 ids={[1, 2]}
                 data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
                 resource="bar"
-                basePath=""
+                basePath="/bar"
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+        const linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 2);
+        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+            '/bar/1',
+            '/bar/2',
+        ]);
+    });
+
+    it('should render a link to the Edit page of the related record when the resource contains slashes', () => {
+        const wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
+                resource="bar"
+                basePath="/bar"
             >
                 <ChipField source="title" />
             </SingleFieldList>
@@ -33,8 +52,8 @@ describe('<SingleFieldList />', () => {
                     1: { id: 1, title: 'foo' },
                     2: { id: 2, title: 'bar' },
                 }}
-                resource="bar"
-                basePath=""
+                resource="prefix/bar"
+                basePath="/prefix/bar"
                 linkType="show"
             >
                 <ChipField source="title" />
@@ -44,8 +63,8 @@ describe('<SingleFieldList />', () => {
         const linkElements = wrapper.find('WithStyles(Link)');
         assert.equal(linkElements.length, 2);
         assert.deepEqual(linkElements.map(link => link.prop('to')), [
-            '/bar/1/show',
-            '/bar/2/show',
+            '/prefix/bar/1/show',
+            '/prefix/bar/2/show',
         ]);
     });
 
@@ -55,7 +74,7 @@ describe('<SingleFieldList />', () => {
                 ids={[1, 2]}
                 data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
                 resource="bar"
-                basePath=""
+                basePath="/bar"
                 linkType={false}
             >
                 <ChipField source="title" />

--- a/packages/react-admin/src/mui/list/SingleFieldList.spec.js
+++ b/packages/react-admin/src/mui/list/SingleFieldList.spec.js
@@ -11,8 +11,8 @@ describe('<SingleFieldList />', () => {
             <SingleFieldList
                 ids={[1, 2]}
                 data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
-                resource="bar"
-                basePath="/bar"
+                resource="posts"
+                basePath="/posts"
             >
                 <ChipField source="title" />
             </SingleFieldList>
@@ -20,8 +20,8 @@ describe('<SingleFieldList />', () => {
         const linkElements = wrapper.find('WithStyles(Link)');
         assert.equal(linkElements.length, 2);
         assert.deepEqual(linkElements.map(link => link.prop('to')), [
-            '/bar/1',
-            '/bar/2',
+            '/posts/1',
+            '/posts/2',
         ]);
     });
 
@@ -30,8 +30,8 @@ describe('<SingleFieldList />', () => {
             <SingleFieldList
                 ids={[1, 2]}
                 data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
-                resource="bar"
-                basePath="/bar"
+                resource="posts"
+                basePath="/posts"
             >
                 <ChipField source="title" />
             </SingleFieldList>
@@ -39,8 +39,8 @@ describe('<SingleFieldList />', () => {
         const linkElements = wrapper.find('WithStyles(Link)');
         assert.equal(linkElements.length, 2);
         assert.deepEqual(linkElements.map(link => link.prop('to')), [
-            '/bar/1',
-            '/bar/2',
+            '/posts/1',
+            '/posts/2',
         ]);
     });
 

--- a/packages/react-admin/src/mui/list/SingleFieldList.spec.js
+++ b/packages/react-admin/src/mui/list/SingleFieldList.spec.js
@@ -44,6 +44,42 @@ describe('<SingleFieldList />', () => {
         ]);
     });
 
+    it('should render a link to the Edit page of the related record when the resource is named edit or show', () => {
+        let wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
+                resource="edit"
+                basePath="/edit"
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+        let linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 2);
+        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+            '/edit/1',
+            '/edit/2',
+        ]);
+
+        wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
+                resource="show"
+                basePath="/show"
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+        linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 2);
+        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+            '/show/1',
+            '/show/2',
+        ]);
+    });
+
     it('should render a link to the Show page of the related record when the linkType is show', () => {
         const wrapper = shallow(
             <SingleFieldList
@@ -65,6 +101,44 @@ describe('<SingleFieldList />', () => {
         assert.deepEqual(linkElements.map(link => link.prop('to')), [
             '/prefix/bar/1/show',
             '/prefix/bar/2/show',
+        ]);
+    });
+
+    it('should render a link to the Edit page of the related record when the resource is named edit or show and linkType is show', () => {
+        let wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
+                resource="edit"
+                basePath="/edit"
+                linkType="show"
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+        let linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 2);
+        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+            '/edit/1/show',
+            '/edit/2/show',
+        ]);
+
+        wrapper = shallow(
+            <SingleFieldList
+                ids={[1, 2]}
+                data={[{ id: 1, title: 'foo' }, { id: 2, title: 'bar' }]}
+                resource="show"
+                basePath="/show"
+                linkType="show"
+            >
+                <ChipField source="title" />
+            </SingleFieldList>
+        );
+        linkElements = wrapper.find('WithStyles(Link)');
+        assert.equal(linkElements.length, 2);
+        assert.deepEqual(linkElements.map(link => link.prop('to')), [
+            '/show/1/show',
+            '/show/2/show',
         ]);
     });
 

--- a/packages/react-admin/src/util/linkToRecord.js
+++ b/packages/react-admin/src/util/linkToRecord.js
@@ -1,1 +1,9 @@
-export default (basePath, id) => `${basePath}/${encodeURIComponent(id)}`;
+export default (basePath, id, linkType = 'edit') => {
+    let link = `${basePath}/${encodeURIComponent(id)}`;
+
+    if (linkType === 'show') {
+        return `${link}/show`;
+    }
+
+    return link;
+};

--- a/packages/react-admin/src/util/linkToRecord.spec.js
+++ b/packages/react-admin/src/util/linkToRecord.spec.js
@@ -2,12 +2,23 @@ import assert from 'assert';
 import linkToRecord from './linkToRecord';
 
 describe('Linking to a record', () => {
-    it('should generate valid links', () => {
+    it('should generate valid edition links by default', () => {
         assert.equal(linkToRecord('books', 22), 'books/22');
         assert.equal(linkToRecord('books', '/books/13'), 'books/%2Fbooks%2F13');
         assert.equal(
             linkToRecord('blogs', 'https://dunglas.fr'),
             'blogs/https%3A%2F%2Fdunglas.fr'
+        );
+    });
+    it('should generate valid show links if requested', () => {
+        assert.equal(linkToRecord('books', 22, 'show'), 'books/22/show');
+        assert.equal(
+            linkToRecord('books', '/books/13', 'show'),
+            'books/%2Fbooks%2F13/show'
+        );
+        assert.equal(
+            linkToRecord('blogs', 'https://dunglas.fr', 'show'),
+            'blogs/https%3A%2F%2Fdunglas.fr/show'
         );
     });
 });


### PR DESCRIPTION
- [x] `SingleFieldList` accepts a `linkType` prop (which defaults to `edit`)
- [x] Ensure we correctly handle resource names with slashes in both `SingleFieldList` and `ReferenceField`
- [x] Documentation

Fixes #740 
Fixes #1291 