### PR TITLE
[RFR] fix GET_MANY_REFERENCE example in RestClients.md

### DIFF
--- a/docs/RestClients.md
+++ b/docs/RestClients.md
@@ -385,7 +385,7 @@ restClient(GET_MANY_REFERENCE, 'comments', {
     target: 'post_id',
     id: 123,
     sort: { field: 'created_at', order: 'DESC' }
-});
+})
 .then(response => console.log(response));
 // {
 //     data: [


### PR DESCRIPTION
The GET_MANY_REFERENCE example code was broken because of a `;` before the `.then`, probably carried over from the previous example.