### PR TITLE
[RFR]: Allow title to be an element

### DIFF
--- a/packages/ra-core/src/CoreAdminRouter.js
+++ b/packages/ra-core/src/CoreAdminRouter.js
@@ -171,7 +171,7 @@ CoreAdminRouter.propTypes = {
     logout: PropTypes.node,
     menu: componentPropType,
     theme: PropTypes.object,
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 const mapStateToProps = state => ({

--- a/packages/ra-core/src/RoutesWithLayout.js
+++ b/packages/ra-core/src/RoutesWithLayout.js
@@ -81,7 +81,7 @@ RoutesWithLayout.propTypes = {
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     customRoutes: PropTypes.array,
     dashboard: componentPropType,
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 export default RoutesWithLayout;

--- a/packages/ra-ui-materialui/src/layout/AppBar.js
+++ b/packages/ra-ui-materialui/src/layout/AppBar.js
@@ -96,7 +96,7 @@ const AppBar = ({
                 color="inherit"
                 className={classes.title}
             >
-                {title}
+                {typeof title === 'string' ? title : React.cloneElement(title)}
             </Typography>
             {logout &&
                 cloneElement(logout, {


### PR DESCRIPTION
Changed some proptypes and use `cloneElement` when title is an element. This allows the element to use the correct `theme` (themeprovider is initialized in the layout). 