### PR TITLE
[RFR] Better error messages for references of undeclared Resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install: package.json ## install dependencies
 run: run-simple
 
 run-simple: ## run the simple example
-	@cd examples/simple && ./node_modules/.bin/webpack-dev-server --hot --inline --config ./webpack.config.js
+	@cd examples/simple && ./node_modules/.bin/webpack-dev-server -d --hot --inline --config ./webpack.config.js
 
 run-tutorial: build ## run the tutorial example
 	@cd examples/tutorial && yarn start

--- a/packages/ra-core/src/reducer/admin/references/oneToMany.js
+++ b/packages/ra-core/src/reducer/admin/references/oneToMany.js
@@ -20,8 +20,28 @@ export const getIds = (state, relatedTo) =>
 export const getReferences = (state, reference, relatedTo) => {
     const ids = getIds(state, relatedTo);
     if (typeof ids === 'undefined') return undefined;
+
+    if (!state.admin.resources[reference]) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `Invalid Resource "${reference}"\n` +
+                `You are trying to display or edit a field of a resource called "${reference}", ` +
+                'but it has not been declared.\n' +
+                "Declare this resource in the Admin or check the 'reference' prop of ReferenceArrayField and ReferenceManyField.",
+            { ids }
+        );
+    }
+
     return ids
-        .map(id => state.admin.resources[reference].data[id])
+        .map(id => {
+            const resource = state.admin.resources[reference];
+
+            if (!resource) {
+                return;
+            }
+
+            return resource.data[id];
+        })
         .filter(r => typeof r !== 'undefined')
         .reduce((prev, record) => {
             prev[record.id] = record; // eslint-disable-line no-param-reassign
@@ -31,8 +51,28 @@ export const getReferences = (state, reference, relatedTo) => {
 
 export const getReferencesByIds = (state, reference, ids) => {
     if (ids.length === 0) return {};
+
+    if (!state.admin.resources[reference]) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `Invalid Resource "${reference}"\n` +
+                `You are trying to display or edit a field of a resource called "${reference}", ` +
+                'but it has not been declared.\n' +
+                "Declare this resource in the Admin or check the 'reference' prop of ReferenceArrayField.",
+            { ids }
+        );
+    }
+
     return ids
-        .map(id => state.admin.resources[reference].data[id])
+        .map(id => {
+            const resource = state.admin.resources[reference];
+
+            if (!resource) {
+                return;
+            }
+
+            return resource.data[id];
+        })
         .filter(r => typeof r !== 'undefined')
         .reduce((prev, record) => {
             prev[record.id] = record; // eslint-disable-line no-param-reassign


### PR DESCRIPTION
References to a non-declared Resource is a common error in ng-admin and admin-on-rest (see #1393).
The current error message is pretty misleading.

I improved it a bit with a description of what is happening and how to resolve it.
For example, now if you remove the resource `tags` of the simple example:

![image](https://user-images.githubusercontent.com/1819833/36273082-ac1d2af0-1283-11e8-9ac6-953158477c73.png)
