### PR TITLE
[RFR]: Remove passing through rest props to Labelled component

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
@@ -70,7 +70,6 @@ export const ReferenceArrayInputView = ({
                 source={source}
                 resource={resource}
                 className={className}
-                {...sanitizeRestProps(rest)}
             >
                 <LinearProgress />
             </Labeled>

--- a/packages/ra-ui-materialui/src/input/ReferenceInput.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceInput.js
@@ -76,7 +76,6 @@ export const ReferenceInputView = ({
                 source={source}
                 resource={resource}
                 className={className}
-                {...sanitizeRestProps(rest)}
             >
                 <LinearProgress />
             </Labeled>


### PR DESCRIPTION
For `ReferenceInput` and `ReferenceArrayInput` remove passing through rest props to Labelled component. Is gives a lot of errors in the console, because `Loading` does support there props. 