### PR TITLE
Fix npm warnings

### DIFF
--- a/packages/react-admin/package.json
+++ b/packages/react-admin/package.json
@@ -27,8 +27,8 @@
         "react-test-renderer": "~16.0.0"
     },
     "peerDependencies": {
-        "react": "^15.4.0 || ~16.0.0",
-        "react-dom": "^15.4.0 || ~16.0.0"
+        "react": "^15.4.0 || ^16.0.0",
+        "react-dom": "^15.4.0 || ^16.0.0"
     },
     "dependencies": {
         "autosuggest-highlight": "^3.1.1",


### PR DESCRIPTION
~16.0.0 is a range (tilde) constraint. It means that it will match several versions.
In fact, the current constraint will be satisfied by any version matching >=16.0.0 <16.1.0.
It won't work with the latest version of React 16.2.0. Hence the following warnings in my console:

> warning " > react-admin@2.0.0-beta2" has incorrect peer dependency "react@^15.4.0 || ~16.0.0".
warning " > react-admin@2.0.0-beta2" has incorrect peer dependency "react-dom@^15.4.0 || ~16.0.0".

^16.0.0 is a range (caret) constraint. It means that it will match several versions.
In fact, the current constraint will be satisfied by any version matching >=16.0.0 <17.0.0.

http://jubianchi.github.io/semver-check/