### PR TITLE
Update redux-form to 7.1.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "react-router-redux": "~5.0.0-alpha.6",
         "recompose": "~0.25.0",
         "redux": "~3.7.2",
-        "redux-form": "~7.0.3",
+        "redux-form": "~7.1.1",
         "redux-saga": "~0.15.0",
         "reselect": "~3.0.0"
     }


### PR DESCRIPTION
Hello,

We have [some warnings on api-platform/admin](https://travis-ci.org/api-platform/admin/jobs/353729496#L501) due to [redux-form](https://github.com/erikras/redux-form/issues/3385).

Update `redux-form` to (at least) `7.1.0` resolves the problem (I used `7.1.1` because `7.1.0` had [a problem with immutablejs](https://github.com/erikras/redux-form/issues/3493)).

According to [your version policy](https://github.com/marmelab/admin-on-rest/pull/1533), I kept `tilde` for version range.