### PR TITLE
[RFR]: Allow custom validation message and allow message to be a function

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,7 +25,7 @@
 - [Logout is now displayed in the AppBar on desktop](#logout-is-now-displayed-in-the-appbar-on-desktop)
 - [Data providers should support two more types for bulk actions](#data-providers-should-support-two-more-types-for-bulk-actions)
 - [react-admin addon packages renamed with ra prefix and moved into root repository](#react-admin-addon-packages-renamed-with-ra-prefix-and-moved-into-root-repository)
-
+- [require,number and email validation should be renamed to require(),number() and validation()](#validations-should-be-initialized)
 
 ## Admin-on-rest Renamed to React-Admin
 
@@ -1325,3 +1325,27 @@ import buildGraphcoolProvider from 'aor-graphql-client-graphcool';
 // after
 import buildGraphcoolProvider from 'ra-data-graphcool';
 ```
+
+## Validations should be initialized
+
+Previously the message of `required`,`number` and `email` weren't customizable.
+
+Update your `require`,`number` and `email` validations. 
+ 
+```jsx
+// before
+<TextInput source="foo" validate={required} />
+// after
+<TextInput source="foo" validate={required()} />
+
+// before
+<TextInput source="foo" validate={number} />
+// after
+<TextInput source="foo" validate={number()} />
+
+// before
+<TextInput source="foo" validate={email} />
+// after
+<TextInput source="foo" validate={email()} />
+```
+  

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,7 +25,7 @@
 - [Logout is now displayed in the AppBar on desktop](#logout-is-now-displayed-in-the-appbar-on-desktop)
 - [Data providers should support two more types for bulk actions](#data-providers-should-support-two-more-types-for-bulk-actions)
 - [react-admin addon packages renamed with ra prefix and moved into root repository](#react-admin-addon-packages-renamed-with-ra-prefix-and-moved-into-root-repository)
-- [require,number and email validation should be renamed to require(),number() and validation()](#validations-should-be-initialized)
+- [The require,number and email validators should be renamed to require(),number() and validation()](#validators-should-be-initialized)
 
 ## Admin-on-rest Renamed to React-Admin
 
@@ -1326,26 +1326,20 @@ import buildGraphcoolProvider from 'aor-graphql-client-graphcool';
 import buildGraphcoolProvider from 'ra-data-graphcool';
 ```
 
-## Validations should be initialized
+## Validators should be initialized
 
-Previously the message of `required`,`number` and `email` weren't customizable.
+The `required`,`number` and `email` validators must now be executed just like the other validators, not passed as function arguments.
 
 Update your `require`,`number` and `email` validations. 
  
-```jsx
-// before
-<TextInput source="foo" validate={required} />
-// after
-<TextInput source="foo" validate={required()} />
+```diff
+-<TextInput source="foo" validate={[required,maxSize(2)]} />
++<TextInput source="foo" validate={[required(),maxSize(2)]} />
 
-// before
-<TextInput source="foo" validate={number} />
-// after
-<TextInput source="foo" validate={number()} />
+-<TextInput source="foo" validate={number} />
++<TextInput source="foo" validate={number()} />
 
-// before
-<TextInput source="foo" validate={email} />
-// after
-<TextInput source="foo" validate={email()} />
+-<TextInput source="foo" validate={email} />
++<TextInput source="foo" validate={email()} />
 ```
   

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -618,9 +618,9 @@ export const UserCreate = ({ ...props }) =>
                 toolbar={<UserCreateToolbar permissions={permissions} />}
                 defaultValue={{ role: 'user' }}
             >
-                <TextInput source="name" validate={[required]} />
+                <TextInput source="name" validate={[required()]} />
                 {permissions === 'admin' &&
-                    <TextInput source="role" validate={[required]} />}
+                    <TextInput source="role" validate={[required()]} />}
             </SimpleForm>}
     </Create>;
 
@@ -647,9 +647,9 @@ export const UserCreate = ({ permissions, ...props }) =>
             toolbar={<UserCreateToolbar permissions={permissions} />}
             defaultValue={{ role: 'user' }}
         >
-            <TextInput source="name" validate={[required]} />
+            <TextInput source="name" validate={[required()]} />
             {permissions === 'admin' &&
-                <TextInput source="role" validate={[required]} />}
+                <TextInput source="role" validate={[required()]} />}
         </SimpleForm>
     </Create>;
 ```
@@ -664,11 +664,11 @@ export const UserEdit = ({ ...props }) =>
             <TabbedForm defaultValue={{ role: 'user' }}>
                 <FormTab label="user.form.summary">
                     {permissions === 'admin' && <DisabledInput source="id" />}
-                    <TextInput source="name" validate={required} />
+                    <TextInput source="name" validate={required()} />
                 </FormTab>
                 {permissions === 'admin' &&
                     <FormTab label="user.form.security">
-                        <TextInput source="role" validate={required} />
+                        <TextInput source="role" validate={required()} />
                     </FormTab>}
             </TabbedForm>}
     </Edit>;
@@ -679,11 +679,11 @@ export const UserEdit = ({ permissions, ...props }) =>
         <TabbedForm defaultValue={{ role: 'user' }}>
             <FormTab label="user.form.summary">
                 {permissions === 'admin' && <DisabledInput source="id" />}
-                <TextInput source="name" validate={required} />
+                <TextInput source="name" validate={required()} />
             </FormTab>
             {permissions === 'admin' &&
                 <FormTab label="user.form.security">
-                    <TextInput source="role" validate={required} />
+                    <TextInput source="role" validate={required()} />
                 </FormTab>}
         </TabbedForm>
     </Edit>;

--- a/docs/Authorization.md
+++ b/docs/Authorization.md
@@ -130,9 +130,9 @@ export const UserCreate = ({ permissions, ...props }) =>
             toolbar={<UserCreateToolbar permissions={permissions} />}
             defaultValue={{ role: 'user' }}
         >
-            <TextInput source="name" validate={[required]} />
+            <TextInput source="name" validate={[required()]} />
             {permissions === 'admin' &&
-                <TextInput source="role" validate={[required]} />}
+                <TextInput source="role" validate={[required()]} />}
         </SimpleForm>
     </Create>;
 ```
@@ -149,11 +149,11 @@ export const UserEdit = ({ permissions, ...props }) =>
         <TabbedForm defaultValue={{ role: 'user' }}>
             <FormTab label="user.form.summary">
                 {permissions === 'admin' && <DisabledInput source="id" />}
-                <TextInput source="name" validate={required} />
+                <TextInput source="name" validate={required()} />
             </FormTab>
             {permissions === 'admin' &&
                 <FormTab label="user.form.security">
-                    <TextInput source="role" validate={required} />
+                    <TextInput source="role" validate={required()} />
                 </FormTab>}
         </TabbedForm>
     </Edit>;

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -386,7 +386,7 @@ React-admin already bundles a few validator functions, that you can just require
 * `minLength(min, message)` to specify a minimum length for strings,
 * `maxLength(max, message)` to specify a maximum length for strings,
 * `number(message)` to check that the input is a valid number,
-* `email` to check that the input is a valid email address,
+* `email(message)` to check that the input is a valid email address,
 * `regex(pattern, message)` to validate that the input matches a regex,
 * `choices(list, message)` to validate that the input is within a given list,
 
@@ -404,7 +404,7 @@ export const UserCreate = (props) => (
     <Create {...props}>
         <SimpleForm>
             <TextInput label="First Name" source="firstName" validate={validateFirstName} />
-            <TextInput label="Email" source="email" validate={email} />
+            <TextInput label="Email" source="email" validate={email()} />
             <TextInput label="Age" source="age" validate={validateAge}/>
             <TextInput label="Zip Code" source="zip" validate={validateZipCode}/>
             <SelectInput label="Sex" source="sex" choices={[
@@ -415,6 +415,12 @@ export const UserCreate = (props) => (
     </Create>
 );
 ```
+
+**Tip**: You can pass a function as a message callback, for example: 
+```javascript
+<TextInput label="Email" source="email" validate={email(({translate})=>translate(''))} />
+```
+The callback signature is: `({args,value,values,translate,...props}) => String`
 
 ## Submit On Enter
 

--- a/docs/CreateEdit.md
+++ b/docs/CreateEdit.md
@@ -59,9 +59,9 @@ export const PostEdit = (props) => (
     <Edit title={<PostTitle />} {...props}>
         <SimpleForm>
             <DisabledInput label="Id" source="id" />
-            <TextInput source="title" validate={required} />
-            <LongTextInput source="teaser" validate={required} />
-            <RichTextInput source="body" validate={required} />
+            <TextInput source="title" validate={required()} />
+            <LongTextInput source="teaser" validate={required()} />
+            <RichTextInput source="body" validate={required()} />
             <DateInput label="Publication date" source="published_at" />
             <ReferenceManyField label="Comments" reference="comments" target="post_id">
                 <Datagrid>
@@ -202,16 +202,16 @@ export const PostEdit = (props) => (
         <TabbedForm>
             <FormTab label="summary">
                 <DisabledInput label="Id" source="id" />
-                <TextInput source="title" validate={required} />
-                <LongTextInput source="teaser" validate={required} />
+                <TextInput source="title" validate={required()} />
+                <LongTextInput source="teaser" validate={required()} />
             </FormTab>
             <FormTab label="body">
-                <RichTextInput source="body" validate={required} addLabel={false} />
+                <RichTextInput source="body" validate={required()} addLabel={false} />
             </FormTab>
             <FormTab label="Miscellaneous">
                 <TextInput label="Password (if protected post)" source="password" type="password" />
                 <DateInput label="Publication date" source="published_at" />
-                <NumberInput source="average_note" validate={[ number, minValue(0) ]} />
+                <NumberInput source="average_note" validate={[ number(), minValue(0) ]} />
                 <BooleanInput label="Allow comments?" source="commentable" defaultValue />
                 <DisabledInput label="Nb views" source="views" />
             </FormTab>
@@ -330,8 +330,8 @@ const ageValidation = (value, allValues) => {
     return [];
 }
 
-const validateFirstName = [required, maxLength(15)];
-const validateAge = [required, number, ageValidation];
+const validateFirstName = [required(), maxLength(15)];
+const validateAge = [required(), number(), ageValidation];
 
 export const UserCreate = (props) => (
     <Create {...props}>
@@ -356,7 +356,7 @@ const required = (value, allValues, props) => value ? undefined : props.translat
 ```jsx
 import { Edit, SimpleForm, NumberInput, required, minValue, number } from 'react-admin';
 
-const validateStock = [required, number, minValue(0)];
+const validateStock = [required(), number(), minValue(0)];
 
 export const ProductEdit = ({ ...props }) => (
     <Edit {...props}>
@@ -380,12 +380,12 @@ export const ProductEdit = ({ ...props }) => (
 
 React-admin already bundles a few validator functions, that you can just require and use as field validators:
 
-* `required` if the field is mandatory,
+* `required(message)` if the field is mandatory,
 * `minValue(min, message)` to specify a minimum value for integers,
 * `maxValue(max, message)` to specify a maximum value for integers,
 * `minLength(min, message)` to specify a minimum length for strings,
 * `maxLength(max, message)` to specify a maximum length for strings,
-* `number` to check that the input is a valid number,
+* `number(message)` to check that the input is a valid number,
 * `email` to check that the input is a valid email address,
 * `regex(pattern, message)` to validate that the input matches a regex,
 * `choices(list, message)` to validate that the input is within a given list,
@@ -396,7 +396,7 @@ Example usage:
 import { required, minLength, maxLength, minValue, maxValue, number, regex, email, choices } from 'react-admin';
 
 const validateFirstName = [required, minLength(2), maxLength(15)];
-const validateAge = [number, minValue(18)];
+const validateAge = [number(), minValue(18)];
 const validateZipCode = regex(/^\d{5}$/, 'Must be a valid Zip Code');
 const validateSex = choices(['m', 'f'], 'Must be Male or Female');
 
@@ -548,9 +548,9 @@ export const UserCreate = ({ permissions, ...props }) =>
             toolbar={<UserCreateToolbar permissions={permissions} />}
             defaultValue={{ role: 'user' }}
         >
-            <TextInput source="name" validate={[required]} />
+            <TextInput source="name" validate={[required()]} />
             {permissions === 'admin' &&
-                <TextInput source="role" validate={[required]} />}
+                <TextInput source="role" validate={[required()]} />}
         </SimpleForm>
     </Create>;
 ```
@@ -567,11 +567,11 @@ export const UserEdit = ({ permissions, ...props }) =>
         <TabbedForm defaultValue={{ role: 'user' }}>
             <FormTab label="user.form.summary">
                 {permissions === 'admin' && <DisabledInput source="id" />}
-                <TextInput source="name" validate={required} />
+                <TextInput source="name" validate={required()} />
             </FormTab>
             {permissions === 'admin' &&
                 <FormTab label="user.form.security">
-                    <TextInput source="role" validate={required} />
+                    <TextInput source="role" validate={required()} />
                 </FormTab>}
         </TabbedForm>
     </Edit>;

--- a/examples/demo/src/products/index.js
+++ b/examples/demo/src/products/index.js
@@ -16,6 +16,7 @@ import {
     TabbedForm,
     TextField,
     TextInput,
+    required,
 } from 'react-admin';
 import Icon from 'material-ui-icons/Collections';
 import Chip from 'material-ui/Chip';
@@ -75,30 +76,30 @@ export const ProductCreate = withStyles(
                 <TextInput
                     source="image"
                     options={{ fullWidth: true }}
-                    validation={{ required: true }}
+                    validate={required()}
                 />
                 <TextInput
                     source="thumbnail"
                     options={{ fullWidth: true }}
-                    validation={{ required: true }}
+                    validate={required()}
                 />
             </FormTab>
             <FormTab label="resources.products.tabs.details">
-                <TextInput source="reference" validation={{ required: true }} />
+                <TextInput source="reference" validate={required()} />
                 <NumberInput
                     source="price"
-                    validation={{ required: true }}
+                    validate={required()}
                     className={classes.price}
                 />
                 <NumberInput
                     source="width"
-                    validation={{ required: true }}
+                    validate={required()}
                     className={classes.width}
                     formClassName={classes.widthFormGroup}
                 />
                 <NumberInput
                     source="height"
-                    validation={{ required: true }}
+                    validate={required()}
                     className={classes.height}
                     formClassName={classes.heightFormGroup}
                 />
@@ -111,7 +112,7 @@ export const ProductCreate = withStyles(
                 </ReferenceInput>
                 <NumberInput
                     source="stock"
-                    validation={{ required: true }}
+                    validate={required()}
                     className={classes.stock}
                 />
             </FormTab>

--- a/examples/simple/comments.js
+++ b/examples/simple/comments.js
@@ -207,7 +207,7 @@ export const CommentCreate = props => (
                 source="post_id"
                 reference="posts"
                 allowEmpty
-                validate={required}
+                validate={required()}
             >
                 <SelectInput optionText="title" />
             </ReferenceInput>

--- a/examples/simple/posts.js
+++ b/examples/simple/posts.js
@@ -222,7 +222,7 @@ export const PostEdit = props => (
         <TabbedForm defaultValue={{ average_note: 0 }}>
             <FormTab label="post.form.summary">
                 <DisabledInput source="id" />
-                <TextInput source="title" validate={required} />
+                <TextInput source="title" validate={required()} />
                 <CheckboxGroupInput
                     source="notifications"
                     choices={[
@@ -231,7 +231,7 @@ export const PostEdit = props => (
                         { id: 42, name: 'Sean Phonee' },
                     ]}
                 />
-                <LongTextInput source="teaser" validate={required} />
+                <LongTextInput source="teaser" validate={required()} />
                 <ImageInput multiple source="pictures" accept="image/*">
                     <ImageField source="src" title="title" />
                 </ImageInput>
@@ -240,7 +240,7 @@ export const PostEdit = props => (
                 <RichTextInput
                     source="body"
                     label=""
-                    validate={required}
+                    validate={required()}
                     addLabel={false}
                 />
             </FormTab>
@@ -260,7 +260,7 @@ export const PostEdit = props => (
                 />
                 <NumberInput
                     source="average_note"
-                    validate={[required, number, minValue(0)]}
+                    validate={[required(), number(), minValue(0)]}
                 />
                 <BooleanInput source="commentable" defaultValue />
                 <DisabledInput source="views" />

--- a/examples/simple/users.js
+++ b/examples/simple/users.js
@@ -105,9 +105,9 @@ export const UserCreate = ({ permissions, ...props }) => (
             toolbar={<UserCreateToolbar permissions={permissions} />}
             defaultValue={{ role: 'user' }}
         >
-            <TextInput source="name" validate={[required]} />
+            <TextInput source="name" validate={[required()]} />
             {permissions === 'admin' && (
-                <TextInput source="role" validate={[required]} />
+                <TextInput source="role" validate={[required()]} />
             )}
         </SimpleForm>
     </Create>
@@ -118,11 +118,11 @@ export const UserEdit = ({ permissions, ...props }) => (
         <TabbedForm defaultValue={{ role: 'user' }}>
             <FormTab label="user.form.summary">
                 {permissions === 'admin' && <DisabledInput source="id" />}
-                <TextInput source="name" validate={required} />
+                <TextInput source="name" validate={required()} />
             </FormTab>
             {permissions === 'admin' && (
                 <FormTab label="user.form.security">
-                    <TextInput source="role" validate={required} />
+                    <TextInput source="role" validate={required()} />
                 </FormTab>
             )}
         </TabbedForm>

--- a/examples/simple/validators.js
+++ b/examples/simple/validators.js
@@ -1,0 +1,7 @@
+import {
+    required as createRequiredValidator,
+    number as createNumberValidator,
+} from 'react-admin';
+
+export const required = createRequiredValidator();
+export const number = createNumberValidator();

--- a/packages/ra-core/src/form/FormField.js
+++ b/packages/ra-core/src/form/FormField.js
@@ -4,12 +4,11 @@ import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 
 import { initializeForm } from '../actions';
-import { required } from './validate';
 
 const isRequired = validate => {
-    if (validate === required) return true;
+    if (validate && validate.isRequired) return true;
     if (Array.isArray(validate)) {
-        return validate.includes(required);
+        return validate.find(it => it.isRequired);
     }
     return false;
 };

--- a/packages/ra-core/src/form/FormField.js
+++ b/packages/ra-core/src/form/FormField.js
@@ -8,7 +8,7 @@ import { initializeForm } from '../actions';
 const isRequired = validate => {
     if (validate && validate.isRequired) return true;
     if (Array.isArray(validate)) {
-        return validate.find(it => it.isRequired);
+        return !!validate.find(it => it.isRequired);
     }
     return false;
 };

--- a/packages/ra-core/src/form/validate.js
+++ b/packages/ra-core/src/form/validate.js
@@ -5,54 +5,90 @@ const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"
 const isEmpty = value =>
     typeof value === 'undefined' || value === null || value === '';
 
-export const required = (value, _, props) =>
-    isEmpty(value) ? props.translate('ra.validation.required') : undefined;
+const getMessage = (message, messageArgs, value, values, { translate }) =>
+    typeof message === 'function'
+        ? message(messageArgs, value, values)
+        : translate(message, {
+              _: message,
+              ...messageArgs,
+          });
 
-export const minLength = (min, message) => (value, _, props) =>
+export const required = (message = 'ra.validation.required') =>
+    Object.assign(
+        (value, values, props) =>
+            isEmpty(value)
+                ? getMessage(message, undefined, value, values, props)
+                : undefined,
+        { isRequired: true }
+    );
+
+export const minLength = (min, message = 'ra.validation.minLength') => (
+    value,
+    values,
+    props
+) =>
     !isEmpty(value) && value.length < min
-        ? props.translate(message || 'ra.validation.minLength', {
-              min,
-              _: message,
-          })
+        ? getMessage(message, { min }, value, values, props)
         : undefined;
 
-export const maxLength = (max, message) => (value, _, props) =>
+export const maxLength = (max, message = 'ra.validation.maxLength') => (
+    value,
+    values,
+    props
+) =>
     !isEmpty(value) && value.length > max
-        ? props.translate(message || 'ra.validation.maxLength', {
-              max,
-              _: message,
-          })
+        ? getMessage(message, { max }, value, values, props)
         : undefined;
 
-export const minValue = (min, message) => (value, _, props) =>
+export const minValue = (min, message = 'ra.validation.minValue') => (
+    value,
+    values,
+    props
+) =>
     !isEmpty(value) && value < min
-        ? props.translate(message || 'ra.validation.minValue', {
-              min,
-              _: message,
-          })
+        ? getMessage(message, { min }, value, values, props)
         : undefined;
 
-export const maxValue = (max, message) => (value, _, props) =>
+export const maxValue = (max, message = 'ra.validation.maxValue') => (
+    value,
+    values,
+    props
+) =>
     !isEmpty(value) && value > max
-        ? props.translate(message || 'ra.validation.maxValue', {
-              max,
-              _: message,
-          })
+        ? getMessage(message, { max }, value, values, props)
         : undefined;
 
-export const number = (value, _, props) =>
+export const number = (message = 'ra.validation.number') => (
+    value,
+    values,
+    props
+) =>
     !isEmpty(value) && isNaN(Number(value))
-        ? props.translate('ra.validation.number')
+        ? getMessage(message, undefined, value, values, props)
         : undefined;
 
-export const regex = (pattern, message) => (value, _, props) =>
+export const regex = (pattern, message = 'ra.validation.regex') => (
+    value,
+    values,
+    props
+) =>
     !isEmpty(value) && typeof value === 'string' && !pattern.test(value)
-        ? props.translate(message, { _: message })
+        ? getMessage(message, { pattern }, value, values, props)
         : undefined;
 
-export const email = regex(EMAIL_REGEX, 'ra.validation.email');
+export const email = (message = 'ra.validation.email') =>
+    regex(EMAIL_REGEX, message);
 
-export const choices = (list, message) => (value, _, props) =>
+const oneOfTypeMessage = ({ list }, value, values, { translate }) => {
+    translate('ra.validation.oneOf', {
+        options: list.join(', '),
+    });
+};
+export const choices = (list, message = oneOfTypeMessage) => (
+    value,
+    values,
+    props
+) =>
     !isEmpty(value) && list.indexOf(value) === -1
-        ? props.translate(message, { _: message })
+        ? getMessage(message, { list }, value, values, props)
         : undefined;

--- a/packages/ra-core/src/form/validate.js
+++ b/packages/ra-core/src/form/validate.js
@@ -5,9 +5,15 @@ const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"
 const isEmpty = value =>
     typeof value === 'undefined' || value === null || value === '';
 
-const getMessage = (message, messageArgs, value, values, { translate }) =>
+const getMessage = (
+    message,
+    messageArgs,
+    value,
+    values,
+    { translate, ...props }
+) =>
     typeof message === 'function'
-        ? message(messageArgs, value, values)
+        ? message(messageArgs, value, values, translate, props)
         : translate(message, {
               _: message,
               ...messageArgs,

--- a/packages/ra-core/src/form/validate.js
+++ b/packages/ra-core/src/form/validate.js
@@ -5,16 +5,15 @@ const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"
 const isEmpty = value =>
     typeof value === 'undefined' || value === null || value === '';
 
-const getMessage = (
-    message,
-    messageArgs,
-    value,
-    values,
-    { translate, ...props }
-) =>
+const getMessage = (message, messageArgs, value, values, props) =>
     typeof message === 'function'
-        ? message(messageArgs, value, values, translate, props)
-        : translate(message, {
+        ? message({
+              args: messageArgs,
+              value,
+              values,
+              ...props,
+          })
+        : props.translate(message, {
               _: message,
               ...messageArgs,
           });

--- a/packages/ra-core/src/form/validate.spec.js
+++ b/packages/ra-core/src/form/validate.spec.js
@@ -22,10 +22,10 @@ describe('Validators', () => {
 
     describe('required', () => {
         it('should return undefined if the value is not empty', () => {
-            test(required, ['foo', 12], undefined);
+            test(required(), ['foo', 12], undefined);
         });
         it('should return an error message if the value is empty', () => {
-            test(required, [undefined, '', null], 'ra.validation.required');
+            test(required(), [undefined, '', null], 'ra.validation.required');
         });
     });
     describe('minLength', () => {
@@ -86,13 +86,13 @@ describe('Validators', () => {
     });
     describe('number', () => {
         it('should return undefined if the value is empty', () => {
-            test(number, [undefined, '', null], undefined);
+            test(number(), [undefined, '', null], undefined);
         });
         it('should return undefined if the value is a number', () => {
-            test(number, [123, '123', new Date(), 0, 2.5, -5], undefined);
+            test(number(), [123, '123', new Date(), 0, 2.5, -5], undefined);
         });
         it('should return an error message if the value is not a number', () => {
-            test(number, ['foo'], 'ra.validation.number');
+            test(number(), ['foo'], 'ra.validation.number');
         });
     });
     describe('regex', () => {
@@ -119,16 +119,20 @@ describe('Validators', () => {
     });
     describe('email', () => {
         it('should return undefined if the value is empty', () => {
-            test(email, [undefined, '', null], undefined);
+            test(email(), [undefined, '', null], undefined);
         });
         it('should return undefined if the value is not a string', () => {
-            test(email, [1234, new Date()], undefined);
+            test(email(), [1234, new Date()], undefined);
         });
         it('should return undefined if the value is a valid email', () => {
-            test(email, ['foo@bar.com', 'john.doe@mydomain.co.uk'], undefined);
+            test(
+                email(),
+                ['foo@bar.com', 'john.doe@mydomain.co.uk'],
+                undefined
+            );
         });
         it('should return an error if the value is not a valid email', () => {
-            test(email, ['foo@bar', 'hello, world'], 'ra.validation.email');
+            test(email(), ['foo@bar', 'hello, world'], 'ra.validation.email');
         });
     });
     describe('choices', () => {

--- a/packages/ra-core/src/form/validate.spec.js
+++ b/packages/ra-core/src/form/validate.spec.js
@@ -38,13 +38,12 @@ describe('Validators', () => {
                 'ra.validation.required'
             );
             expect(message).toHaveBeenCalledTimes(3);
-            expect(message).toHaveBeenLastCalledWith(
-                undefined,
-                null,
-                null,
+            expect(message).toHaveBeenLastCalledWith({
+                args: undefined,
+                value: null,
+                values: null,
                 translate,
-                {}
-            );
+            });
         });
     });
     describe('minLength', () => {
@@ -68,13 +67,12 @@ describe('Validators', () => {
                 'ra.validation.minLength'
             );
             expect(message).toHaveBeenCalledTimes(2);
-            expect(message).toHaveBeenLastCalledWith(
-                { min: 5 },
-                '12',
-                null,
+            expect(message).toHaveBeenLastCalledWith({
+                args: { min: 5 },
+                value: '12',
+                values: null,
                 translate,
-                {}
-            );
+            });
         });
     });
     describe('maxLength', () => {
@@ -98,13 +96,12 @@ describe('Validators', () => {
                 'ra.validation.maxLength'
             );
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenLastCalledWith(
-                { max: 10 },
-                '12345678901',
-                null,
+            expect(message).toHaveBeenLastCalledWith({
+                args: { max: 10 },
+                value: '12345678901',
+                values: null,
                 translate,
-                {}
-            );
+            });
         });
     });
     describe('minValue', () => {
@@ -124,13 +121,12 @@ describe('Validators', () => {
             const message = jest.fn(() => 'ra.validation.minValue');
             test(minValue(10, message), [0], 'ra.validation.minValue');
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenLastCalledWith(
-                { min: 10 },
-                0,
-                null,
+            expect(message).toHaveBeenLastCalledWith({
+                args: { min: 10 },
+                value: 0,
+                values: null,
                 translate,
-                {}
-            );
+            });
         });
     });
     describe('maxValue', () => {
@@ -154,13 +150,12 @@ describe('Validators', () => {
                 'ra.validation.maxValue'
             );
             expect(message).toHaveBeenCalledTimes(3);
-            expect(message).toHaveBeenLastCalledWith(
-                { max: 10 },
-                '11',
-                null,
+            expect(message).toHaveBeenLastCalledWith({
+                args: { max: 10 },
+                value: '11',
+                values: null,
                 translate,
-                {}
-            );
+            });
         });
     });
     describe('number', () => {
@@ -177,13 +172,12 @@ describe('Validators', () => {
             const message = jest.fn(() => 'ra.validation.number');
             test(number(message), ['foo'], 'ra.validation.number');
             expect(message).toHaveBeenCalledTimes(1);
-            expect(message).toHaveBeenLastCalledWith(
-                undefined,
-                'foo',
-                null,
+            expect(message).toHaveBeenLastCalledWith({
+                args: undefined,
+                value: 'foo',
+                values: null,
                 translate,
-                {}
-            );
+            });
         });
     });
     describe('regex', () => {

--- a/packages/ra-core/src/form/validate.spec.js
+++ b/packages/ra-core/src/form/validate.spec.js
@@ -12,20 +12,39 @@ import {
 } from './validate';
 
 describe('Validators', () => {
+    const translate = x => x;
     const test = (validator, inputs, message) =>
         assert.deepEqual(
             inputs
-                .map(input => validator(input, null, { translate: x => x }))
+                .map(input => validator(input, null, { translate }))
                 .filter(m => m === message),
             Array(...Array(inputs.length)).map(() => message)
         );
-
     describe('required', () => {
         it('should return undefined if the value is not empty', () => {
             test(required(), ['foo', 12], undefined);
         });
         it('should return an error message if the value is empty', () => {
             test(required(), [undefined, '', null], 'ra.validation.required');
+        });
+        it('should have a `isRequired` prop for allowing the UI to add a required marker', () => {
+            expect(required().isRequired).toEqual(true);
+        });
+        it('should allow message to be a callback', () => {
+            const message = jest.fn(() => 'ra.validation.required');
+            test(
+                required(message),
+                [undefined, '', null],
+                'ra.validation.required'
+            );
+            expect(message).toHaveBeenCalledTimes(3);
+            expect(message).toHaveBeenLastCalledWith(
+                undefined,
+                null,
+                null,
+                translate,
+                {}
+            );
         });
     });
     describe('minLength', () => {
@@ -41,6 +60,22 @@ describe('Validators', () => {
         it('should return an error message if the value has smaller length than the given minimum', () => {
             test(minLength(5), ['1234', '12'], 'ra.validation.minLength');
         });
+        it('should allow message to be a callback', () => {
+            const message = jest.fn(() => 'ra.validation.minLength');
+            test(
+                minLength(5, message),
+                ['1234', '12'],
+                'ra.validation.minLength'
+            );
+            expect(message).toHaveBeenCalledTimes(2);
+            expect(message).toHaveBeenLastCalledWith(
+                { min: 5 },
+                '12',
+                null,
+                translate,
+                {}
+            );
+        });
     });
     describe('maxLength', () => {
         it('should return undefined if the value is empty', () => {
@@ -54,6 +89,22 @@ describe('Validators', () => {
         });
         it('should return an error message if the value has higher length than the given maximum', () => {
             test(maxLength(10), ['12345678901'], 'ra.validation.maxLength');
+        });
+        it('should allow message to be a callback', () => {
+            const message = jest.fn(() => 'ra.validation.maxLength');
+            test(
+                maxLength(10, message),
+                ['12345678901'],
+                'ra.validation.maxLength'
+            );
+            expect(message).toHaveBeenCalledTimes(1);
+            expect(message).toHaveBeenLastCalledWith(
+                { max: 10 },
+                '12345678901',
+                null,
+                translate,
+                {}
+            );
         });
     });
     describe('minValue', () => {
@@ -69,6 +120,18 @@ describe('Validators', () => {
         it('should return an error message if the value is 0', () => {
             test(minValue(10), [0], 'ra.validation.minValue');
         });
+        it('should allow message to be a callback', () => {
+            const message = jest.fn(() => 'ra.validation.minValue');
+            test(minValue(10, message), [0], 'ra.validation.minValue');
+            expect(message).toHaveBeenCalledTimes(1);
+            expect(message).toHaveBeenLastCalledWith(
+                { min: 10 },
+                0,
+                null,
+                translate,
+                {}
+            );
+        });
     });
     describe('maxValue', () => {
         it('should return undefined if the value is empty', () => {
@@ -83,6 +146,22 @@ describe('Validators', () => {
         it('should return undefined if the value is 0', () => {
             test(maxValue(10), [0], undefined);
         });
+        it('should allow message to be a callback', () => {
+            const message = jest.fn(() => 'ra.validation.maxValue');
+            test(
+                maxValue(10, message),
+                [11, 10.5, '11'],
+                'ra.validation.maxValue'
+            );
+            expect(message).toHaveBeenCalledTimes(3);
+            expect(message).toHaveBeenLastCalledWith(
+                { max: 10 },
+                '11',
+                null,
+                translate,
+                {}
+            );
+        });
     });
     describe('number', () => {
         it('should return undefined if the value is empty', () => {
@@ -93,6 +172,18 @@ describe('Validators', () => {
         });
         it('should return an error message if the value is not a number', () => {
             test(number(), ['foo'], 'ra.validation.number');
+        });
+        it('should allow message to be a callback', () => {
+            const message = jest.fn(() => 'ra.validation.number');
+            test(number(message), ['foo'], 'ra.validation.number');
+            expect(message).toHaveBeenCalledTimes(1);
+            expect(message).toHaveBeenLastCalledWith(
+                undefined,
+                'foo',
+                null,
+                translate,
+                {}
+            );
         });
     });
     describe('regex', () => {

--- a/packages/ra-language-english/index.js
+++ b/packages/ra-language-english/index.js
@@ -100,6 +100,8 @@ module.exports = {
             maxValue: 'Must be %{max} or less',
             number: 'Must be a number',
             email: 'Must be a valid email',
+            oneOf: 'Must be one of: %{options}',
+            regex: 'Must match a specific format (regexp): %{pattern}',
         },
     },
 };


### PR DESCRIPTION
Allow to customize each validation message and allow message to be a function. 

The later is useful if the user wants to allow lazy initialization of the error message (useful for nested lookups). 

It's a breaking change, because `required` validator should now be used as `required()`, `number` as `number()` and `email` as `email()`. This is inline with all other validators. 