### PR TITLE
[RFR]: Pass through action in generic Fetch actions

### DIFF
--- a/packages/ra-core/src/sideEffect/fetch.js
+++ b/packages/ra-core/src/sideEffect/fetch.js
@@ -27,7 +27,7 @@ export function* handleFetch(dataProvider, action) {
     try {
         yield all([
             put({ type: `${type}_LOADING`, payload, meta }),
-            put({ type: FETCH_START }),
+            put({ type: FETCH_START, action }),
         ]);
         let response = yield call(
             dataProvider,
@@ -49,7 +49,7 @@ export function* handleFetch(dataProvider, action) {
                 fetchStatus: FETCH_END,
             },
         });
-        yield put({ type: FETCH_END });
+        yield put({ type: FETCH_END, action });
     } catch (error) {
         yield put({
             type: `${type}_FAILURE`,
@@ -62,10 +62,10 @@ export function* handleFetch(dataProvider, action) {
                 fetchStatus: FETCH_ERROR,
             },
         });
-        yield put({ type: FETCH_ERROR, error });
+        yield put({ type: FETCH_ERROR, error, action });
     } finally {
         if (yield cancelled()) {
-            yield put({ type: FETCH_CANCEL });
+            yield put({ type: FETCH_CANCEL, action });
             return; /* eslint no-unsafe-finally:0 */
         }
     }

--- a/packages/ra-core/src/sideEffect/fetch.js
+++ b/packages/ra-core/src/sideEffect/fetch.js
@@ -27,7 +27,7 @@ export function* handleFetch(dataProvider, action) {
     try {
         yield all([
             put({ type: `${type}_LOADING`, payload, meta }),
-            put({ type: FETCH_START, action }),
+            put({ type: FETCH_START, requestPayload: payload }),
         ]);
         let response = yield call(
             dataProvider,
@@ -49,7 +49,7 @@ export function* handleFetch(dataProvider, action) {
                 fetchStatus: FETCH_END,
             },
         });
-        yield put({ type: FETCH_END, action });
+        yield put({ type: FETCH_END, requestPayload: payload });
     } catch (error) {
         yield put({
             type: `${type}_FAILURE`,
@@ -62,10 +62,10 @@ export function* handleFetch(dataProvider, action) {
                 fetchStatus: FETCH_ERROR,
             },
         });
-        yield put({ type: FETCH_ERROR, error, action });
+        yield put({ type: FETCH_ERROR, error, requestPayload: payload });
     } finally {
         if (yield cancelled()) {
-            yield put({ type: FETCH_CANCEL, action });
+            yield put({ type: FETCH_CANCEL, requestPayload: payload });
             return; /* eslint no-unsafe-finally:0 */
         }
     }


### PR DESCRIPTION
I need to monitor each individual fetch request to the initiator. Currently there's no way of telling which `FETCH_*` action belongs to which action. I like to tie them down to an action by simply passing the action in the generic fetch actions (`FETCH_START,FETCH_END,FETCH_ERROR and FETCH_CANCEL`). This is not in anyway helpful for `ra` at the moment, but would help me. 