### PR TITLE
[RFR]: SelectArrayInput render child instead of Chip

### DIFF
--- a/packages/ra-ui-materialui/src/field/ChipField.js
+++ b/packages/ra-ui-materialui/src/field/ChipField.js
@@ -13,7 +13,7 @@ const styles = {
 
 export const ChipField = ({
     className,
-    classes,
+    classes = {},
     source,
     record = {},
     ...rest

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -6,7 +6,6 @@ import { MenuItem } from 'material-ui/Menu';
 import Input, { InputLabel } from 'material-ui/Input';
 import { FormControl, FormHelperText } from 'material-ui/Form';
 import { withStyles } from 'material-ui/styles';
-import Chip from 'material-ui/Chip';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
 import { addField, translate, FieldTitle } from 'ra-core';
@@ -156,6 +155,7 @@ export class SelectArrayInput extends Component {
 
     render() {
         const {
+            children,
             choices,
             classes,
             className,
@@ -201,13 +201,13 @@ export class SelectArrayInput extends Component {
                                 .filter(choice =>
                                     selected.includes(get(choice, optionValue))
                                 )
-                                .map(choice => (
-                                    <Chip
-                                        key={get(choice, optionValue)}
-                                        label={get(choice, optionText)}
-                                        className={classes.chip}
-                                    />
-                                ))}
+                                .map(choice =>
+                                    React.cloneElement(children, {
+                                        key: get(choice, optionValue),
+                                        record: choice,
+                                        className: classes.chip,
+                                    })
+                                )}
                         </div>
                     )}
                     {...options}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import assert from 'assert';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { SelectArrayInput } from './SelectArrayInput';
+import { ChipField } from '../field/ChipField';
 
 describe('<SelectArrayInput />', () => {
     const defaultProps = {
+        classes: {},
         source: 'foo',
         meta: {},
         input: {},
@@ -177,6 +179,25 @@ describe('<SelectArrayInput />', () => {
         const helperText = wrapper.find('WithStyles(FormHelperText)');
         assert.equal(helperText.length, 1);
         assert.equal(helperText.childAt(0).text(), 'Can i help you?');
+    });
+
+    describe('rendering children', () => {
+        it('should render its children', () => {
+            const wrapper = mount(
+                <SelectArrayInput
+                    {...defaultProps}
+                    input={{ value: ['M'] }}
+                    choices={[
+                        { id: 'M', name: 'Male' },
+                        { id: 'F', name: 'Female' },
+                    ]}
+                >
+                    <ChipField source="name" />
+                </SelectArrayInput>
+            );
+            expect(wrapper.find('ChipField')).toHaveLength(1);
+            expect(wrapper.find('ChipField').text()).toEqual('Male');
+        });
     });
 
     describe('error message', () => {


### PR DESCRIPTION
The simple example shows : 
```
<ReferenceArrayInput reference="tags" source="tags">
    <SelectArrayInput>
        <ChipField source="name" />
    </SelectArrayInput>
</ReferenceArrayInput>
```
This make me think that the `SelectArrayInput` uses `ChipField` to render, but it doesn't. Currently it renders a `<Chip >` field. This PR changes this to clone the child element instead. 
