### PR TITLE
[RFR] Use material ui features

### DIFF
--- a/e2e/tests/permissions.js
+++ b/e2e/tests/permissions.js
@@ -54,8 +54,8 @@ describe('Permissions', () => {
             await ListPage.navigate();
             assert.deepEqual(await ListPage.getColumns(), [
                 '', // Checkbox column
-                'ID',
-                'NAME',
+                'Id',
+                'Name',
                 '',
                 '',
             ]);
@@ -94,9 +94,9 @@ describe('Permissions', () => {
             await ListPage.navigate();
             assert.deepEqual(await ListPage.getColumns(), [
                 '', // Checkbox column
-                'ID',
-                'NAME',
-                'ROLE',
+                'Id',
+                'Name',
+                'Role',
                 '',
                 '',
             ]);

--- a/examples/simple/posts.js
+++ b/examples/simple/posts.js
@@ -48,8 +48,10 @@ import {
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
 import RichTextInput from 'ra-input-rich-text';
 import Chip from 'material-ui/Chip';
+import { InputAdornment } from 'material-ui/Input';
 import { withStyles } from 'material-ui/styles';
 import BookIcon from 'material-ui-icons/Book';
+import SearchIcon from 'material-ui-icons/Search';
 export const PostIcon = BookIcon;
 import ResetViewsAction from './ResetViewsAction';
 
@@ -59,7 +61,18 @@ const QuickFilter = translate(({ label, translate }) => (
 
 const PostFilter = props => (
     <Filter {...props}>
-        <TextInput label="post.list.search" source="q" alwaysOn />
+        <TextInput
+            label="post.list.search"
+            source="q"
+            alwaysOn
+            InputProps={{
+                endAdornment: (
+                    <InputAdornment position="end">
+                        <SearchIcon color="disabled" />
+                    </InputAdornment>
+                ),
+            }}
+        />
         <TextInput
             source="title"
             defaultValue="Qui tempore rerum et voluptates"

--- a/examples/simple/posts.js
+++ b/examples/simple/posts.js
@@ -127,6 +127,7 @@ export const PostList = withStyles(styles)(({ classes, ...props }) => (
                     <BooleanField
                         source="commentable"
                         label="resources.posts.fields.commentable_short"
+                        sortable={false}
                     />
                     <NumberField source="views" />
                     <ReferenceArrayField

--- a/examples/simple/users.js
+++ b/examples/simple/users.js
@@ -24,12 +24,25 @@ import {
     required,
     translate,
 } from 'react-admin'; // eslint-disable-line import/no-unresolved
+import { InputAdornment } from 'material-ui/Input';
 import PeopleIcon from 'material-ui-icons/People';
+import SearchIcon from 'material-ui-icons/Search';
 export const UserIcon = PeopleIcon;
 
 const UserFilter = ({ permissions, ...props }) => (
     <Filter {...props}>
-        <TextInput label="user.list.search" source="q" alwaysOn />
+        <TextInput
+            label="user.list.search"
+            source="q"
+            alwaysOn
+            InputProps={{
+                endAdornment: (
+                    <InputAdornment position="end">
+                        <SearchIcon color="disabled" />
+                    </InputAdornment>
+                ),
+            }}
+        />
         <TextInput source="name" />
         {permissions === 'admin' ? <TextInput source="role" /> : null}
     </Filter>

--- a/examples/simple/users.js
+++ b/examples/simple/users.js
@@ -50,7 +50,7 @@ export const UserList = ({ permissions, ...props }) => (
                 />
             }
             medium={
-                <Datagrid>
+                <Datagrid hover={false}>
                     <TextField source="id" />
                     <TextField source="name" />
                     {permissions === 'admin' && <TextField source="role" />}

--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -7,6 +7,7 @@ module.exports = {
             save: 'Save',
             create: 'Create',
             edit: 'Edit',
+            sort: 'Sort',
             cancel: 'Cancel',
             refresh: 'Refresh',
             add_filter: 'Add filter',

--- a/packages/ra-language-french/index.js
+++ b/packages/ra-language-french/index.js
@@ -7,6 +7,7 @@ module.exports = {
             save: 'Enregistrer',
             create: 'Créer',
             edit: 'Éditer',
+            sort: 'Trier',
             cancel: 'Quitter',
             refresh: 'Actualiser',
             add_filter: 'Ajouter un filtre',

--- a/packages/ra-ui-materialui/src/field/sanitizeRestProps.js
+++ b/packages/ra-ui-materialui/src/field/sanitizeRestProps.js
@@ -11,6 +11,7 @@ export default ({
     locale,
     record,
     resource,
+    sortable,
     source,
     textAlign,
     translateChoice,

--- a/packages/ra-ui-materialui/src/layout/Confirm.js
+++ b/packages/ra-ui-materialui/src/layout/Confirm.js
@@ -68,6 +68,10 @@ const Confirm = ({
             <DialogContentText>{content}</DialogContentText>
         </DialogContent>
         <DialogActions>
+            <Button onClick={onClose}>
+                <AlertError className={classes.iconPaddingStyle} />
+                {cancel}
+            </Button>
             <Button
                 onClick={onConfirm}
                 className={classnames('ra-confirm', {
@@ -78,10 +82,6 @@ const Confirm = ({
             >
                 <ActionCheck className={classes.iconPaddingStyle} />
                 {confirm}
-            </Button>
-            <Button onClick={onClose}>
-                <AlertError className={classes.iconPaddingStyle} />
-                {cancel}
             </Button>
         </DialogActions>
     </Dialog>

--- a/packages/ra-ui-materialui/src/list/BulkActions.js
+++ b/packages/ra-ui-materialui/src/list/BulkActions.js
@@ -1,9 +1,9 @@
 import React, { cloneElement, Children, Component } from 'react';
 
 import PropTypes from 'prop-types';
-import MoreVertIcon from 'material-ui-icons/MoreVert';
+import FilterNoneIcon from 'material-ui-icons/FilterNone';
 import Popover from 'material-ui/Popover';
-import { MenuList, MenuItem } from 'material-ui/Menu';
+import Menu, { MenuItem } from 'material-ui/Menu';
 import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
@@ -18,6 +18,9 @@ const styles = theme => ({
             easing: theme.transitions.easing.sharp,
             duration: theme.transitions.duration.leavingScreen,
         }),
+    },
+    icon: {
+        marginRight: theme.spacing.unit,
     },
     unselected: {
         opacity: 0,
@@ -93,41 +96,35 @@ class BulkActions extends Component {
                     alignIcon="right"
                     aria-owns={isOpen ? 'bulk-actions-menu' : null}
                     aria-haspopup="true"
-                    label={translate(label, {
-                        _: label,
-                        smart_count: selectedIds.length,
-                    })}
                     onClick={this.handleClick}
                     {...sanitizeRestProps(rest)}
                 >
-                    <MoreVertIcon />
+                    <FilterNoneIcon className={classes.icon} />
+                    {translate(label, {
+                        _: label,
+                        smart_count: selectedIds.length,
+                    })}
                 </Button>
-                <Popover
+                <Menu
                     id="bulk-actions-menu"
                     anchorEl={this.anchorElement}
-                    anchorOrigin={{
-                        vertical: 'bottom',
-                        horizontal: 'left',
-                    }}
                     onClose={this.handleClose}
                     open={isOpen}
                 >
-                    <MenuList>
-                        {Children.map(children, (child, index) => (
-                            <MenuItem
-                                key={index}
-                                className={classnames(
-                                    'bulk-actions-menu-item',
-                                    child.props.className
-                                )}
-                                onClick={() => this.handleLaunchAction(index)}
-                                {...sanitizeRestProps(rest)}
-                            >
-                                {translate(child.props.label)}
-                            </MenuItem>
-                        ))}
-                    </MenuList>
-                </Popover>
+                    {Children.map(children, (child, index) => (
+                        <MenuItem
+                            key={index}
+                            className={classnames(
+                                'bulk-actions-menu-item',
+                                child.props.className
+                            )}
+                            onClick={() => this.handleLaunchAction(index)}
+                            {...sanitizeRestProps(rest)}
+                        >
+                            {translate(child.props.label)}
+                        </MenuItem>
+                    ))}
+                </Menu>
                 {Children.map(
                     children,
                     (child, index) =>

--- a/packages/ra-ui-materialui/src/list/BulkActions.js
+++ b/packages/ra-ui-materialui/src/list/BulkActions.js
@@ -2,7 +2,8 @@ import React, { cloneElement, Children, Component } from 'react';
 
 import PropTypes from 'prop-types';
 import MoreVertIcon from 'material-ui-icons/MoreVert';
-import Menu, { MenuItem } from 'material-ui/Menu';
+import Popover from 'material-ui/Popover';
+import Menu, { MenuList, MenuItem } from 'material-ui/Menu';
 import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
@@ -101,26 +102,32 @@ class BulkActions extends Component {
                 >
                     <MoreVertIcon />
                 </Button>
-                <Menu
+                <Popover
                     id="bulk-actions-menu"
                     anchorEl={this.anchorElement}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'left',
+                    }}
                     onClose={this.handleClose}
                     open={isOpen}
                 >
-                    {Children.map(children, (child, index) => (
-                        <MenuItem
-                            key={index}
-                            className={classnames(
-                                'bulk-actions-menu-item',
-                                child.props.className
-                            )}
-                            onClick={() => this.handleLaunchAction(index)}
-                            {...sanitizeRestProps(rest)}
-                        >
-                            {translate(child.props.label)}
-                        </MenuItem>
-                    ))}
-                </Menu>
+                    <MenuList>
+                        {Children.map(children, (child, index) => (
+                            <MenuItem
+                                key={index}
+                                className={classnames(
+                                    'bulk-actions-menu-item',
+                                    child.props.className
+                                )}
+                                onClick={() => this.handleLaunchAction(index)}
+                                {...sanitizeRestProps(rest)}
+                            >
+                                {translate(child.props.label)}
+                            </MenuItem>
+                        ))}
+                    </MenuList>
+                </Popover>
                 {Children.map(
                     children,
                     (child, index) =>

--- a/packages/ra-ui-materialui/src/list/BulkActions.js
+++ b/packages/ra-ui-materialui/src/list/BulkActions.js
@@ -3,7 +3,7 @@ import React, { cloneElement, Children, Component } from 'react';
 import PropTypes from 'prop-types';
 import MoreVertIcon from 'material-ui-icons/MoreVert';
 import Popover from 'material-ui/Popover';
-import Menu, { MenuList, MenuItem } from 'material-ui/Menu';
+import { MenuList, MenuItem } from 'material-ui/Menu';
 import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';

--- a/packages/ra-ui-materialui/src/list/BulkActions.js
+++ b/packages/ra-ui-materialui/src/list/BulkActions.js
@@ -1,8 +1,6 @@
 import React, { cloneElement, Children, Component } from 'react';
-
 import PropTypes from 'prop-types';
 import FilterNoneIcon from 'material-ui-icons/FilterNone';
-import Popover from 'material-ui/Popover';
 import Menu, { MenuItem } from 'material-ui/Menu';
 import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -17,10 +17,7 @@ const styles = {
         height: 'inherit',
     },
     headerCell: {
-        padding: 0,
-        '&:first-child': {
-            padding: '0 0 0 12px',
-        },
+        padding: '0 12px',
     },
     checkbox: {
         height: 'auto',
@@ -31,13 +28,6 @@ const styles = {
     rowCell: {
         padding: '0 12px',
         whiteSpace: 'normal',
-        '&:first-child': {
-            padding: '0 12px 0 16px',
-            whiteSpace: 'normal',
-        },
-        '&:last-child': {
-            padding: '0 12px',
-        },
     },
 };
 
@@ -100,6 +90,7 @@ class Datagrid extends Component {
             className,
             currentSort,
             hasBulkActions,
+            hover,
             ids,
             isLoading,
             resource,
@@ -152,6 +143,7 @@ class Datagrid extends Component {
                     classes={classes}
                     data={data}
                     hasBulkActions={hasBulkActions}
+                    hover={hover}
                     ids={ids}
                     isLoading={isLoading}
                     onToggleItem={onToggleItem}
@@ -177,6 +169,7 @@ Datagrid.propTypes = {
     }),
     data: PropTypes.object.isRequired,
     hasBulkActions: PropTypes.bool.isRequired,
+    hover: PropTypes.bool,
     ids: PropTypes.arrayOf(PropTypes.any).isRequired,
     isLoading: PropTypes.bool,
     onSelect: PropTypes.func,

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -13,6 +13,7 @@ const DatagridBody = ({
     resource,
     children,
     hasBulkActions,
+    hover,
     ids,
     isLoading,
     data,
@@ -38,6 +39,7 @@ const DatagridBody = ({
                 record={data[id]}
                 resource={resource}
                 selected={selectedIds.includes(id)}
+                hover={hover}
                 style={rowStyle ? rowStyle(data[id], rowIndex) : null}
             >
                 {children}
@@ -53,6 +55,7 @@ DatagridBody.propTypes = {
     children: PropTypes.node,
     data: PropTypes.object.isRequired,
     hasBulkActions: PropTypes.bool.isRequired,
+    hover: PropTypes.bool,
     ids: PropTypes.arrayOf(PropTypes.any).isRequired,
     isLoading: PropTypes.bool,
     onToggleItem: PropTypes.func,

--- a/packages/ra-ui-materialui/src/list/DatagridCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridCell.js
@@ -1,16 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TableCell } from 'material-ui/Table';
-import { withStyles } from 'material-ui/styles';
 import classnames from 'classnames';
-
-const styles = {
-    cellRightAligned: { textAlign: 'right' },
-};
 
 const sanitizeRestProps = ({
     cellClassName,
-    classes,
     className,
     field,
     formClassName,
@@ -22,7 +16,6 @@ const sanitizeRestProps = ({
 }) => rest;
 
 export const DatagridCell = ({
-    classes = {},
     className,
     field,
     record,
@@ -31,13 +24,9 @@ export const DatagridCell = ({
     ...rest
 }) => (
     <TableCell
-        className={classnames(
-            {
-                [classes.cellRightAligned]: field.props.textAlign === 'right',
-            },
-            className,
-            field.props.cellClassName
-        )}
+        className={classnames(className, field.props.cellClassName)}
+        numeric={field.props.textAlign === 'right'}
+        padding="none"
         {...sanitizeRestProps(rest)}
     >
         {React.cloneElement(field, {
@@ -49,7 +38,6 @@ export const DatagridCell = ({
 );
 
 DatagridCell.propTypes = {
-    classes: PropTypes.object,
     className: PropTypes.string,
     field: PropTypes.element,
     record: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -57,4 +45,4 @@ DatagridCell.propTypes = {
     resource: PropTypes.string,
 };
 
-export default withStyles(styles)(DatagridCell);
+export default DatagridCell;

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.js
@@ -3,96 +3,61 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import shouldUpdate from 'recompose/shouldUpdate';
 import compose from 'recompose/compose';
-import { TableCell } from 'material-ui/Table';
-import Button from 'material-ui/Button';
-import { withStyles } from 'material-ui/styles';
-import ContentSort from 'material-ui-icons/Sort';
-
-import { FieldTitle } from 'ra-core';
-
-const styles = {
-    cellRightAligned: { textAlign: 'right' },
-    sortButton: {
-        minWidth: 40,
-    },
-    sortIcon: {
-        transition: 'transform .25s cubic-bezier(0.0, 0, 0.2, 1)',
-        marginLeft: '0.5em',
-    },
-    sortIconReversed: {
-        transform: 'rotate(180deg)',
-    },
-    nonSortableLabel: {
-        position: 'relative',
-        paddingLeft: 16,
-        paddingRight: 16,
-        verticalAlign: 'middle',
-        letterSpacing: 0,
-        textTransform: 'uppercase',
-        fontWeight: 500,
-        fontSize: 14,
-    },
-};
+import { TableCell, TableSortLabel } from 'material-ui/Table';
+import Tooltip from 'material-ui/Tooltip';
+import { FieldTitle, translate } from 'ra-core';
 
 export const DatagridHeaderCell = ({
-    classes = {},
     className,
     field,
     currentSort,
     updateSort,
     resource,
     isSorting,
+    translate,
     ...rest
 }) => (
     <TableCell
-        className={classnames(
-            {
-                [classes.cellRightAligned]: field.props.textAlign === 'right',
-            },
-            className,
-            field.props.headerClassName
-        )}
+        className={classnames(className, field.props.headerClassName)}
+        numeric={field.props.textAlign === 'right'}
+        padding="none"
+        variant="head"
         {...rest}
     >
         {field.props.sortable !== false && field.props.source ? (
-            <Button
-                onClick={updateSort}
-                data-sort={field.props.source}
-                className={classes.sortButton}
+            <Tooltip
+                title={translate('ra.action.sort')}
+                placement={
+                    field.props.textAlign === 'right'
+                        ? 'bottom-end'
+                        : 'bottom-start'
+                }
+                enterDelay={300}
             >
-                <FieldTitle
-                    label={field.props.label}
-                    source={field.props.source}
-                    resource={resource}
-                />
-
-                {field.props.source === currentSort.field && (
-                    <ContentSort
-                        className={classnames(
-                            classes.sortIcon,
-                            currentSort.order === 'ASC'
-                                ? classes.sortIconReversed
-                                : ''
-                        )}
-                    />
-                )}
-            </Button>
-        ) : (
-            <span className={classes.nonSortableLabel}>
-                {
+                <TableSortLabel
+                    active={field.props.source === currentSort.field}
+                    direction={currentSort.order === 'ASC' ? 'asc' : 'desc'}
+                    data-sort={field.props.source}
+                    onClick={updateSort}
+                >
                     <FieldTitle
                         label={field.props.label}
                         source={field.props.source}
                         resource={resource}
                     />
-                }
-            </span>
+                </TableSortLabel>
+            </Tooltip>
+        ) : (
+            <FieldTitle
+                label={field.props.label}
+                source={field.props.source}
+                resource={resource}
+            />
         )}
     </TableCell>
 );
 
 DatagridHeaderCell.propTypes = {
-    classes: PropTypes.object,
     className: PropTypes.string,
     field: PropTypes.element,
     currentSort: PropTypes.shape({
@@ -102,6 +67,7 @@ DatagridHeaderCell.propTypes = {
     isSorting: PropTypes.bool,
     sortable: PropTypes.bool,
     resource: PropTypes.string,
+    translate: PropTypes.func.isRequired,
     updateSort: PropTypes.func.isRequired,
 };
 
@@ -112,7 +78,7 @@ const enhance = compose(
             (nextProps.isSorting &&
                 props.currentSort.order !== nextProps.currentSort.order)
     ),
-    withStyles(styles)
+    translate
 );
 
 export default enhance(DatagridHeaderCell);

--- a/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
+++ b/packages/ra-ui-materialui/src/list/DatagridHeaderCell.spec.js
@@ -18,9 +18,10 @@ describe('<DatagridHeaderCell />', () => {
                     currentSort={{}}
                     field={<Field source="title" />}
                     updateSort={() => true}
+                    translate={() => ''}
                 />
             );
-            assert.equal(wrapper.find('WithStyles(Button)').length, 1);
+            assert.equal(wrapper.find('WithStyles(TableSortLabel)').length, 1);
         });
 
         it('should be disabled when field has no source', () => {
@@ -29,10 +30,11 @@ describe('<DatagridHeaderCell />', () => {
                     currentSort={{}}
                     field={<Field />}
                     updateSort={() => true}
+                    translate={() => ''}
                 />
             );
 
-            assert.equal(wrapper.find('WithStyles(Button)').length, 0);
+            assert.equal(wrapper.find('WithStyles(TableSortLabel)').length, 0);
         });
 
         it('should be disabled when sortable prop is explicitly set to false', () => {
@@ -41,10 +43,11 @@ describe('<DatagridHeaderCell />', () => {
                     currentSort={{}}
                     field={<Field source="title" sortable={false} />}
                     updateSort={() => true}
+                    translate={() => ''}
                 />
             );
 
-            assert.equal(wrapper.find('WithStyles(Button)').length, 0);
+            assert.equal(wrapper.find('WithStyles(TableSortLabel)').length, 0);
         });
 
         it('should use cell className if specified', () => {
@@ -52,6 +55,7 @@ describe('<DatagridHeaderCell />', () => {
                 <DatagridHeaderCell
                     currentSort={{}}
                     updateSort={() => true}
+                    translate={() => ''}
                     field={<Field />}
                     className="blue"
                 />

--- a/packages/ra-ui-materialui/src/list/DatagridRow.js
+++ b/packages/ra-ui-materialui/src/list/DatagridRow.js
@@ -34,6 +34,7 @@ class DatagridRow extends Component {
             classes,
             className,
             hasBulkActions,
+            hover,
             id,
             record,
             resource,
@@ -47,6 +48,7 @@ class DatagridRow extends Component {
                 className={className}
                 key={id}
                 style={style}
+                hover={hover}
                 {...sanitizeRestProps(rest)}
             >
                 {hasBulkActions && (
@@ -85,6 +87,7 @@ DatagridRow.propTypes = {
     classes: PropTypes.object,
     className: PropTypes.string,
     hasBulkActions: PropTypes.bool.isRequired,
+    hover: PropTypes.bool,
     id: PropTypes.any,
     onToggleItem: PropTypes.func,
     record: PropTypes.object.isRequired,
@@ -96,6 +99,7 @@ DatagridRow.propTypes = {
 
 DatagridRow.defaultProps = {
     hasBulkActions: false,
+    hover: true,
     record: {},
     selected: false,
 };

--- a/packages/ra-ui-materialui/src/list/FilterButton.js
+++ b/packages/ra-ui-materialui/src/list/FilterButton.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
-import Popover from 'material-ui/Popover';
-import { MenuList } from 'material-ui/Menu';
+import Menu from 'material-ui/Menu';
 import { withStyles } from 'material-ui/styles';
 import ContentFilter from 'material-ui-icons/FilterList';
 import classnames from 'classnames';
@@ -93,30 +92,20 @@ export class FilterButton extends Component {
                     >
                         <ContentFilter />
                     </Button>
-                    <Popover
+                    <Menu
                         open={open}
                         anchorEl={anchorEl}
-                        anchorOrigin={{
-                            vertical: 'bottom',
-                            horizontal: 'left',
-                        }}
-                        transformOrigin={{
-                            vertical: 'top',
-                            horizontal: 'left',
-                        }}
                         onClose={this.handleRequestClose}
                     >
-                        <MenuList>
-                            {hiddenFilters.map(filterElement => (
-                                <FilterButtonMenuItem
-                                    key={filterElement.props.source}
-                                    filter={filterElement.props}
-                                    resource={resource}
-                                    onShow={this.handleShow}
-                                />
-                            ))}
-                        </MenuList>
-                    </Popover>
+                        {hiddenFilters.map(filterElement => (
+                            <FilterButtonMenuItem
+                                key={filterElement.props.source}
+                                filter={filterElement.props}
+                                resource={resource}
+                                onShow={this.handleShow}
+                            />
+                        ))}
+                    </Menu>
                 </div>
             )
         );

--- a/packages/ra-ui-materialui/src/list/Pagination.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.js
@@ -18,6 +18,9 @@ const styles = {
     pageInfo: {
         padding: '1.2em',
     },
+    desktopToolbar: {
+        justifyContent: 'flex-end',
+    },
     mobileToolbar: {
         justifyContent: 'center',
     },
@@ -170,7 +173,13 @@ export class Pagination extends Component {
                     </Toolbar>
                 }
                 medium={
-                    <Toolbar className={className} {...rest}>
+                    <Toolbar
+                        className={classnames(
+                            className,
+                            classes.desktopToolbar
+                        )}
+                        {...rest}
+                    >
                         <Typography
                             variant="body1"
                             className="displayed-records"


### PR DESCRIPTION
Since we implemented the components with early versions of material-ui 1.0, their have implemented features that we also implemented on our side.

Let's catch up by using their features instead of ours. Benefits: less code to maintain, better alignment of header and content in datagrid.

Before:

![image](https://user-images.githubusercontent.com/99944/36502864-7dbb066a-174b-11e8-83fe-43d2745d0052.png)

After:

![image](https://user-images.githubusercontent.com/99944/36502816-62273144-174b-11e8-8dc2-850108305ba2.png)


