### PR TITLE
[RFR]: Use ui to trigger undoable complete action

### DIFF
--- a/packages/ra-core/src/actions/undoActions.js
+++ b/packages/ra-core/src/actions/undoActions.js
@@ -4,9 +4,9 @@ export const COMPLETE = 'RA/COMPLETE';
 export const START_OPTIMISTIC_MODE = 'RA/START_OPTIMISTIC_MODE';
 export const STOP_OPTIMISTIC_MODE = 'RA/STOP_OPTIMISTIC_MODE';
 
-export const startUndoable = (action, delay = 4000) => ({
+export const startUndoable = action => ({
     type: UNDOABLE,
-    payload: { action, delay },
+    payload: { action },
 });
 
 export const undo = () => ({

--- a/packages/ra-core/src/actions/undoActions.js
+++ b/packages/ra-core/src/actions/undoActions.js
@@ -1,5 +1,6 @@
 export const UNDOABLE = 'RA/UNDOABLE';
 export const UNDO = 'RA/UNDO';
+export const COMPLETE = 'RA/COMPLETE';
 export const START_OPTIMISTIC_MODE = 'RA/START_OPTIMISTIC_MODE';
 export const STOP_OPTIMISTIC_MODE = 'RA/STOP_OPTIMISTIC_MODE';
 
@@ -10,6 +11,9 @@ export const startUndoable = (action, delay = 4000) => ({
 
 export const undo = () => ({
     type: UNDO,
+});
+export const complete = () => ({
+    type: COMPLETE,
 });
 
 export const startOptimisticMode = () => ({

--- a/packages/ra-core/src/sideEffect/undo.spec.js
+++ b/packages/ra-core/src/sideEffect/undo.spec.js
@@ -23,7 +23,6 @@ describe('undo saga', () => {
                     },
                 },
             },
-            delay: 100,
         },
     };
     describe('cancelled', () => {
@@ -65,7 +64,7 @@ describe('undo saga', () => {
             expect(generator.next().done).toEqual(true);
         });
     });
-    describe('timed out', () => {
+    describe('complete', () => {
         const generator = handleUndoRace(action);
 
         it('should start optimistic mode', () => {
@@ -88,7 +87,7 @@ describe('undo saga', () => {
             expect(generator.next().value).toHaveProperty('RACE');
         });
         it('should stop the optimistic mode', () => {
-            expect(generator.next({ timeout: true }).value).toEqual(
+            expect(generator.next({ complete: true }).value).toEqual(
                 put(stopOptimisticMode())
             );
         });

--- a/packages/ra-ui-materialui/src/layout/Notification.js
+++ b/packages/ra-ui-materialui/src/layout/Notification.js
@@ -7,7 +7,13 @@ import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
 
-import { hideNotification, getNotification, translate, undo } from 'ra-core';
+import {
+    hideNotification,
+    getNotification,
+    translate,
+    undo,
+    complete,
+} from 'ra-core';
 
 const styles = theme => ({
     confirm: {
@@ -38,12 +44,17 @@ class Notification extends React.Component {
     };
 
     handleExited = () => {
-        this.props.hideNotification();
+        const { notification, hideNotification, complete } = this.props;
+        if (notification.undoable) {
+            complete();
+        }
+        hideNotification();
     };
 
     render() {
         const {
             undo,
+            complete,
             classes,
             className,
             type,
@@ -93,6 +104,7 @@ class Notification extends React.Component {
 }
 
 Notification.propTypes = {
+    complete: PropTypes.func,
     classes: PropTypes.object,
     className: PropTypes.string,
     notification: PropTypes.shape({
@@ -121,6 +133,7 @@ export default compose(
     translate,
     withStyles(styles),
     connect(mapStateToProps, {
+        complete,
         hideNotification,
         undo,
     })


### PR DESCRIPTION
So a user be like: let me check the notification in the snackbar by hovering my mouse over it. After a couple of seconds he/she understands the message and decides to undo the action, but it does not work, the record is already removed. see screenshot: 
![2018-03-10_00-15-47](https://user-images.githubusercontent.com/621098/37234613-2c1c1b18-23f9-11e8-9259-63e962f4cd21.gif)

This PR removes the `delay` from the saga and allows the UI to call the complete: 
As you can see nothing happens while the mouse is over the snackbar. 
![2018-03-10_00-18-12](https://user-images.githubusercontent.com/621098/37234657-6406f82c-23f9-11e8-9c80-01693b0f4c23.gif)

