### PR TITLE
[RFR]: Default redirect disables passing redirect to SimpleForm

### DIFF
--- a/packages/ra-ui-materialui/src/button/SaveButton.js
+++ b/packages/ra-ui-materialui/src/button/SaveButton.js
@@ -117,7 +117,6 @@ SaveButton.propTypes = {
 };
 
 SaveButton.defaultProps = {
-    redirect: 'list',
     handleSubmitWithRedirect: () => () => {},
 };
 


### PR DESCRIPTION
The `redirect` is defaulted in `EditController` and should be passed down to `SaveButton`. The `defaultProp` in `SaveButton` overrides this.
```
<Edit>
<SimpleForm redirect={false}>
</SimpleForm>
</Edit>
```
This currently does not work, the redirect still is `list`. (I know I can pass custom `toolbar`). 