### PR TITLE
[RFR] Reduce datagrid toolbar horizontal spacing

### DIFF
--- a/examples/simple/posts.js
+++ b/examples/simple/posts.js
@@ -49,7 +49,7 @@ import {
 import RichTextInput from 'ra-input-rich-text';
 import Chip from 'material-ui/Chip';
 import { withStyles } from 'material-ui/styles';
-
+import MuiToolbar from 'material-ui/Toolbar';
 import BookIcon from 'material-ui-icons/Book';
 export const PostIcon = BookIcon;
 import UpdateCommentableMenuItem from './customBulkAction';
@@ -79,6 +79,9 @@ const styles = {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
+    },
+    gridButtons: {
+        minHeight: 'auto',
     },
     publishedAt: { fontStyle: 'italic' },
 };
@@ -128,8 +131,10 @@ export const PostList = withStyles(styles)(({ classes, ...props }) => (
                             <ChipField source="name" />
                         </SingleFieldList>
                     </ReferenceArrayField>
-                    <EditButton />
-                    <ShowButton />
+                    <MuiToolbar disableGutters className={classes.gridButtons}>
+                        <EditButton />
+                        <ShowButton />
+                    </MuiToolbar>
                 </Datagrid>
             }
         />

--- a/packages/ra-ui-materialui/src/button/Button.js
+++ b/packages/ra-ui-materialui/src/button/Button.js
@@ -37,6 +37,7 @@ const Button = ({
         small={
             <IconButton
                 arial-label={label && translate(label, { _: label })}
+                className={className}
                 color={color}
                 {...rest}
             >

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -32,6 +32,9 @@ const styles = {
             padding: '0 12px 0 16px',
             whiteSpace: 'normal',
         },
+        '&:last-child': {
+            padding: '0 12px',
+        },
     },
 };
 


### PR DESCRIPTION
Leave more space to the content and less to the chrome.

Before:

![image](https://user-images.githubusercontent.com/99944/36369560-f52bfd72-155b-11e8-8a14-1abaf87d1de4.png)

After:

![image](https://user-images.githubusercontent.com/99944/36369539-e081bda8-155b-11e8-885b-4fbd083e01d5.png)
