### PR TITLE
[RFR] Improve colors, sidebar, and layout

### DIFF
--- a/packages/ra-ui-materialui/src/auth/Logout.js
+++ b/packages/ra-ui-materialui/src/auth/Logout.js
@@ -12,7 +12,7 @@ import Responsive from '../layout/Responsive';
 import { translate, userLogout as userLogoutAction } from 'ra-core';
 
 const styles = {
-    iconPaddingStyle: { paddingRight: '0.5em' },
+    iconPaddingStyle: { paddingRight: '1.2em' },
 };
 
 const sanitizeRestProps = ({

--- a/packages/ra-ui-materialui/src/button/DeleteButton.js
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.js
@@ -2,21 +2,39 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ActionDelete from 'material-ui-icons/Delete';
 import { linkToRecord } from 'ra-core';
+import { withStyles } from 'material-ui/styles';
+import { fade } from 'material-ui/styles/colorManipulator';
+import classnames from 'classnames';
 
-import Link from '../Link';
+import { Link } from 'react-router-dom';
 import Button from './Button';
+
+const styles = theme => ({
+    deleteButton: {
+        color: theme.palette.error.main,
+        '&:hover': {
+            backgroundColor: fade(theme.palette.error.main, 0.12),
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: 'transparent',
+            },
+        },
+    },
+});
 
 const DeleteButton = ({
     basePath = '',
     label = 'ra.action.delete',
     record = {},
+    classes = {},
+    className,
     ...rest
 }) => (
     <Button
         component={Link}
         to={`${linkToRecord(basePath, record.id)}/delete`}
         label={label}
-        color="secondary"
+        className={classnames(classes.deleteButton, className)}
         {...rest}
     >
         <ActionDelete />
@@ -25,8 +43,10 @@ const DeleteButton = ({
 
 DeleteButton.propTypes = {
     basePath: PropTypes.string,
+    classes: PropTypes.object,
+    className: PropTypes.string,
     label: PropTypes.string,
     record: PropTypes.object,
 };
 
-export default DeleteButton;
+export default withStyles(styles)(DeleteButton);

--- a/packages/ra-ui-materialui/src/defaultTheme.js
+++ b/packages/ra-ui-materialui/src/defaultTheme.js
@@ -1,1 +1,10 @@
-export default {};
+export default {
+    palette: {
+        secondary: {
+            light: '#6ec6ff',
+            main: '#2196f3',
+            dark: '#0069c0',
+            contrastText: '#fff',
+        },
+    },
+};

--- a/packages/ra-ui-materialui/src/delete/Delete.js
+++ b/packages/ra-ui-materialui/src/delete/Delete.js
@@ -17,6 +17,17 @@ const styles = theme => ({
     button: {
         margin: theme.spacing.unit * 2,
     },
+    buttonDelete: {
+        backgroundColor: theme.palette.error.main,
+        color: theme.palette.error.contrastText,
+        '&:hover': {
+            backgroundColor: theme.palette.error.dark,
+            // Reset on mouse devices
+            '@media (hover: none)': {
+                backgroundColor: theme.palette.error.main,
+            },
+        },
+    },
     iconPaddingStyle: {
         paddingRight: '0.5em',
     },
@@ -94,8 +105,7 @@ const DeleteView = ({
                     <Button
                         variant="raised"
                         type="submit"
-                        color="primary"
-                        className={classes.button}
+                        className={`${classes.button} ${classes.buttonDelete}`}
                     >
                         <ActionCheck className={classes.iconPaddingStyle} />
                         {translate('ra.action.delete')}

--- a/packages/ra-ui-materialui/src/field/ReferenceField.js
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.js
@@ -10,7 +10,7 @@ import sanitizeRestProps from './sanitizeRestProps';
 
 const styles = theme => ({
     link: {
-        color: theme.palette.secondary.main,
+        color: theme.palette.primary.main,
     },
 });
 

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -9,9 +9,8 @@ import MenuIcon from 'material-ui-icons/Menu';
 import Typography from 'material-ui/Typography';
 import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
-
 import { toggleSidebar as toggleSidebarAction } from 'ra-core';
-import { DRAWER_WIDTH } from './Sidebar';
+
 import LoadingIndicator from './LoadingIndicator';
 
 const styles = theme => ({
@@ -20,21 +19,25 @@ const styles = theme => ({
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,
         }),
-    },
-    appBarShift: {
-        marginLeft: DRAWER_WIDTH,
-        width: `calc(100% - ${DRAWER_WIDTH}px)`,
-        transition: theme.transitions.create(['margin', 'width'], {
-            easing: theme.transitions.easing.easeOut,
-            duration: theme.transitions.duration.enteringScreen,
-        }),
+        zIndex: 1300,
     },
     menuButton: {
-        marginLeft: 12,
-        marginRight: 20,
+        marginLeft: '0.5em',
+        marginRight: '0.5em',
     },
-    hide: {
-        display: 'none',
+    menuButtonIconClosed: {
+        transition: theme.transitions.create(['transform'], {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+        transform: 'rotate(0deg)',
+    },
+    menuButtonIconOpen: {
+        transition: theme.transitions.create(['transform'], {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+        transform: 'rotate(180deg)',
     },
     title: {
         flex: 1,
@@ -51,7 +54,7 @@ const styles = theme => ({
         marginRight: 'auto',
     },
     logout: {
-        color: theme.palette.primary.contrastText,
+        color: theme.palette.secondary.contrastText,
     },
 });
 
@@ -65,21 +68,25 @@ const AppBar = ({
     ...rest
 }) => (
     <MuiAppBar
-        className={classNames(
-            classes.appBar,
-            open && classes.appBarShift,
-            className
-        )}
+        className={classNames(classes.appBar, className)}
+        color="secondary"
+        position="absolute"
         {...rest}
     >
-        <Toolbar disableGutters={!open}>
+        <Toolbar disableGutters>
             <IconButton
                 color="inherit"
                 aria-label="open drawer"
                 onClick={toggleSidebar}
-                className={classNames(classes.menuButton, open && classes.hide)}
+                className={classNames(classes.menuButton)}
             >
-                <MenuIcon />
+                <MenuIcon
+                    classes={{
+                        root: open
+                            ? classes.menuButtonIconOpen
+                            : classes.menuButtonIconClosed,
+                    }}
+                />
             </IconButton>
             <Typography
                 variant="title"

--- a/packages/ra-ui-materialui/src/layout/AppBarMobile.js
+++ b/packages/ra-ui-materialui/src/layout/AppBarMobile.js
@@ -9,14 +9,13 @@ import Typography from 'material-ui/Typography';
 import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
+import { toggleSidebar } from 'ra-core';
 
 import LoadingIndicator from './LoadingIndicator';
-import { toggleSidebar } from 'ra-core';
 
 const styles = {
     bar: {
         height: '3em',
-        position: 'absolute',
         top: 0,
     },
     title: {
@@ -50,7 +49,12 @@ const AppBarMobile = ({
     toggleSidebar,
     ...rest
 }) => (
-    <MuiAppBar className={classnames(classes.bar, className)} {...rest}>
+    <MuiAppBar
+        className={classnames(classes.bar, className)}
+        color="secondary"
+        position="fixed"
+        {...rest}
+    >
         <Toolbar>
             <IconButton
                 color="inherit"

--- a/packages/ra-ui-materialui/src/layout/Layout.js
+++ b/packages/ra-ui-materialui/src/layout/Layout.js
@@ -11,7 +11,7 @@ import Hidden from 'material-ui/Hidden';
 import compose from 'recompose/compose';
 
 import AppBar from './AppBar';
-import Sidebar, { DRAWER_WIDTH } from './Sidebar';
+import Sidebar from './Sidebar';
 import Menu from './Menu';
 import Notification from './Notification';
 import defaultTheme from '../defaultTheme';
@@ -20,44 +20,27 @@ const styles = theme => ({
     root: {
         width: '100%',
         zIndex: 1,
+        minHeight: '100vh',
+        backgroundColor: theme.palette.background.default,
     },
     appFrame: {
         position: 'relative',
         display: 'flex',
         width: '100%',
-        height: '100%',
     },
     content: {
         width: '100%',
-        marginLeft: 0,
         flexGrow: 1,
-        backgroundColor: theme.palette.background.default,
         padding: theme.spacing.unit * 3,
-        transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen,
-        }),
-        height: 'calc(100% - 56px)',
-        [theme.breakpoints.up('md')]: {
-            content: {
-                height: 'calc(100% - 64px)',
-                marginTop: 64,
-            },
-        },
         [theme.breakpoints.up('xs')]: {
             marginTop: '4em',
+            paddingLeft: 5,
         },
         [theme.breakpoints.down('sm')]: {
             padding: 0,
         },
-    },
-    contentShift: {
-        [theme.breakpoints.up('md')]: {
-            marginLeft: DRAWER_WIDTH,
-            transition: theme.transitions.create('margin', {
-                easing: theme.transitions.easing.easeOut,
-                duration: theme.transitions.duration.enteringScreen,
-            }),
+        [theme.breakpoints.down('xs')]: {
+            marginTop: '3em',
         },
     },
 });
@@ -92,14 +75,7 @@ const Layout = ({
                         hasDashboard: !!dashboard,
                     })}
                 </Sidebar>
-                <main
-                    className={classnames(
-                        classes.content,
-                        open && classes.contentShift
-                    )}
-                >
-                    {children}
-                </main>
+                <main className={classes.content}>{children}</main>
                 <Notification />
             </div>
         </div>

--- a/packages/ra-ui-materialui/src/layout/Loading.js
+++ b/packages/ra-ui-materialui/src/layout/Loading.js
@@ -40,7 +40,7 @@ const Loading = ({
 }) => (
     <div className={classnames(classes.container, className)}>
         <div className={classes.message}>
-            <CircularProgress className={classes.icon} />
+            <CircularProgress className={classes.icon} color="primary" />
             <h1>{translate(loadingPrimary)}</h1>
             <div>{translate(loadingSecondary)}.</div>
         </div>

--- a/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
+++ b/packages/ra-ui-materialui/src/layout/LoadingIndicator.js
@@ -10,7 +10,6 @@ import compose from 'recompose/compose';
 const styles = {
     loader: {
         margin: 16,
-        color: 'white',
     },
 };
 
@@ -24,8 +23,9 @@ export const LoadingIndicator = ({
     isLoading ? (
         <CircularProgress
             className={classNames('app-loader', classes.loader, className)}
+            color="inherit"
             size={width === 'xs' || width === 'sm' ? 20 : 30}
-            thickness={2}
+            thickness={3}
             {...rest}
         />
     ) : null;

--- a/packages/ra-ui-materialui/src/layout/Menu.js
+++ b/packages/ra-ui-materialui/src/layout/Menu.js
@@ -5,18 +5,19 @@ import inflection from 'inflection';
 import compose from 'recompose/compose';
 import { withStyles } from 'material-ui/styles';
 import classnames from 'classnames';
+import { getResources, translate } from 'ra-core';
 
 import DashboardMenuItem from './DashboardMenuItem';
 import MenuItemLink from './MenuItemLink';
 import Responsive from '../layout/Responsive';
-import { getResources, translate } from 'ra-core';
+import { DRAWER_WIDTH } from './Sidebar';
 
 const styles = {
     main: {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'flex-start',
-        height: '100%',
+        width: DRAWER_WIDTH,
     },
 };
 
@@ -35,6 +36,7 @@ const translatedResourceName = (resource, translate) =>
 const Menu = ({
     classes,
     className,
+    dense,
     hasDashboard,
     onMenuClick,
     resources,
@@ -53,15 +55,17 @@ const Menu = ({
                     primaryText={translatedResourceName(resource, translate)}
                     leftIcon={<resource.icon />}
                     onClick={onMenuClick}
+                    dense={dense}
                 />
             ))}
-        <Responsive small={logout} medium={null} />
+        <Responsive xsmall={logout} medium={null} />
     </div>
 );
 
 Menu.propTypes = {
     classes: PropTypes.object,
     className: PropTypes.string,
+    dense: PropTypes.bool,
     hasDashboard: PropTypes.bool,
     logout: PropTypes.element,
     onMenuClick: PropTypes.func,

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.js
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { NavLink } from 'react-router-dom';
@@ -6,12 +6,15 @@ import { MenuItem } from 'material-ui/Menu';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({
-    root: {},
-    active: {
-        backgroundColor: theme.palette.primary.main,
-        color: theme.palette.primary.contrastText,
+    root: {
+        color: theme.palette.text.secondary,
+        display: 'flex',
+        alignItems: 'flex-start',
     },
-    icon: { paddingRight: '0.5em' },
+    active: {
+        color: theme.palette.text.primary,
+    },
+    icon: { paddingRight: '1.2em' },
 });
 
 export class MenuItemLink extends Component {
@@ -47,7 +50,11 @@ export class MenuItemLink extends Component {
                 {...props}
                 onClick={this.handleMenuTap}
             >
-                {leftIcon && <span className={classes.icon}>{leftIcon}</span>}
+                {leftIcon && (
+                    <span className={classes.icon}>
+                        {cloneElement(leftIcon, { titleAccess: primaryText })}
+                    </span>
+                )}
                 {primaryText}
             </MenuItem>
         );

--- a/packages/ra-ui-materialui/src/layout/Responsive.js
+++ b/packages/ra-ui-materialui/src/layout/Responsive.js
@@ -2,16 +2,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withWidth from 'material-ui/utils/withWidth';
 
-export const Responsive = ({ small, medium, large, width, ...rest }) => {
+export const Responsive = ({
+    xsmall,
+    small,
+    medium,
+    large,
+    width,
+    ...rest
+}) => {
     let element;
     switch (width) {
         case 'xs':
+            element =
+                typeof xsmall !== 'undefined'
+                    ? xsmall
+                    : typeof small !== 'undefined'
+                      ? small
+                      : typeof medium !== 'undefined' ? medium : large;
+            break;
+        case 'sm':
             element =
                 typeof small !== 'undefined'
                     ? small
                     : typeof medium !== 'undefined' ? medium : large;
             break;
-        case 'sm':
         case 'md':
             element =
                 typeof medium !== 'undefined'
@@ -33,6 +47,7 @@ export const Responsive = ({ small, medium, large, width, ...rest }) => {
 };
 
 Responsive.propTypes = {
+    xsmall: PropTypes.element,
     small: PropTypes.element,
     medium: PropTypes.element,
     large: PropTypes.element,

--- a/packages/ra-ui-materialui/src/layout/Responsive.spec.js
+++ b/packages/ra-ui-materialui/src/layout/Responsive.spec.js
@@ -38,7 +38,7 @@ describe('<Responsive>', () => {
                 small={<Small />}
                 medium={<Medium />}
                 large={<Large />}
-                width="sm"
+                width="md"
             />
         );
         const component = wrapper.find('Medium');
@@ -50,7 +50,7 @@ describe('<Responsive>', () => {
                 small={<Small />}
                 medium={null}
                 large={<Large />}
-                width="sm"
+                width="md"
             />
         );
         assert.equal(wrapper.get(0), null);
@@ -134,7 +134,7 @@ describe('<Responsive>', () => {
     });
     it('should fallback to the large component on medium screens', () => {
         const wrapper = shallow(
-            <Responsive small={<Small />} large={<Large />} width="sm" />
+            <Responsive small={<Small />} large={<Large />} width="md" />
         );
         const component = wrapper.find('Large');
         assert.equal(component.length, 1);

--- a/packages/ra-ui-materialui/src/layout/Sidebar.js
+++ b/packages/ra-ui-materialui/src/layout/Sidebar.js
@@ -3,28 +3,41 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import Drawer from 'material-ui/Drawer';
-import Divider from 'material-ui/Divider';
 import { withStyles } from 'material-ui/styles';
 import withWidth from 'material-ui/utils/withWidth';
-import ChevronLeftIcon from 'material-ui-icons/ChevronLeft';
-import IconButton from 'material-ui/IconButton';
+import classnames from 'classnames';
+import { setSidebarVisibility } from 'ra-core';
 
 import Responsive from './Responsive';
-import { setSidebarVisibility } from 'ra-core';
 
 export const DRAWER_WIDTH = 240;
 
 const styles = theme => ({
     drawerPaper: {
-        height: '100%',
+        position: 'relative',
+        height: 'auto',
         width: DRAWER_WIDTH,
+        overflowX: 'hidden',
+        transition: theme.transitions.create('width', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+        }),
+        backgroundColor: 'transparent',
+        borderRight: 'none',
+        marginTop: '4.5em',
+        [theme.breakpoints.only('xs')]: {
+            marginTop: 0,
+            height: '100vh',
+            position: 'inherit',
+            backgroundColor: theme.palette.background.default,
+        },
+        [theme.breakpoints.up('md')]: {
+            border: 'none',
+            marginTop: '5.5em',
+        },
     },
-    drawerHeader: {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'flex-end',
-        padding: '0 8px',
-        ...theme.mixins.toolbar,
+    drawerPaperClose: {
+        width: 55,
     },
 });
 
@@ -48,19 +61,20 @@ class Sidebar extends PureComponent {
             classes,
             open,
             setSidebarVisibility,
+            width,
             ...rest
         } = this.props;
 
         return (
             <Responsive
-                small={
+                xsmall={
                     <Drawer
                         variant="temporary"
                         open={open}
-                        onClose={this.toggleSidebar}
                         classes={{
                             paper: classes.drawerPaper,
                         }}
+                        onClose={this.toggleSidebar}
                         {...rest}
                     >
                         {React.cloneElement(children, {
@@ -68,23 +82,41 @@ class Sidebar extends PureComponent {
                         })}
                     </Drawer>
                 }
-                medium={
+                small={
                     <Drawer
-                        variant="persistent"
+                        variant="permanent"
                         open={open}
                         classes={{
-                            paper: classes.drawerPaper,
+                            paper: classnames(
+                                classes.drawerPaper,
+                                !open && classes.drawerPaperClose
+                            ),
                         }}
                         onClose={this.toggleSidebar}
                         {...rest}
                     >
-                        <div className={classes.drawerHeader}>
-                            <IconButton onClick={this.toggleSidebar}>
-                                <ChevronLeftIcon />
-                            </IconButton>
-                        </div>
-                        <Divider />
-                        {children}
+                        {React.cloneElement(children, {
+                            dense: true,
+                            onMenuClick: this.handleClose,
+                        })}
+                    </Drawer>
+                }
+                medium={
+                    <Drawer
+                        variant="permanent"
+                        open={open}
+                        classes={{
+                            paper: classnames(
+                                classes.drawerPaper,
+                                !open && classes.drawerPaperClose
+                            ),
+                        }}
+                        onClose={this.toggleSidebar}
+                        {...rest}
+                    >
+                        {React.cloneElement(children, {
+                            dense: true,
+                        })}
                     </Drawer>
                 }
             />

--- a/packages/ra-ui-materialui/src/layout/ViewTitle.js
+++ b/packages/ra-ui-materialui/src/layout/ViewTitle.js
@@ -9,7 +9,7 @@ import AppBarMobile from './AppBarMobile';
 
 const ViewTitle = ({ className, title, ...rest }) => (
     <Responsive
-        small={
+        xsmall={
             <AppBarMobile
                 className={classnames('title', className)}
                 title={title}


### PR DESCRIPTION
- [x] use secondary for sidebar and app bar
- [x] use primary for active elements (that's the mui convention)
- [x] Find the right palette
- [x] Use icon-only sidebar when minimized
- [x] Make the app bar move with the window (except on mobile, where is is still fixed)
- [x] Fix scrolling and background color glitches

Before:

![kapture 2018-02-16 at 14 37 56](https://user-images.githubusercontent.com/99944/36310025-0adda4e0-1327-11e8-8969-f22983d27a97.gif)

After:

![kapture 2018-02-16 at 14 32 51](https://user-images.githubusercontent.com/99944/36309805-5201d14e-1326-11e8-8956-a7b4b454b745.gif)

Supersedes #1542
