### PR TITLE
Fix 'bulkActions' boolean functionality

### DIFF
--- a/packages/ra-ui-materialui/src/list/ListActions.js
+++ b/packages/ra-ui-materialui/src/list/ListActions.js
@@ -21,13 +21,14 @@ const Actions = ({
 }) => {
     return (
         <CardActions className={className} {...rest}>
-            {cloneElement(bulkActions, {
-                basePath,
-                filterValues,
-                resource,
-                selectedIds,
-                onUnselectItems,
-            })}
+            {bulkActions &&
+                cloneElement(bulkActions, {
+                    basePath,
+                    filterValues,
+                    resource,
+                    selectedIds,
+                    onUnselectItems,
+                })}
             {filters &&
                 cloneElement(filters, {
                     resource,


### PR DESCRIPTION
The page breaks (with error message), when using `bulkActions` prop as a boolean `false` (for hiding the checkboxes):
```
<List
    {...props}
    title={<TitleList />}
    bulkActions={false}
  >
```

This PR fixes this problem.