### PR TITLE
[RFR] Fix form unmount issues

### DIFF
--- a/e2e/pages/EditPage.js
+++ b/e2e/pages/EditPage.js
@@ -75,6 +75,11 @@ export default url => driver => ({
         return input.sendKeys(value);
     },
 
+    async getInputValue(name) {
+        const input = await driver.findElement(this.elements.input(name));
+        return await input.getAttribute('value');
+    },
+
     clickInput(name) {
         const input = driver.findElement(this.elements.input(name));
         input.click();

--- a/e2e/tests/edit.js
+++ b/e2e/tests/edit.js
@@ -3,51 +3,69 @@ import driver from '../chromeDriver';
 import editPageFactory from '../pages/EditPage';
 
 describe('Edit Page', () => {
-    const EditPage = editPageFactory('http://localhost:8083/#/posts/5')(driver);
+    const EditPostPage = editPageFactory('http://localhost:8083/#/posts/5')(
+        driver
+    );
+    const EditCommentPage = editPageFactory(
+        'http://localhost:8083/#/comments/5'
+    )(driver);
 
-    beforeEach(async () => await EditPage.navigate());
+    beforeEach(async () => await EditPostPage.navigate());
 
     describe('TabbedForm', () => {
         it('should display the title in a TextField', async () => {
             assert.equal(
-                await EditPage.getInputValue('title'),
+                await EditPostPage.getInputValue('title'),
                 'Sed quo et et fugiat modi'
             );
         });
 
         it('should allow to update elements', async () => {
-            await EditPage.setInputValue('title', 'Lorem Ipsum');
-            await EditPage.submit();
-            await EditPage.navigate();
-            assert.equal(await EditPage.getInputValue('title'), 'Lorem Ipsum');
+            await EditPostPage.setInputValue('title', 'Lorem Ipsum');
+            await EditPostPage.submit();
+            await EditPostPage.navigate();
+            assert.equal(
+                await EditPostPage.getInputValue('title'),
+                'Lorem Ipsum'
+            );
             await driver.sleep(3000);
         });
 
         it('should redirect to list page after edit success', async () => {
-            await EditPage.setInputValue('title', 'Lorem Ipsum +');
-            await EditPage.submit();
+            await EditPostPage.setInputValue('title', 'Lorem Ipsum +');
+            await EditPostPage.submit();
             assert.equal(
                 await driver.getCurrentUrl(),
                 'http://localhost:8083/#/posts'
             );
-            await EditPage.navigate();
+            await EditPostPage.navigate();
         });
 
         it('should allow to switch tabs', async () => {
-            await EditPage.gotoTab(3);
-            assert.equal(await EditPage.getInputValue('average_note'), '3');
+            await EditPostPage.gotoTab(3);
+            assert.equal(await EditPostPage.getInputValue('average_note'), '3');
         });
 
         it('should keep DateInput value after opening datapicker', async () => {
-            await EditPage.gotoTab(3);
-            const valueBeforeClick = await EditPage.getInputValue(
+            await EditPostPage.gotoTab(3);
+            const valueBeforeClick = await EditPostPage.getInputValue(
                 'published_at'
             );
-            await EditPage.clickInput('published_at');
+            await EditPostPage.clickInput('published_at');
             assert.equal(
-                await EditPage.getInputValue('published_at'),
+                await EditPostPage.getInputValue('published_at'),
                 valueBeforeClick
             );
         });
+    });
+
+    it('should fill form correctly even when switching from one form type to another', async () => {
+        await EditCommentPage.navigate();
+        const author = await EditCommentPage.getInputValue('author.name');
+        assert.equal(author, 'Edmond Schulist');
+
+        await EditPostPage.navigate();
+        const title = await EditPostPage.getInputValue('title');
+        assert.equal(title, 'Sed quo et et fugiat modi');
     });
 });

--- a/packages/ra-ui-materialui/src/form/SimpleForm.js
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.js
@@ -135,6 +135,7 @@ const enhance = compose(
     translate, // Must be before reduxForm so that it can be used in validation
     reduxForm({
         form: 'record-form',
+        destroyOnUnmount: false,
         enableReinitialize: true,
     }),
     withStyles(styles)

--- a/packages/ra-ui-materialui/src/form/TabbedForm.js
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.js
@@ -232,6 +232,7 @@ const enhance = compose(
     translate, // Must be before reduxForm so that it can be used in validation
     reduxForm({
         form: 'record-form',
+        destroyOnUnmount: false,
         enableReinitialize: true,
     }),
     withStyles(styles)


### PR DESCRIPTION
Fixes #1613.

A bug is present from the upgrade to React16:

1. Edit a post on /#/posts/5,
2. Change URL and go on /#/comments/5 instead

Comment form is empty. This is due to the way React16 handle component lifecycle: it mounts the new component, then unmount the previous one. Hence, our form values are first initialized during the mounting of the new component, and then destroyed by the unmounting. As we are using the same name, it raises the issue.

We may either change form names, or never unmount our forms. As the first solution would break a lot of ecosystem plug-in (for instance [aor-dependant-input](https://github.com/marmelab/aor-dependent-input)), we choose the latter solution. Memory footprint should not be too much increased, as we only have two different forms: `filtersForm` and `recordForm`. 