### PR TITLE
[RFR] Optimistic Updates

### DIFF
--- a/e2e/pages/CreatePage.js
+++ b/e2e/pages/CreatePage.js
@@ -88,8 +88,15 @@ export default url => driver => ({
     },
 
     submit() {
-        driver.findElement(this.elements.submitButton).click();
-        return this.waitUntilDataLoaded();
+        return driver
+            .findElement(this.elements.submitButton)
+            .click()
+            .then(() =>
+                driver.wait(until.elementLocated(this.elements.snackbar), 3000)
+            )
+            .then(() => driver.findElement(this.elements.body).click()) // dismiss notification
+            .then(() => driver.sleep(200)) // let the notification disappear (could block further submits)
+            .then(() => this.waitUntilDataLoaded());
     },
 
     submitAndAdd() {

--- a/examples/simple/app.js
+++ b/examples/simple/app.js
@@ -5,9 +5,6 @@ import { render } from 'react-dom';
 import { Route } from 'react-router';
 
 import { Admin, Resource } from 'react-admin'; // eslint-disable-line import/no-unresolved
-import jsonRestDataProvider from 'ra-data-fakerest';
-
-import addUploadFeature from './addUploadFeature';
 
 import { PostList, PostCreate, PostEdit, PostShow, PostIcon } from './posts';
 import {
@@ -21,24 +18,14 @@ import { UserList, UserEdit, UserCreate, UserIcon, UserShow } from './users';
 import CustomRouteNoLayout from './customRouteNoLayout';
 import CustomRouteLayout from './customRouteLayout';
 
-import data from './data';
 import authProvider from './authProvider';
+import dataProvider from './dataProvider';
 import i18nProvider from './i18nProvider';
-
-const dataProvider = jsonRestDataProvider(data, true);
-const uploadCapableDataProvider = addUploadFeature(dataProvider);
-const delayedDataProvider = (type, resource, params) =>
-    new Promise(resolve =>
-        setTimeout(
-            () => resolve(uploadCapableDataProvider(type, resource, params)),
-            1000
-        )
-    );
 
 render(
     <Admin
         authProvider={authProvider}
-        dataProvider={delayedDataProvider}
+        dataProvider={dataProvider}
         i18nProvider={i18nProvider}
         title="Example Admin"
         locale="en"

--- a/examples/simple/dataProvider.js
+++ b/examples/simple/dataProvider.js
@@ -1,0 +1,16 @@
+import jsonRestDataProvider from 'ra-data-fakerest';
+
+import data from './data';
+import addUploadFeature from './addUploadFeature';
+
+const dataProvider = jsonRestDataProvider(data, true);
+const uploadCapableDataProvider = addUploadFeature(dataProvider);
+const delayedDataProvider = (type, resource, params) =>
+    new Promise(resolve =>
+        setTimeout(
+            () => resolve(uploadCapableDataProvider(type, resource, params)),
+            1000
+        )
+    );
+
+export default delayedDataProvider;

--- a/examples/simple/dataProvider.js
+++ b/examples/simple/dataProvider.js
@@ -5,10 +5,18 @@ import addUploadFeature from './addUploadFeature';
 
 const dataProvider = jsonRestDataProvider(data, true);
 const uploadCapableDataProvider = addUploadFeature(dataProvider);
+const sometimesFailsDataProvider = (type, resource, params) =>
+    new Promise((resolve, reject) => {
+        // add rejection by type or resource here for tests, e.g.
+        // if (type === 'DELETE' && resource === 'posts') {
+        //     return reject('deletion error');
+        // }
+        return resolve(uploadCapableDataProvider(type, resource, params));
+    });
 const delayedDataProvider = (type, resource, params) =>
     new Promise(resolve =>
         setTimeout(
-            () => resolve(uploadCapableDataProvider(type, resource, params)),
+            () => resolve(sometimesFailsDataProvider(type, resource, params)),
             1000
         )
     );

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -7,7 +7,7 @@ import {
     CREATE,
     UPDATE,
 } from '../../../dataFetchActions';
-import { CRUD_UPDATE } from '../../../actions/dataActions';
+import { CRUD_UPDATE, CRUD_UPDATE_MANY } from '../../../actions/dataActions';
 
 import getFetchedAt from '../../../util/getFetchedAt';
 
@@ -63,7 +63,15 @@ export default resource => (
         return previousState;
     }
     if (type === CRUD_UPDATE) {
+        // optimistic update
         return addRecords([payload.data], previousState);
+    }
+    if (type === CRUD_UPDATE_MANY) {
+        // optimistic update
+        const updatedRecords = payload.ids
+            .reduce((records, id) => records.concat(previousState[id]), [])
+            .map(record => ({ ...record, ...payload.data }));
+        return addRecords(updatedRecords, previousState);
     }
     if (!meta.fetchResponse || meta.fetchStatus !== FETCH_END) {
         return previousState;

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -7,6 +7,7 @@ import {
     CREATE,
     UPDATE,
 } from '../../../dataFetchActions';
+import { CRUD_UPDATE } from '../../../actions/dataActions';
 
 import getFetchedAt from '../../../util/getFetchedAt';
 
@@ -56,10 +57,13 @@ Object.defineProperty(initialState, 'fetchedAt', { value: {} }); // non enumerab
 
 export default resource => (
     previousState = initialState,
-    { payload, meta }
+    { type, payload, meta }
 ) => {
     if (!meta || meta.resource !== resource) {
         return previousState;
+    }
+    if (type === CRUD_UPDATE) {
+        return addRecords([payload.data], previousState);
     }
     if (!meta.fetchResponse || meta.fetchStatus !== FETCH_END) {
         return previousState;

--- a/packages/ra-core/src/reducer/admin/resource/data.js
+++ b/packages/ra-core/src/reducer/admin/resource/data.js
@@ -64,7 +64,8 @@ export default resource => (
     }
     if (type === CRUD_UPDATE) {
         // optimistic update
-        return addRecords([payload.data], previousState);
+        const updatedRecord = { ...previousState[payload.id], ...payload.data };
+        return addRecords([updatedRecord], previousState);
     }
     if (type === CRUD_UPDATE_MANY) {
         // optimistic update

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.js
@@ -1,7 +1,7 @@
 import uniq from 'lodash.uniq';
 import {
     CRUD_GET_LIST_SUCCESS,
-    CRUD_DELETE_SUCCESS,
+    CRUD_DELETE,
     CRUD_DELETE_MANY,
     CRUD_GET_MANY_SUCCESS,
     CRUD_GET_MANY_REFERENCE_SUCCESS,
@@ -51,9 +51,10 @@ export default resource => (
         case CRUD_CREATE_SUCCESS:
         case CRUD_UPDATE_SUCCESS:
             return addRecordIds([payload.data.id], previousState);
-        case CRUD_DELETE_SUCCESS: {
+        case CRUD_DELETE: {
+            // optimistic delete
             const index = previousState
-                .map(el => el == requestPayload.id) // eslint-disable-line eqeqeq
+                .map(el => el == payload.id) // eslint-disable-line eqeqeq
                 .indexOf(true);
             if (index === -1) {
                 return previousState;

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.js
@@ -2,7 +2,7 @@ import uniq from 'lodash.uniq';
 import {
     CRUD_GET_LIST_SUCCESS,
     CRUD_DELETE_SUCCESS,
-    CRUD_DELETE_MANY_SUCCESS,
+    CRUD_DELETE_MANY,
     CRUD_GET_MANY_SUCCESS,
     CRUD_GET_MANY_REFERENCE_SUCCESS,
     CRUD_GET_ONE_SUCCESS,
@@ -71,9 +71,10 @@ export default resource => (
 
             return newState;
         }
-        case CRUD_DELETE_MANY_SUCCESS: {
+        case CRUD_DELETE_MANY: {
+            // optimistic delete
             const newState = previousState.filter(
-                el => !requestPayload.ids.includes(el)
+                el => !payload.ids.includes(el)
             );
 
             Object.defineProperty(

--- a/packages/ra-core/src/reducer/admin/resource/list/ids.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/ids.js
@@ -29,10 +29,7 @@ export const addRecordIdsFactory = getFetchedAt => (
 
 const addRecordIds = addRecordIdsFactory(getFetchedAt);
 
-export default resource => (
-    previousState = [],
-    { type, payload, requestPayload, meta }
-) => {
+export default resource => (previousState = [], { type, payload, meta }) => {
     if (!meta || meta.resource !== resource) {
         return previousState;
     }

--- a/packages/ra-core/src/reducer/admin/resource/list/total.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/total.js
@@ -1,4 +1,7 @@
-import { CRUD_GET_LIST_SUCCESS } from '../../../../actions/dataActions';
+import {
+    CRUD_GET_LIST_SUCCESS,
+    CRUD_DELETE_MANY,
+} from '../../../../actions/dataActions';
 
 export default resource => (previousState = 0, { type, payload, meta }) => {
     if (!meta || meta.resource !== resource) {
@@ -6,6 +9,9 @@ export default resource => (previousState = 0, { type, payload, meta }) => {
     }
     if (type === CRUD_GET_LIST_SUCCESS) {
         return payload.total;
+    }
+    if (type === CRUD_DELETE_MANY) {
+        return previousState - payload.ids.length;
     }
     return previousState;
 };

--- a/packages/ra-core/src/reducer/admin/resource/list/total.js
+++ b/packages/ra-core/src/reducer/admin/resource/list/total.js
@@ -1,5 +1,6 @@
 import {
     CRUD_GET_LIST_SUCCESS,
+    CRUD_DELETE,
     CRUD_DELETE_MANY,
 } from '../../../../actions/dataActions';
 
@@ -9,6 +10,9 @@ export default resource => (previousState = 0, { type, payload, meta }) => {
     }
     if (type === CRUD_GET_LIST_SUCCESS) {
         return payload.total;
+    }
+    if (type === CRUD_DELETE) {
+        return previousState - 1;
     }
     if (type === CRUD_DELETE_MANY) {
         return previousState - payload.ids.length;

--- a/packages/ra-core/src/sideEffect/saga/crudResponse.js
+++ b/packages/ra-core/src/sideEffect/saga/crudResponse.js
@@ -174,7 +174,11 @@ function* handleResponse({ type, requestPayload, error, payload, meta }) {
                 typeof error === 'string'
                     ? error
                     : error.message || 'ra.notification.http_error';
-            return yield put(showNotification(errorMessage, 'warning'));
+
+            return yield [
+                put(refreshView()),
+                put(showNotification(errorMessage, 'warning')),
+            ];
         }
         default:
             return yield all([]);

--- a/packages/ra-core/src/sideEffect/saga/crudResponse.js
+++ b/packages/ra-core/src/sideEffect/saga/crudResponse.js
@@ -14,6 +14,7 @@ import {
     CRUD_GET_MANY_REFERENCE_FAILURE,
     CRUD_GET_ONE_SUCCESS,
     CRUD_GET_ONE_FAILURE,
+    CRUD_UPDATE,
     CRUD_UPDATE_FAILURE,
     CRUD_UPDATE_SUCCESS,
     CRUD_UPDATE_MANY_FAILURE,
@@ -24,10 +25,7 @@ import { refreshView } from '../../actions/uiActions';
 import { setListSelectedIds } from '../../actions/listActions';
 import resolveRedirectTo from '../../util/resolveRedirectTo';
 
-/**
- * Optimistic redirection side effect for deletion
- */
-function* handleDelete({ payload }) {
+function* handleOptimisticRedirect({ payload }) {
     if (payload.redirectTo) {
         return yield put(
             push(
@@ -50,31 +48,13 @@ function* handleDelete({ payload }) {
 function* handleResponse({ type, requestPayload, error, payload, meta }) {
     switch (type) {
         case CRUD_UPDATE_SUCCESS: {
-            const actions = [
-                put(
-                    showNotification('ra.notification.updated', 'info', {
-                        messageArgs: {
-                            smart_count: 1,
-                        },
-                    })
-                ),
-            ];
-
-            if (requestPayload.redirectTo) {
-                actions.push(
-                    put(
-                        push(
-                            resolveRedirectTo(
-                                requestPayload.redirectTo,
-                                requestPayload.basePath,
-                                requestPayload.id
-                            )
-                        )
-                    )
-                );
-            }
-
-            return yield all(actions);
+            return yield put(
+                showNotification('ra.notification.updated', 'info', {
+                    messageArgs: {
+                        smart_count: 1,
+                    },
+                })
+            );
         }
         case CRUD_UPDATE_MANY_SUCCESS: {
             const actions = [
@@ -189,7 +169,8 @@ function* handleResponse({ type, requestPayload, error, payload, meta }) {
 
 export default function*() {
     yield all([
-        takeEvery(CRUD_DELETE, handleDelete),
+        takeEvery(CRUD_DELETE, handleOptimisticRedirect),
+        takeEvery(CRUD_UPDATE, handleOptimisticRedirect),
         takeEvery(
             action => action.meta && action.meta.fetchResponse,
             handleResponse

--- a/packages/ra-core/src/sideEffect/saga/crudResponse.js
+++ b/packages/ra-core/src/sideEffect/saga/crudResponse.js
@@ -4,7 +4,6 @@ import { reset } from 'redux-form';
 import {
     CRUD_CREATE_FAILURE,
     CRUD_CREATE_SUCCESS,
-    CRUD_DELETE,
     CRUD_DELETE_FAILURE,
     CRUD_DELETE_SUCCESS,
     CRUD_DELETE_MANY_FAILURE,
@@ -14,7 +13,6 @@ import {
     CRUD_GET_MANY_REFERENCE_FAILURE,
     CRUD_GET_ONE_SUCCESS,
     CRUD_GET_ONE_FAILURE,
-    CRUD_UPDATE,
     CRUD_UPDATE_FAILURE,
     CRUD_UPDATE_SUCCESS,
     CRUD_UPDATE_MANY_FAILURE,
@@ -24,21 +22,6 @@ import { showNotification } from '../../actions/notificationActions';
 import { refreshView } from '../../actions/uiActions';
 import { setListSelectedIds } from '../../actions/listActions';
 import resolveRedirectTo from '../../util/resolveRedirectTo';
-
-function* handleOptimisticRedirect({ payload }) {
-    if (payload.redirectTo) {
-        return yield put(
-            push(
-                resolveRedirectTo(
-                    payload.redirectTo,
-                    payload.basePath,
-                    payload.id
-                )
-            )
-        );
-    }
-    return;
-}
 
 /**
  * Side effects for fetch responses
@@ -168,12 +151,8 @@ function* handleResponse({ type, requestPayload, error, payload, meta }) {
 }
 
 export default function*() {
-    yield all([
-        takeEvery(CRUD_DELETE, handleOptimisticRedirect),
-        takeEvery(CRUD_UPDATE, handleOptimisticRedirect),
-        takeEvery(
-            action => action.meta && action.meta.fetchResponse,
-            handleResponse
-        ),
-    ]);
+    yield takeEvery(
+        action => action.meta && action.meta.fetchResponse,
+        handleResponse
+    );
 }

--- a/packages/ra-core/src/sideEffect/saga/crudSaga.js
+++ b/packages/ra-core/src/sideEffect/saga/crudSaga.js
@@ -2,6 +2,7 @@ import { all } from 'redux-saga/effects';
 import auth from './auth';
 import crudFetch from './crudFetch';
 import crudResponse from './crudResponse';
+import optimistic from './optimistic';
 import referenceFetch from './referenceFetch';
 import i18n from './i18n';
 
@@ -16,5 +17,6 @@ export default (dataProvider, authProvider, i18nProvider) =>
             crudFetch(dataProvider)(),
             crudResponse(),
             referenceFetch(),
+            optimistic(),
         ]);
     };

--- a/packages/ra-core/src/sideEffect/saga/index.js
+++ b/packages/ra-core/src/sideEffect/saga/index.js
@@ -2,5 +2,6 @@ export auth from './auth';
 export crudFetch from './crudFetch';
 export crudResponse from './crudResponse';
 export crudSaga from './crudSaga';
+export optimistic from './optimistic';
 export referenceFetch from './referenceFetch';
 export i18n from './i18n';

--- a/packages/ra-core/src/sideEffect/saga/optimistic.js
+++ b/packages/ra-core/src/sideEffect/saga/optimistic.js
@@ -1,0 +1,35 @@
+import { all, put, takeEvery } from 'redux-saga/effects';
+import { push } from 'react-router-redux';
+import {
+    CRUD_DELETE,
+    CRUD_DELETE_MANY,
+    CRUD_UPDATE,
+    CRUD_UPDATE_MANY,
+} from '../../actions/dataActions';
+import { refreshView } from '../../actions/uiActions';
+import resolveRedirectTo from '../../util/resolveRedirectTo';
+
+function* handleOptimisticRedirect({ payload }) {
+    const actions = [put(refreshView())];
+    if (payload.redirectTo) {
+        actions.push(
+            put(
+                push(
+                    resolveRedirectTo(
+                        payload.redirectTo,
+                        payload.basePath,
+                        payload.id
+                    )
+                )
+            )
+        );
+    }
+    return yield all(actions);
+}
+
+export default function*() {
+    yield takeEvery(
+        [CRUD_DELETE, CRUD_DELETE_MANY, CRUD_UPDATE, CRUD_UPDATE_MANY],
+        handleOptimisticRedirect
+    );
+}

--- a/packages/ra-ui-materialui/src/list/Datagrid.js
+++ b/packages/ra-ui-materialui/src/list/Datagrid.js
@@ -99,6 +99,7 @@ class Datagrid extends Component {
             setSort,
             onSelect,
             onToggleItem,
+            version,
             ...rest
         } = this.props;
 
@@ -150,6 +151,7 @@ class Datagrid extends Component {
                     resource={resource}
                     rowStyle={rowStyle}
                     selectedIds={selectedIds}
+                    version={version}
                 >
                     {children}
                 </DatagridBody>
@@ -178,6 +180,7 @@ Datagrid.propTypes = {
     rowStyle: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
     setSort: PropTypes.func,
+    version: PropTypes.number,
 };
 
 Datagrid.defaultProps = {

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -21,6 +21,7 @@ const DatagridBody = ({
     styles,
     rowStyle,
     onToggleItem,
+    version,
     ...rest
 }) => (
     <TableBody className={classnames('datagrid-body', className)} {...rest}>
@@ -71,13 +72,9 @@ DatagridBody.defaultProps = {
     ids: [],
 };
 
-const areArraysEqual = (arr1, arr2) =>
-    arr1.length == arr2.length && arr1.every((v, i) => v === arr2[i]);
-
 const PureDatagridBody = shouldUpdate(
     (props, nextProps) =>
-        !areArraysEqual(props.ids, nextProps.ids) ||
-        nextProps.isLoading === false
+        props.version !== nextProps.version || nextProps.isLoading === false
 )(DatagridBody);
 
 // trick material-ui Table into thinking this is one of the child type it supports

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -71,8 +71,13 @@ DatagridBody.defaultProps = {
     ids: [],
 };
 
+const areArraysEqual = (arr1, arr2) =>
+    arr1.length == arr2.length && arr1.every((v, i) => v === arr2[i]);
+
 const PureDatagridBody = shouldUpdate(
-    (props, nextProps) => nextProps.isLoading === false
+    (props, nextProps) =>
+        !areArraysEqual(props.ids, nextProps.ids) ||
+        nextProps.isLoading === false
 )(DatagridBody);
 
 // trick material-ui Table into thinking this is one of the child type it supports

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -64,6 +64,7 @@ DatagridBody.propTypes = {
     rowStyle: PropTypes.func,
     selectedIds: PropTypes.arrayOf(PropTypes.any).isRequired,
     styles: PropTypes.object,
+    version: PropTypes.number,
 };
 
 DatagridBody.defaultProps = {

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -150,6 +150,7 @@ export const ListView = ({
                                 resource,
                                 selectedIds,
                                 setSort,
+                                version,
                             })}
                         {!isLoading &&
                             !ids.length && (


### PR DESCRIPTION
The idea is to accelerate the rendering of the admin after the user saves some changes by using optimistic rendering, i.e. updating the local store and rerendering *before* the server acknowledges the change.

- [x] Implement optimistic rendering for `DELETE`
- [x] Implement optimistic rendering for `DELETE_MANY`
- [x] Implement optimistic rendering for `UPDATE`
- [x] Implement optimistic rendering for `UPDATE_MANY`
- [x] Handle delete error case (force refresh)
- [ ] ~~Explore the possibility to replace the `Confirm` dialog by a `Snackbar` with an "undo" action.~~(moved to a future PR)

In the following screencast, notice how the two selected items disappear right after clicking on "Delete" - and way before the Snackbar, which displays the server confirmation, appears.

![kapture 2018-02-22 at 11 37 16](https://user-images.githubusercontent.com/99944/36533740-d2d77344-17c4-11e8-93f7-8b3e6d7562c3.gif)
