### PR TITLE
[RFR] Move `setFilters` debounce to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,15 @@
         "full-icu": "~1.1.3",
         "jest": "20.0.4",
         "lerna": "~2.5.1",
+        "lolex": "~2.3.2",
         "mocha": "~4.0.1",
         "prettier": "~1.7.0",
         "prettier-eslint-cli": "~4.4.0",
         "raf": "~3.4.0",
         "selenium-webdriver": "~3.5.0"
     },
-    "workspaces": ["packages/*", "examples/*"]
+    "workspaces": [
+        "packages/*",
+        "examples/*"
+    ]
 }

--- a/packages/ra-core/src/controller/ListController.js
+++ b/packages/ra-core/src/controller/ListController.js
@@ -88,6 +88,10 @@ export class ListController extends Component {
         }
     }
 
+    componentWillUnmount() {
+        this.setFilters.cancel();
+    }
+
     componentWillReceiveProps(nextProps) {
         if (
             nextProps.resource !== this.props.resource ||

--- a/packages/ra-core/src/controller/ListController.spec.js
+++ b/packages/ra-core/src/controller/ListController.spec.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import lolex from 'lolex';
+
+import { ListController } from './ListController';
+import TextField from 'material-ui/TextField/TextField';
+
+describe('ListController', () => {
+    const defaultProps = {
+        changeListParams: () => {},
+        children: () => {},
+        crudGetList: () => {},
+        hasCreate: true,
+        hasEdit: true,
+        hasList: true,
+        hasShow: true,
+        ids: [],
+        isLoading: false,
+        location: {
+            pathname: '',
+        },
+        params: {},
+        push: () => {},
+        query: {},
+        resource: '',
+        setSelectedIds: () => {},
+        toggleItem: () => {},
+        total: 100,
+        translate: () => {},
+    };
+
+    describe('setFilters', () => {
+        let clock;
+        beforeEach(() => {
+            clock = lolex.install();
+        });
+
+        it('should take only last change in case of a burst of changes (case of inputs being currently edited)', () => {
+            const props = {
+                ...defaultProps,
+                debounce: 200,
+                changeListParams: jest.fn(),
+                children: ({ setFilters }) => (
+                    <TextField onChange={setFilters} />
+                ),
+            };
+
+            const wrapper = shallow(<ListController {...props} />);
+            const onChange = wrapper.find(TextField).prop('onChange');
+
+            onChange({ q: 'hel' });
+            onChange({ q: 'hell' });
+            onChange({ q: 'hello' });
+
+            clock.tick(200);
+
+            const changeListParamsCalls = props.changeListParams.mock.calls;
+
+            expect(changeListParamsCalls.length).toBe(1);
+            expect(changeListParamsCalls[0][1].filter).toEqual({ q: 'hello' });
+        });
+
+        it('should not call filtering function if filters are unchanged', () => {
+            const props = {
+                ...defaultProps,
+                debounce: 200,
+                changeListParams: jest.fn(),
+                filterValues: { q: 'hello' },
+                children: ({ setFilters }) => (
+                    <TextField onChange={setFilters} />
+                ),
+            };
+
+            const wrapper = shallow(<ListController {...props} />);
+            const onChange = wrapper.find(TextField).prop('onChange');
+
+            onChange({ q: 'hello' });
+            clock.tick(200);
+
+            expect(props.changeListParams).not.toHaveBeenCalled();
+        });
+
+        it('should remove empty filters', () => {
+            const props = {
+                ...defaultProps,
+                debounce: 200,
+                changeListParams: jest.fn(),
+                filterValues: { q: 'hello' },
+                children: ({ setFilters }) => (
+                    <TextField onChange={setFilters} />
+                ),
+            };
+
+            const wrapper = shallow(<ListController {...props} />);
+            const onChange = wrapper.find(TextField).prop('onChange');
+
+            onChange({ q: '' });
+            clock.tick(200);
+
+            expect(props.changeListParams.mock.calls[0][1].filter).toEqual({});
+        });
+
+        afterEach(() => {
+            clock.uninstall();
+        });
+    });
+});

--- a/packages/ra-core/src/controller/ListController.spec.js
+++ b/packages/ra-core/src/controller/ListController.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import lolex from 'lolex';
+import { setDisplayName } from 'recompose';
 
 import { ListController } from './ListController';
 import TextField from 'material-ui/TextField/TextField';
@@ -31,8 +32,13 @@ describe('ListController', () => {
 
     describe('setFilters', () => {
         let clock;
+        let fakeComponent;
+
         beforeEach(() => {
             clock = lolex.install();
+            fakeComponent = setDisplayName(
+                'FakeComponent' // for eslint
+            )(({ setFilters }) => <TextField onChange={setFilters} />);
         });
 
         it('should take only last change in case of a burst of changes (case of inputs being currently edited)', () => {
@@ -40,9 +46,7 @@ describe('ListController', () => {
                 ...defaultProps,
                 debounce: 200,
                 changeListParams: jest.fn(),
-                children: ({ setFilters }) => (
-                    <TextField onChange={setFilters} />
-                ),
+                children: fakeComponent,
             };
 
             const wrapper = shallow(<ListController {...props} />);
@@ -66,9 +70,7 @@ describe('ListController', () => {
                 debounce: 200,
                 changeListParams: jest.fn(),
                 filterValues: { q: 'hello' },
-                children: ({ setFilters }) => (
-                    <TextField onChange={setFilters} />
-                ),
+                children: fakeComponent,
             };
 
             const wrapper = shallow(<ListController {...props} />);
@@ -86,9 +88,7 @@ describe('ListController', () => {
                 debounce: 200,
                 changeListParams: jest.fn(),
                 filterValues: { q: 'hello' },
-                children: ({ setFilters }) => (
-                    <TextField onChange={setFilters} />
-                ),
+                children: fakeComponent,
             };
 
             const wrapper = shallow(<ListController {...props} />);

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -1,12 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import debounce from 'lodash.debounce';
-import isEqual from 'lodash.isequal';
 import { withStyles } from 'material-ui/styles';
 
 import FilterForm from './FilterForm';
 import FilterButton from './FilterButton';
-import { removeEmpty } from 'ra-core';
 
 const styles = {
     button: {},

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -29,15 +29,6 @@ export class Filter extends Component {
         }
     }
 
-    setFilters = debounce(filters => {
-        if (!isEqual(filters, this.filters)) {
-            // fix for redux-form bug with onChange and enableReinitialize
-            const filtersWithoutEmpty = removeEmpty(filters);
-            this.props.setFilters(filtersWithoutEmpty);
-            this.filters = filtersWithoutEmpty;
-        }
-    }, this.props.debounce);
-
     renderButton() {
         const {
             classes = {},
@@ -88,7 +79,7 @@ export class Filter extends Component {
                 hideFilter={hideFilter}
                 displayedFilters={displayedFilters}
                 initialValues={filterValues}
-                setFilters={this.setFilters}
+                setFilters={setFilters}
                 {...rest}
             />
         );

--- a/packages/ra-ui-materialui/src/list/Filter.js
+++ b/packages/ra-ui-materialui/src/list/Filter.js
@@ -13,17 +13,6 @@ const styles = {
 export class Filter extends Component {
     constructor(props) {
         super(props);
-        this.filters = this.props.filterValues;
-    }
-
-    componentWillReceiveProps(nextProps) {
-        this.filters = nextProps.filterValues;
-    }
-
-    componentWillUnmount() {
-        if (this.props.setFilters) {
-            this.setFilters.cancel();
-        }
     }
 
     renderButton() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,6 +5539,10 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
+lolex@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,7 +5539,7 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
-lolex@2.3.2:
+lolex@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
 


### PR DESCRIPTION
Currently, `setFilters` is debounced only in Material UI package. As a consequence, when implementing a custom theme without the `ra-ui-materialui` package, we also need to add manually a debounce. Otherwise, editing a text input filter would spam API (see tests for a real world scenario).

As I can't see any scenario where we would need to spam API (causing network slowness), let's move it to the core package.