### PR TITLE
[RFR] Display SelectInput with a minimum width

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectInput.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import get from 'lodash.get';
 import TextField from 'material-ui/TextField';
 import { MenuItem } from 'material-ui/Menu';
+import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 import { addField, translate, FieldTitle } from 'ra-core';
 
@@ -44,6 +45,12 @@ const sanitizeRestProps = ({
     validation,
     ...rest
 }) => rest;
+
+const styles = theme => ({
+    input: {
+        minWidth: theme.spacing.unit * 20,
+    },
+});
 
 /**
  * An Input component for a select box, using an array of objects for the options
@@ -157,6 +164,7 @@ export class SelectInput extends Component {
     render() {
         const {
             choices,
+            classes,
             className,
             isRequired,
             label,
@@ -187,7 +195,7 @@ export class SelectInput extends Component {
                         isRequired={isRequired}
                     />
                 }
-                className={className}
+                className={`${classes.input} ${className}`}
                 error={!!(touched && error)}
                 helperText={(touched && error) || helperText}
                 {...options}
@@ -203,6 +211,7 @@ export class SelectInput extends Component {
 SelectInput.propTypes = {
     allowEmpty: PropTypes.bool.isRequired,
     choices: PropTypes.arrayOf(PropTypes.object),
+    classes: PropTypes.object,
     className: PropTypes.string,
     input: PropTypes.object,
     isRequired: PropTypes.bool,
@@ -223,6 +232,7 @@ SelectInput.propTypes = {
 
 SelectInput.defaultProps = {
     allowEmpty: false,
+    classes: {},
     choices: [],
     options: {},
     optionText: 'name',
@@ -230,4 +240,4 @@ SelectInput.defaultProps = {
     translateChoice: true,
 };
 
-export default compose(addField, translate)(SelectInput);
+export default compose(addField, translate, withStyles(styles))(SelectInput);


### PR DESCRIPTION
Closes #1604

Before:

![image](https://user-images.githubusercontent.com/99944/37403592-96b9c526-278f-11e8-9db2-240b93de6629.png)


After:

![image](https://user-images.githubusercontent.com/99944/37403524-6b4d9f98-278f-11e8-817c-e391505c0e07.png)



Refs https://github.com/mui-org/material-ui/issues/8778