### PR TITLE
[RFC] Add a maximum page limit to the List view

### DIFF
--- a/docs/List.md
+++ b/docs/List.md
@@ -22,6 +22,7 @@ Here are all the props accepted by the `<List>` component:
 * [`bulkActions`](#bulk-actions)
 * [`filters`](#filters) (a React element used to display the filter form)
 * [`perPage`](#records-per-page)
+* [`maxPage`](#maximum-page-limit)
 * [`sort`](#default-sort-field)
 * [`filter`](#permanent-filter) (the permanent filter used in the REST request)
 * [`pagination`](#pagination)
@@ -135,7 +136,7 @@ export const PostList = (props) => (
 
 **Tip**: You can also disable bulk actions altogether by passing `false` to the `bulkActions` prop. When using a `Datagrid` inside a `List` with disabled bulk actions, the checkboxes column won't be added.
 
-React-admin uses the `label` prop of the bulk action components to display the bulk action menu items. 
+React-admin uses the `label` prop of the bulk action components to display the bulk action menu items.
 
 Bulk action components are regular React component that gets mounted when the related menu item is clicked. The component receives several props allowing it to perform its job:
 
@@ -289,6 +290,19 @@ export const PostList = (props) => (
 );
 ```
 
+### Maximum Page Limit
+
+By default, the list paginates all the results without limit. You can override this setting by specifying the `maxPage` prop:
+
+```jsx
+// in src/posts.js
+export const PostList = (props) => (
+    <List {...props} maxPage={10}>
+        ...
+    </List>
+);
+```
+
 ### Default Sort Field
 
 Pass an object literal as the `sort` prop to determine the default `field` and `order` used for sorting:
@@ -357,8 +371,13 @@ import ChevronLeft from 'material-ui-icons/ChevronLeft';
 import ChevronRight from 'material-ui-icons/ChevronRight';
 import Toolbar from 'material-ui/Toolbar';
 
-const PostPagination = ({ page, perPage, total, setPage }) => {
-    const nbPages = Math.ceil(total / perPage) || 1;
+const PostPagination = ({ page, perPage, total, setPage, maxPage }) => {
+    let nbPages = Math.ceil(total / perPage) || 1;
+
+    if (maxPage && nbPages > maxPage) {
+        nbPages = maxPage;
+    }
+
     return (
         nbPages > 1 &&
             <Toolbar>

--- a/packages/ra-core/src/controller/ListController.js
+++ b/packages/ra-core/src/controller/ListController.js
@@ -221,6 +221,7 @@ export class ListController extends Component {
             translate,
             version,
             selectedIds,
+            maxPage,
         } = this.props;
         const query = this.getQuery();
 
@@ -249,6 +250,7 @@ export class ListController extends Component {
             hideFilter: this.hideFilter,
             ids,
             isLoading,
+            maxPage,
             onSelect: this.handleSelect,
             onToggleItem: this.handleToggleItem,
             onUnselectItems: this.handleUnselectItems,
@@ -274,6 +276,7 @@ ListController.propTypes = {
     filters: PropTypes.element,
     pagination: PropTypes.element,
     perPage: PropTypes.number.isRequired,
+    maxPage: PropTypes.number,
     sort: PropTypes.shape({
         field: PropTypes.string,
         order: PropTypes.string,
@@ -308,6 +311,7 @@ ListController.defaultProps = {
     filter: {},
     filterValues: {},
     perPage: 10,
+    maxPage: null,
     sort: {
         field: 'id',
         order: SORT_DESC,

--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -82,6 +82,7 @@ export const ListView = ({
     onSelect,
     onToggleItem,
     onUnselectItems,
+    maxPage,
     page,
     pagination = <DefaultPagination />,
     perPage,
@@ -170,6 +171,7 @@ export const ListView = ({
                                 page,
                                 perPage,
                                 setPage,
+                                maxPage,
                                 total,
                             })}
                     </div>
@@ -205,6 +207,7 @@ ListView.propTypes = {
     hideFilter: PropTypes.func,
     ids: PropTypes.array,
     isLoading: PropTypes.bool,
+    maxPage: PropTypes.number,
     onSelect: PropTypes.func,
     onToggleItem: PropTypes.func,
     onUnselectItems: PropTypes.func,
@@ -280,6 +283,7 @@ List.propTypes = {
     className: PropTypes.string,
     filter: PropTypes.object,
     filters: PropTypes.element,
+    maxPage: PropTypes.number,
     pagination: PropTypes.element,
     perPage: PropTypes.number.isRequired,
     sort: PropTypes.shape({
@@ -302,6 +306,7 @@ List.propTypes = {
 
 List.defaultProps = {
     filter: {},
+    maxPage: null,
     perPage: 10,
     theme: defaultTheme,
 };

--- a/packages/ra-ui-materialui/src/list/Pagination.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.js
@@ -30,9 +30,11 @@ const styles = {
 export class Pagination extends Component {
     range() {
         const input = [];
-        const { page, perPage, total } = this.props;
+        const { page } = this.props;
+
         if (isNaN(page)) return input;
-        const nbPages = Math.ceil(total / perPage) || 1;
+
+        const nbPages = this.getNbPages();
 
         // display page links around the current page
         if (page > 2) {
@@ -65,7 +67,10 @@ export class Pagination extends Component {
     }
 
     getNbPages() {
-        return Math.ceil(this.props.total / this.props.perPage) || 1;
+        const { total, perPage, maxPage } = this.props;
+        const nbPages = Math.ceil(total / perPage) || 1;
+
+        return maxPage && nbPages > maxPage ? maxPage : nbPages;
     }
 
     prevPage = event => {
@@ -137,6 +142,7 @@ export class Pagination extends Component {
             translate,
             ...rest
         } = this.props;
+
         if (total === 0) return null;
         const offsetEnd = Math.min(page * perPage, total);
         const offsetBegin = Math.min((page - 1) * perPage + 1, offsetEnd);
@@ -230,6 +236,11 @@ Pagination.propTypes = {
     setPage: PropTypes.func,
     translate: PropTypes.func.isRequired,
     total: PropTypes.number,
+    maxPage: PropTypes.number,
+};
+
+Pagination.defaultProps = {
+    maxPage: null,
 };
 
 const enhance = compose(pure, translate, withStyles(styles));

--- a/packages/ra-ui-materialui/src/list/Pagination.spec.js
+++ b/packages/ra-ui-materialui/src/list/Pagination.spec.js
@@ -25,6 +25,7 @@ describe('<Pagination />', () => {
             const flatButtons = wrapper.find('WithStyles(Button)');
             assert.equal(flatButtons.length, 0);
         });
+
         it('should render only the text when no pagination is necessary', () => {
             const wrapper = shallow(
                 <Pagination
@@ -52,6 +53,7 @@ describe('<Pagination />', () => {
             );
         });
     });
+
     describe('desktop', () => {
         it('should render a normal <Toolbar>', () => {
             const wrapper = shallow(
@@ -72,6 +74,7 @@ describe('<Pagination />', () => {
             const flatButtons = wrapper.find('WithStyles(Button)');
             assert.equal(flatButtons.length, 5);
         });
+
         it('should render only the text when no pagination is necessary', () => {
             const wrapper = shallow(
                 <Pagination
@@ -96,6 +99,26 @@ describe('<Pagination />', () => {
                     .text(),
                 'ra.navigation.page_range_info'
             );
+        });
+
+        it('should limit the page number if maxPage prop is specified', () => {
+            const wrapper = shallow(
+                <Pagination
+                    page={1}
+                    perPage={10}
+                    total={100}
+                    maxPage={5}
+                    translate={x => x}
+                    width={1}
+                />
+            )
+                .shallow()
+                .shallow()
+                .shallow()
+                .shallow();
+
+            const lastPageNumber = wrapper.find('.page-number').last();
+            expect(lastPageNumber.prop('data-page')).toBe(5);
         });
     });
 });


### PR DESCRIPTION
The goal of this PR is to introduce a new feature to the List view: limit the page number if needed by providing a new optional prop `maxPage` to the `List` and `Pagination` component.

I don't know if it will be widely used.. for one of our clients, it's a "security issue".
So, I made a PR in case it might be useful.

## TODO
- [x] Update the documentation
- [x] Use `maxPage` in the Pagination
- [x] Pass the `maxPage` prop through the List & List controller
- [ ] Add a E2E test (?)
- [ ] Add this prop in at least one example