### PR TITLE
[RFR] Customize mui Palette to be less ugly

### DIFF
--- a/packages/react-admin/src/mui/auth/Logout.js
+++ b/packages/react-admin/src/mui/auth/Logout.js
@@ -13,7 +13,7 @@ import translate from '../../i18n/translate';
 import { userLogout as userLogoutAction } from '../../actions/authActions';
 
 const styles = {
-    iconPaddingStyle: { paddingRight: '0.5em' },
+    iconPaddingStyle: { paddingRight: '1.2em' },
 };
 
 const sanitizeRestProps = ({

--- a/packages/react-admin/src/mui/button/DeleteButton.js
+++ b/packages/react-admin/src/mui/button/DeleteButton.js
@@ -16,7 +16,7 @@ const DeleteButton = ({
         component={Link}
         to={`${linkToRecord(basePath, record.id)}/delete`}
         label={label}
-        color="secondary"
+        color="error"
         {...rest}
     >
         <ActionDelete />

--- a/packages/react-admin/src/mui/button/DeleteButton.js
+++ b/packages/react-admin/src/mui/button/DeleteButton.js
@@ -1,22 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ActionDelete from 'material-ui-icons/Delete';
+import { withStyles } from 'material-ui/styles';
+import { fade } from 'material-ui/styles/colorManipulator';
+import classnames from 'classnames';
 
-import Link from '../Link';
+import { Link } from 'react-router-dom';
 import linkToRecord from '../../util/linkToRecord';
 import Button from './Button';
+
+const styles = theme => ({
+    deleteButton: {
+        color: theme.palette.error.main,
+        '&:hover': {
+            backgroundColor: fade(theme.palette.error.main, 0.12),
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: 'transparent',
+            },
+        },
+    },
+});
 
 const DeleteButton = ({
     basePath = '',
     label = 'ra.action.delete',
     record = {},
+    classes = {},
+    className,
     ...rest
 }) => (
     <Button
+        className={classnames(classes.deleteButton, className)}
         component={Link}
         to={`${linkToRecord(basePath, record.id)}/delete`}
         label={label}
-        color="error"
         {...rest}
     >
         <ActionDelete />
@@ -25,8 +43,10 @@ const DeleteButton = ({
 
 DeleteButton.propTypes = {
     basePath: PropTypes.string,
+    classes: PropTypes.object,
+    className: PropTypes.string,
     label: PropTypes.string,
     record: PropTypes.object,
 };
 
-export default DeleteButton;
+export default withStyles(styles)(DeleteButton);

--- a/packages/react-admin/src/mui/defaultTheme.js
+++ b/packages/react-admin/src/mui/defaultTheme.js
@@ -1,1 +1,10 @@
-export default {};
+export default {
+    palette: {
+        secondary: {
+            light: '#E8EAF6',
+            main: '#3f51b5',
+            dark: '#303f9f',
+            contrastText: '#fff',
+        },
+    },
+};

--- a/packages/react-admin/src/mui/defaultTheme.js
+++ b/packages/react-admin/src/mui/defaultTheme.js
@@ -1,9 +1,9 @@
 export default {
     palette: {
         secondary: {
-            light: '#E8EAF6',
-            main: '#3f51b5',
-            dark: '#303f9f',
+            light: '#6ec6ff',
+            main: '#2196f3',
+            dark: '#0069c0',
             contrastText: '#fff',
         },
     },

--- a/packages/react-admin/src/mui/delete/Delete.js
+++ b/packages/react-admin/src/mui/delete/Delete.js
@@ -21,6 +21,17 @@ const styles = theme => ({
     button: {
         margin: theme.spacing.unit * 2,
     },
+    buttonDelete: {
+        backgroundColor: theme.palette.error.main,
+        color: theme.palette.error.contrastText,
+        '&:hover': {
+            backgroundColor: theme.palette.error.dark,
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: theme.palette.error.main,
+            },
+        },
+    },
     iconPaddingStyle: {
         paddingRight: '0.5em',
     },
@@ -206,8 +217,7 @@ export class Delete extends Component {
                             <Button
                                 variant="raised"
                                 type="submit"
-                                color="primary"
-                                className={classes.button}
+                                className={`${classes.button} ${classes.buttonDelete}`}
                             >
                                 <ActionCheck
                                     className={classes.iconPaddingStyle}

--- a/packages/react-admin/src/mui/field/ReferenceField.js
+++ b/packages/react-admin/src/mui/field/ReferenceField.js
@@ -14,7 +14,7 @@ import sanitizeRestProps from './sanitizeRestProps';
 
 const styles = theme => ({
     link: {
-        color: theme.palette.secondary.main,
+        color: theme.palette.primary.main,
     },
 });
 

--- a/packages/react-admin/src/mui/layout/AppBar.js
+++ b/packages/react-admin/src/mui/layout/AppBar.js
@@ -20,21 +20,25 @@ const styles = theme => ({
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,
         }),
-    },
-    appBarShift: {
-        marginLeft: DRAWER_WIDTH,
-        width: `calc(100% - ${DRAWER_WIDTH}px)`,
-        transition: theme.transitions.create(['margin', 'width'], {
-            easing: theme.transitions.easing.easeOut,
-            duration: theme.transitions.duration.enteringScreen,
-        }),
+        zIndex: 1300,
     },
     menuButton: {
         marginLeft: 12,
         marginRight: 20,
     },
-    hide: {
-        display: 'none',
+    menuButtonIconClosed: {
+        transition: theme.transitions.create(['transform'], {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+        transform: 'rotate(0deg)',
+    },
+    menuButtonIconOpen: {
+        transition: theme.transitions.create(['transform'], {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+        transform: 'rotate(180deg)',
     },
     title: {
         flex: 1,
@@ -65,22 +69,24 @@ const AppBar = ({
     ...rest
 }) => (
     <MuiAppBar
-        className={classNames(
-            classes.appBar,
-            open && classes.appBarShift,
-            className
-        )}
+        className={classNames(classes.appBar, className)}
         color="secondary"
         {...rest}
     >
-        <Toolbar disableGutters={!open}>
+        <Toolbar disableGutters>
             <IconButton
                 color="inherit"
                 aria-label="open drawer"
                 onClick={toggleSidebar}
-                className={classNames(classes.menuButton, open && classes.hide)}
+                className={classNames(classes.menuButton)}
             >
-                <MenuIcon />
+                <MenuIcon
+                    classes={{
+                        root: open
+                            ? classes.menuButtonIconOpen
+                            : classes.menuButtonIconClosed,
+                    }}
+                />
             </IconButton>
             <Typography
                 variant="title"

--- a/packages/react-admin/src/mui/layout/AppBar.js
+++ b/packages/react-admin/src/mui/layout/AppBar.js
@@ -70,6 +70,7 @@ const AppBar = ({
     <MuiAppBar
         className={classNames(classes.appBar, className)}
         color="secondary"
+        position="absolute"
         {...rest}
     >
         <Toolbar disableGutters>

--- a/packages/react-admin/src/mui/layout/AppBar.js
+++ b/packages/react-admin/src/mui/layout/AppBar.js
@@ -51,7 +51,7 @@ const styles = theme => ({
         marginRight: 'auto',
     },
     logout: {
-        color: theme.palette.primary.contrastText,
+        color: theme.palette.secondary.contrastText,
     },
 });
 
@@ -70,6 +70,7 @@ const AppBar = ({
             open && classes.appBarShift,
             className
         )}
+        color="secondary"
         {...rest}
     >
         <Toolbar disableGutters={!open}>

--- a/packages/react-admin/src/mui/layout/AppBar.js
+++ b/packages/react-admin/src/mui/layout/AppBar.js
@@ -23,8 +23,8 @@ const styles = theme => ({
         zIndex: 1300,
     },
     menuButton: {
-        marginLeft: 12,
-        marginRight: 20,
+        marginLeft: '0.5em',
+        marginRight: '0.5em',
     },
     menuButtonIconClosed: {
         transition: theme.transitions.create(['transform'], {

--- a/packages/react-admin/src/mui/layout/AppBar.js
+++ b/packages/react-admin/src/mui/layout/AppBar.js
@@ -11,7 +11,6 @@ import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 
 import { toggleSidebar as toggleSidebarAction } from '../../actions';
-import { DRAWER_WIDTH } from './Sidebar';
 import LoadingIndicator from './LoadingIndicator';
 
 const styles = theme => ({

--- a/packages/react-admin/src/mui/layout/AppBarMobile.js
+++ b/packages/react-admin/src/mui/layout/AppBarMobile.js
@@ -50,7 +50,11 @@ const AppBarMobile = ({
     toggleSidebar,
     ...rest
 }) => (
-    <MuiAppBar className={classnames(classes.bar, className)} {...rest}>
+    <MuiAppBar
+        className={classnames(classes.bar, className)}
+        color="secondary"
+        {...rest}
+    >
         <Toolbar>
             <IconButton
                 color="inherit"

--- a/packages/react-admin/src/mui/layout/AppBarMobile.js
+++ b/packages/react-admin/src/mui/layout/AppBarMobile.js
@@ -16,7 +16,6 @@ import LoadingIndicator from './LoadingIndicator';
 const styles = {
     bar: {
         height: '3em',
-        position: 'absolute',
         top: 0,
     },
     title: {
@@ -53,6 +52,7 @@ const AppBarMobile = ({
     <MuiAppBar
         className={classnames(classes.bar, className)}
         color="secondary"
+        position="fixed"
         {...rest}
     >
         <Toolbar>

--- a/packages/react-admin/src/mui/layout/Layout.js
+++ b/packages/react-admin/src/mui/layout/Layout.js
@@ -11,7 +11,7 @@ import Hidden from 'material-ui/Hidden';
 import compose from 'recompose/compose';
 
 import AppBar from './AppBar';
-import Sidebar, { DRAWER_WIDTH } from './Sidebar';
+import Sidebar from './Sidebar';
 import Menu from './Menu';
 import Notification from './Notification';
 import defaultTheme from '../defaultTheme';
@@ -20,6 +20,8 @@ const styles = theme => ({
     root: {
         width: '100%',
         zIndex: 1,
+        minHeight: '100vh',
+        backgroundColor: theme.palette.background.default,
     },
     appFrame: {
         position: 'relative',
@@ -28,36 +30,17 @@ const styles = theme => ({
     },
     content: {
         width: '100%',
-        minHeight: '100vh',
-        marginLeft: 0,
         flexGrow: 1,
-        backgroundColor: theme.palette.background.default,
         padding: theme.spacing.unit * 3,
-        transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen,
-        }),
-        height: 'calc(100% - 56px)',
-        [theme.breakpoints.up('md')]: {
-            content: {
-                height: 'calc(100% - 64px)',
-                marginTop: 64,
-            },
-        },
         [theme.breakpoints.up('xs')]: {
             marginTop: '4em',
+            paddingLeft: 5,
         },
         [theme.breakpoints.down('sm')]: {
             padding: 0,
         },
-    },
-    contentShift: {
-        [theme.breakpoints.up('md')]: {
-            marginLeft: DRAWER_WIDTH,
-            transition: theme.transitions.create('margin', {
-                easing: theme.transitions.easing.easeOut,
-                duration: theme.transitions.duration.enteringScreen,
-            }),
+        [theme.breakpoints.down('xs')]: {
+            marginTop: '3em',
         },
     },
 });
@@ -92,14 +75,7 @@ const Layout = ({
                         hasDashboard: !!dashboard,
                     })}
                 </Sidebar>
-                <main
-                    className={classnames(
-                        classes.content,
-                        open && classes.contentShift
-                    )}
-                >
-                    {children}
-                </main>
+                <main className={classes.content}>{children}</main>
                 <Notification />
             </div>
         </div>

--- a/packages/react-admin/src/mui/layout/Layout.js
+++ b/packages/react-admin/src/mui/layout/Layout.js
@@ -25,10 +25,10 @@ const styles = theme => ({
         position: 'relative',
         display: 'flex',
         width: '100%',
-        height: '100%',
     },
     content: {
         width: '100%',
+        minHeight: '100vh',
         marginLeft: 0,
         flexGrow: 1,
         backgroundColor: theme.palette.background.default,

--- a/packages/react-admin/src/mui/layout/Loading.js
+++ b/packages/react-admin/src/mui/layout/Loading.js
@@ -40,7 +40,7 @@ const Loading = ({
 }) => (
     <div className={classnames(classes.container, className)}>
         <div className={classes.message}>
-            <CircularProgress className={classes.icon} />
+            <CircularProgress className={classes.icon} color="primary" />
             <h1>{translate(loadingPrimary)}</h1>
             <div>{translate(loadingSecondary)}.</div>
         </div>

--- a/packages/react-admin/src/mui/layout/LoadingIndicator.js
+++ b/packages/react-admin/src/mui/layout/LoadingIndicator.js
@@ -10,7 +10,6 @@ import compose from 'recompose/compose';
 const styles = {
     loader: {
         margin: 16,
-        color: 'white',
     },
 };
 
@@ -24,6 +23,7 @@ export const LoadingIndicator = ({
     isLoading ? (
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}
+            color="default"
             size={width === 'xs' || width === 'sm' ? 20 : 30}
             thickness={2}
             {...rest}

--- a/packages/react-admin/src/mui/layout/LoadingIndicator.js
+++ b/packages/react-admin/src/mui/layout/LoadingIndicator.js
@@ -23,9 +23,9 @@ export const LoadingIndicator = ({
     isLoading ? (
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}
-            color="default"
+            color="inherit"
             size={width === 'xs' || width === 'sm' ? 20 : 30}
-            thickness={2}
+            thickness={3}
             {...rest}
         />
     ) : null;

--- a/packages/react-admin/src/mui/layout/Menu.js
+++ b/packages/react-admin/src/mui/layout/Menu.js
@@ -11,13 +11,14 @@ import MenuItemLink from './MenuItemLink';
 import translate from '../../i18n/translate';
 import { getResources } from '../../reducer';
 import Responsive from '../layout/Responsive';
+import { DRAWER_WIDTH } from './Sidebar';
 
 const styles = {
     main: {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'flex-start',
-        height: '100%',
+        width: DRAWER_WIDTH,
     },
 };
 
@@ -58,7 +59,7 @@ const Menu = ({
                     dense={dense}
                 />
             ))}
-        <Responsive small={logout} medium={null} />
+        <Responsive xsmall={logout} medium={null} />
     </div>
 );
 

--- a/packages/react-admin/src/mui/layout/Menu.js
+++ b/packages/react-admin/src/mui/layout/Menu.js
@@ -36,6 +36,7 @@ const translatedResourceName = (resource, translate) =>
 const Menu = ({
     classes,
     className,
+    dense,
     hasDashboard,
     onMenuClick,
     resources,
@@ -54,6 +55,7 @@ const Menu = ({
                     primaryText={translatedResourceName(resource, translate)}
                     leftIcon={<resource.icon />}
                     onClick={onMenuClick}
+                    dense={dense}
                 />
             ))}
         <Responsive small={logout} medium={null} />
@@ -63,6 +65,7 @@ const Menu = ({
 Menu.propTypes = {
     classes: PropTypes.object,
     className: PropTypes.string,
+    dense: PropTypes.bool,
     hasDashboard: PropTypes.bool,
     logout: PropTypes.element,
     onMenuClick: PropTypes.func,

--- a/packages/react-admin/src/mui/layout/MenuItemLink.js
+++ b/packages/react-admin/src/mui/layout/MenuItemLink.js
@@ -6,10 +6,12 @@ import { MenuItem } from 'material-ui/Menu';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({
-    root: {},
+    root: {
+        color: theme.palette.secondary.dark,
+    },
     active: {
-        backgroundColor: theme.palette.primary.main,
-        color: theme.palette.primary.contrastText,
+        backgroundColor: theme.palette.secondary.main,
+        color: theme.palette.secondary.contrastText,
     },
     icon: { paddingRight: '0.5em' },
 });

--- a/packages/react-admin/src/mui/layout/MenuItemLink.js
+++ b/packages/react-admin/src/mui/layout/MenuItemLink.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { NavLink } from 'react-router-dom';
@@ -8,11 +8,13 @@ import { withStyles } from 'material-ui/styles';
 const styles = theme => ({
     root: {
         color: theme.palette.text.secondary,
+        display: 'flex',
+        alignItems: 'flex-start',
     },
     active: {
         color: theme.palette.text.primary,
     },
-    icon: { paddingRight: '0.5em' },
+    icon: { paddingRight: '1.2em' },
 });
 
 export class MenuItemLink extends Component {
@@ -48,7 +50,11 @@ export class MenuItemLink extends Component {
                 {...props}
                 onClick={this.handleMenuTap}
             >
-                {leftIcon && <span className={classes.icon}>{leftIcon}</span>}
+                {leftIcon && (
+                    <span className={classes.icon}>
+                        {cloneElement(leftIcon, { titleAccess: primaryText })}
+                    </span>
+                )}
                 {primaryText}
             </MenuItem>
         );

--- a/packages/react-admin/src/mui/layout/MenuItemLink.js
+++ b/packages/react-admin/src/mui/layout/MenuItemLink.js
@@ -7,11 +7,10 @@ import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({
     root: {
-        color: theme.palette.secondary.dark,
+        color: theme.palette.text.primary,
     },
     active: {
-        backgroundColor: theme.palette.secondary.main,
-        color: theme.palette.secondary.contrastText,
+        backgroundColor: theme.palette.background.default,
     },
     icon: { paddingRight: '0.5em' },
 });

--- a/packages/react-admin/src/mui/layout/MenuItemLink.js
+++ b/packages/react-admin/src/mui/layout/MenuItemLink.js
@@ -7,10 +7,10 @@ import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({
     root: {
-        color: theme.palette.text.primary,
+        color: theme.palette.text.secondary,
     },
     active: {
-        backgroundColor: theme.palette.background.default,
+        color: theme.palette.text.primary,
     },
     icon: { paddingRight: '0.5em' },
 });

--- a/packages/react-admin/src/mui/layout/Responsive.js
+++ b/packages/react-admin/src/mui/layout/Responsive.js
@@ -2,16 +2,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withWidth from 'material-ui/utils/withWidth';
 
-export const Responsive = ({ small, medium, large, width, ...rest }) => {
+export const Responsive = ({
+    xsmall,
+    small,
+    medium,
+    large,
+    width,
+    ...rest
+}) => {
     let element;
     switch (width) {
         case 'xs':
+            element =
+                typeof xsmall !== 'undefined'
+                    ? xsmall
+                    : typeof small !== 'undefined'
+                      ? small
+                      : typeof medium !== 'undefined' ? medium : large;
+            break;
+        case 'sm':
             element =
                 typeof small !== 'undefined'
                     ? small
                     : typeof medium !== 'undefined' ? medium : large;
             break;
-        case 'sm':
         case 'md':
             element =
                 typeof medium !== 'undefined'
@@ -33,6 +47,7 @@ export const Responsive = ({ small, medium, large, width, ...rest }) => {
 };
 
 Responsive.propTypes = {
+    xsmall: PropTypes.element,
     small: PropTypes.element,
     medium: PropTypes.element,
     large: PropTypes.element,

--- a/packages/react-admin/src/mui/layout/Responsive.spec.js
+++ b/packages/react-admin/src/mui/layout/Responsive.spec.js
@@ -38,7 +38,7 @@ describe('<Responsive>', () => {
                 small={<Small />}
                 medium={<Medium />}
                 large={<Large />}
-                width="sm"
+                width="md"
             />
         );
         const component = wrapper.find('Medium');
@@ -50,7 +50,7 @@ describe('<Responsive>', () => {
                 small={<Small />}
                 medium={null}
                 large={<Large />}
-                width="sm"
+                width="md"
             />
         );
         assert.equal(wrapper.get(0), null);
@@ -134,7 +134,7 @@ describe('<Responsive>', () => {
     });
     it('should fallback to the large component on medium screens', () => {
         const wrapper = shallow(
-            <Responsive small={<Small />} large={<Large />} width="sm" />
+            <Responsive small={<Small />} large={<Large />} width="md" />
         );
         const component = wrapper.find('Large');
         assert.equal(component.length, 1);

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -17,6 +17,7 @@ const styles = theme => ({
         position: 'relative',
         height: 'auto',
         width: DRAWER_WIDTH,
+        overflowX: 'hidden',
         transition: theme.transitions.create('width', {
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -81,6 +81,7 @@ class Sidebar extends PureComponent {
                         {...rest}
                     >
                         {React.cloneElement(children, {
+                            dense: true,
                             onMenuClick: this.handleClose,
                         })}
                     </Drawer>
@@ -95,7 +96,9 @@ class Sidebar extends PureComponent {
                         onClose={this.toggleSidebar}
                         {...rest}
                     >
-                        {children}
+                        {React.cloneElement(children, {
+                            dense: true,
+                        })}
                     </Drawer>
                 }
             />

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -3,11 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import Drawer from 'material-ui/Drawer';
-import Divider from 'material-ui/Divider';
 import { withStyles } from 'material-ui/styles';
 import withWidth from 'material-ui/utils/withWidth';
-import ChevronLeftIcon from 'material-ui-icons/ChevronLeft';
-import IconButton from 'material-ui/IconButton';
 
 import Responsive from './Responsive';
 import { setSidebarVisibility } from '../../actions';

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -19,12 +19,13 @@ const styles = theme => ({
         height: '100%',
         width: DRAWER_WIDTH,
         backgroundColor: theme.palette.background.default,
-        border: 'none',
         paddingTop: '5em',
-    },
-    drawerPaperMobile: {
-        height: '100%',
-        width: DRAWER_WIDTH,
+        [theme.breakpoints.up('md')]: {
+            border: 'none',
+        },
+        [theme.breakpoints.down('xs')]: {
+            paddingTop: 0,
+        },
     },
 });
 
@@ -48,19 +49,35 @@ class Sidebar extends PureComponent {
             classes,
             open,
             setSidebarVisibility,
+            width,
             ...rest
         } = this.props;
 
         return (
             <Responsive
-                small={
+                xsmall={
                     <Drawer
                         variant="temporary"
                         open={open}
-                        onClose={this.toggleSidebar}
                         classes={{
-                            paper: classes.drawerPaperMobile,
+                            paper: classes.drawerPaper,
                         }}
+                        onClose={this.toggleSidebar}
+                        {...rest}
+                    >
+                        {React.cloneElement(children, {
+                            onMenuClick: this.handleClose,
+                        })}
+                    </Drawer>
+                }
+                small={
+                    <Drawer
+                        variant="persistent"
+                        open={open}
+                        classes={{
+                            paper: classes.drawerPaper,
+                        }}
+                        onClose={this.toggleSidebar}
                         {...rest}
                     >
                         {React.cloneElement(children, {

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -22,12 +22,14 @@ const styles = theme => ({
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,
         }),
-        backgroundColor: theme.palette.background.default,
+        backgroundColor: 'transparent',
+        borderRight: 'none',
         marginTop: '4.5em',
         [theme.breakpoints.only('xs')]: {
             marginTop: 0,
             height: '100vh',
             position: 'inherit',
+            backgroundColor: theme.palette.background.default,
         },
         [theme.breakpoints.up('md')]: {
             border: 'none',

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -18,7 +18,6 @@ const styles = theme => ({
     drawerPaper: {
         height: '100%',
         width: DRAWER_WIDTH,
-        backgroundColor: theme.palette.secondary.light,
     },
     drawerHeader: {
         display: 'flex',

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -18,13 +18,13 @@ const styles = theme => ({
     drawerPaper: {
         height: '100%',
         width: DRAWER_WIDTH,
+        backgroundColor: theme.palette.background.default,
+        border: 'none',
+        paddingTop: '5em',
     },
-    drawerHeader: {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'flex-end',
-        padding: '0 8px',
-        ...theme.mixins.toolbar,
+    drawerPaperMobile: {
+        height: '100%',
+        width: DRAWER_WIDTH,
     },
 });
 
@@ -59,7 +59,7 @@ class Sidebar extends PureComponent {
                         open={open}
                         onClose={this.toggleSidebar}
                         classes={{
-                            paper: classes.drawerPaper,
+                            paper: classes.drawerPaperMobile,
                         }}
                         {...rest}
                     >
@@ -78,12 +78,6 @@ class Sidebar extends PureComponent {
                         onClose={this.toggleSidebar}
                         {...rest}
                     >
-                        <div className={classes.drawerHeader}>
-                            <IconButton onClick={this.toggleSidebar}>
-                                <ChevronLeftIcon />
-                            </IconButton>
-                        </div>
-                        <Divider />
                         {children}
                     </Drawer>
                 }

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -18,6 +18,7 @@ const styles = theme => ({
     drawerPaper: {
         height: '100%',
         width: DRAWER_WIDTH,
+        backgroundColor: theme.palette.secondary.light,
     },
     drawerHeader: {
         display: 'flex',

--- a/packages/react-admin/src/mui/layout/Sidebar.js
+++ b/packages/react-admin/src/mui/layout/Sidebar.js
@@ -5,6 +5,7 @@ import compose from 'recompose/compose';
 import Drawer from 'material-ui/Drawer';
 import { withStyles } from 'material-ui/styles';
 import withWidth from 'material-ui/utils/withWidth';
+import classnames from 'classnames';
 
 import Responsive from './Responsive';
 import { setSidebarVisibility } from '../../actions';
@@ -13,16 +14,27 @@ export const DRAWER_WIDTH = 240;
 
 const styles = theme => ({
     drawerPaper: {
-        height: '100%',
+        position: 'relative',
+        height: 'auto',
         width: DRAWER_WIDTH,
+        transition: theme.transitions.create('width', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
         backgroundColor: theme.palette.background.default,
-        paddingTop: '5em',
+        marginTop: '4.5em',
+        [theme.breakpoints.only('xs')]: {
+            marginTop: 0,
+            height: '100vh',
+            position: 'inherit',
+        },
         [theme.breakpoints.up('md')]: {
             border: 'none',
+            marginTop: '5.5em',
         },
-        [theme.breakpoints.down('xs')]: {
-            paddingTop: 0,
-        },
+    },
+    drawerPaperClose: {
+        width: 55,
     },
 });
 
@@ -69,10 +81,13 @@ class Sidebar extends PureComponent {
                 }
                 small={
                     <Drawer
-                        variant="persistent"
+                        variant="permanent"
                         open={open}
                         classes={{
-                            paper: classes.drawerPaper,
+                            paper: classnames(
+                                classes.drawerPaper,
+                                !open && classes.drawerPaperClose
+                            ),
                         }}
                         onClose={this.toggleSidebar}
                         {...rest}
@@ -85,10 +100,13 @@ class Sidebar extends PureComponent {
                 }
                 medium={
                     <Drawer
-                        variant="persistent"
+                        variant="permanent"
                         open={open}
                         classes={{
-                            paper: classes.drawerPaper,
+                            paper: classnames(
+                                classes.drawerPaper,
+                                !open && classes.drawerPaperClose
+                            ),
                         }}
                         onClose={this.toggleSidebar}
                         {...rest}

--- a/packages/react-admin/src/mui/layout/ViewTitle.js
+++ b/packages/react-admin/src/mui/layout/ViewTitle.js
@@ -9,7 +9,7 @@ import AppBarMobile from './AppBarMobile';
 
 const ViewTitle = ({ className, title, ...rest }) => (
     <Responsive
-        small={
+        xsmall={
             <AppBarMobile
                 className={classnames('title', className)}
                 title={title}


### PR DESCRIPTION
- [x] use secondary for sidebar and app bar
- [x] use primary for active elements (that's the mui convention)
- [x] Find the right palette
- [x] Use icon-only sidebar when minimized
- [x] Make the app bar move with the window (except on mobile, where is is still fixed)
- [x] Fix scrolling and background color glitches

Before:

![kapture 2018-02-16 at 14 37 56](https://user-images.githubusercontent.com/99944/36310025-0adda4e0-1327-11e8-8969-f22983d27a97.gif)

After:

![kapture 2018-02-16 at 14 32 51](https://user-images.githubusercontent.com/99944/36309805-5201d14e-1326-11e8-8956-a7b4b454b745.gif)


