### PR TITLE
[RFR] Prevent Menu rerenderings

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Menu.js
+++ b/packages/ra-ui-materialui/src/layout/Menu.js
@@ -40,6 +40,7 @@ const Menu = ({
     dense,
     hasDashboard,
     onMenuClick,
+    pathname,
     resources,
     translate,
     logout,
@@ -72,6 +73,7 @@ Menu.propTypes = {
     hasDashboard: PropTypes.bool,
     logout: PropTypes.element,
     onMenuClick: PropTypes.func,
+    pathname: PropTypes.string,
     resources: PropTypes.array.isRequired,
     translate: PropTypes.func.isRequired,
 };
@@ -82,13 +84,21 @@ Menu.defaultProps = {
 
 const mapStateToProps = state => ({
     resources: getResources(state),
+    pathname: state.routing.location.pathname, // used to force redraw on navigation
 });
 
 const enhance = compose(
     translate,
     connect(
         mapStateToProps,
-        {} // Avoid connect passing dispatch in props
+        {}, // Avoid connect passing dispatch in props,
+        null,
+        {
+            areStatePropsEqual: (prev, next) =>
+                prev.resources.every(
+                    (value, index) => value === next.resources[index] // shallow compare resources
+                ) && prev.pathname == next.pathname,
+        }
     ),
     withStyles(styles)
 );


### PR DESCRIPTION
The Menu used to be rerendered at least 4 times on each page, because it was rerendered each time the data changed in the resources.

Before:
![kapture 2018-03-10 at 23 24 34](https://user-images.githubusercontent.com/99944/37247397-78fafcbc-24ba-11e8-97c6-7522100e2257.gif)

After:
![kapture 2018-03-10 at 23 23 31](https://user-images.githubusercontent.com/99944/37247395-6f338f64-24ba-11e8-8c08-8de6e254e917.gif)


