### PR TITLE
[RFR] Documentation - Examples section

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: "Examples"
+---
+
+# Examples
+
+## Adding a Create button linked to a ReferenceManyField
+
+This example demonstrate how you can add a `Create` button visually linked to a `ReferenceManyField` and redirecting to a Create view for the referenced resource with some data already filled.
+
+For example, an `Edit` or `Show` view for a post might have a `ReferenceManyField` for its comments and we could add a button below it to create a comment for the current post.
+
+The relevant code parts are:
+
+* the `CreateCommentButton` component inside `src/posts.js`
+* the `CommentCreate` component inside `src/comments.js` (note how we set the `defaultValue` prop on `SimpleForm`)
+
+CodeSandbox: [https://codesandbox.io/s/pp0o4x40p0](https://codesandbox.io/s/pp0o4x40p0)

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -696,6 +696,12 @@
                             <b>19.</b> Ecosystem
                         </a>
                     </li>
+
+                    <li class="chapter {% if page.path == 'Examples.md' %}active{% endif %}">
+                        <a href="./Examples.html">
+                            <b>20.</b> Examples
+                        </a>
+                    </li>
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
Add an `Examples` section to the documentation with a first example showing how to add a Create button linked to a ReferenceManyField