### PR TITLE
[RFR]: Notification can be undefined when hidden through saga

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.js
+++ b/packages/ra-ui-materialui/src/layout/Notification.js
@@ -45,7 +45,7 @@ class Notification extends React.Component {
 
     handleExited = () => {
         const { notification, hideNotification, complete } = this.props;
-        if (notification.undoable) {
+        if (notification && notification.undoable) {
             complete();
         }
         hideNotification();


### PR DESCRIPTION
When a saga calls `hideNotification` and the `Notification` component is visible, the `notification.undoable` check fails. This PR ensures notification exists. 