### PR TITLE
[RFR]: Allow translate fallback keys

### DIFF
--- a/docs/Translation.md
+++ b/docs/Translation.md
@@ -220,6 +220,7 @@ However, before humanizing names, react-admin checks the `messages` dictionary f
 
 - `${locale}.resources.${resourceName}.name` for resource names (used for the menu and page titles)
 - `${locale}.resources.${resourceName}.fields.${fieldName}` for field names (used for datagrid header and form input labels)
+- `${locale}.common.fields.${fieldName}` for common field names (used for datagrid header and form input labels)
 
 This lets you translate your own resource and field names by passing a `messages` object with a `resources` key:
 
@@ -243,6 +244,11 @@ This lets you translate your own resource and field names by passing a `messages
             }
         }
     },
+    common: {
+       fields: {
+           id: 'Id'       
+       }
+    }
     ...
 }
 ```
@@ -336,6 +342,14 @@ export default translate(MyHelloButton);
 <TextField source="first_name" />
 // and translate the `resources.customers.fields.first_name` key
 ```
+
+## Fallback keys 
+
+`translate` allows to be called with multiple keys, they will be searched in order supplied, for example:
+ 
+```jsx
+<div>{translate(['mypage.title','app.title'],{_:'Default title'})}</div>
+``` 
 
 ## Using Specific Polyglot Features
 

--- a/packages/ra-core/src/i18n/TranslationProvider.js
+++ b/packages/ra-core/src/i18n/TranslationProvider.js
@@ -33,6 +33,16 @@ const mapStateToProps = state => ({
     messages: state.i18n.messages,
 });
 
+export const withFallbackTranslate = translate => (message, options) =>
+    Array.isArray(message)
+        ? message.reverse().reduce((acc, item) => {
+              return translate(item, {
+                  ...options,
+                  _: acc || item,
+              });
+          }, options && options._)
+        : translate(message, options);
+
 const withI18nContext = withContext(
     {
         translate: PropTypes.func.isRequired,
@@ -46,7 +56,7 @@ const withI18nContext = withContext(
 
         return {
             locale,
-            translate: polyglot.t.bind(polyglot),
+            translate: withFallbackTranslate(polyglot.t.bind(polyglot)),
         };
     }
 );

--- a/packages/ra-core/src/util/FieldTitle.js
+++ b/packages/ra-core/src/util/FieldTitle.js
@@ -17,9 +17,18 @@ export const FieldTitle = ({
         {typeof label !== 'undefined'
             ? translate(label, { _: label })
             : typeof source !== 'undefined'
-              ? translate(`resources.${resource}.fields.${source}`, {
-                    _: inflection.transform(source, ['underscore', 'humanize']),
-                })
+              ? translate(
+                    [
+                        `resources.${resource}.fields.${source}`,
+                        `common.fields.${source}`,
+                    ],
+                    {
+                        _: inflection.transform(source, [
+                            'underscore',
+                            'humanize',
+                        ]),
+                    }
+                )
               : ''}
         {isRequired && ' *'}
     </span>

--- a/packages/ra-core/src/util/FieldTitle.spec.js
+++ b/packages/ra-core/src/util/FieldTitle.spec.js
@@ -3,10 +3,13 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { FieldTitle } from './FieldTitle';
+import { withFallbackTranslate } from '../i18n/TranslationProvider';
 
 describe('FieldTitle', () => {
-    const translateMock = dictionary => (term, options) =>
-        dictionary[term] || options._ || '';
+    const translateMock = dictionary =>
+        withFallbackTranslate(
+            (term, options) => dictionary[term] || options._ || ''
+        );
     it('should return empty span by default', () =>
         assert.equal(shallow(<FieldTitle />).html(), '<span></span>'));
     it('should use the label when given', () =>


### PR DESCRIPTION
Adds fallback keys for translatable fields. This allows an array of messages to be supplied to `translate`. 
A fallback is added for the `FieldTitle` lookup: `resources.${resource}.fields.${source}` and `common.fields.${source}` is checked. 

Todo: 

- [X] Add docs