### PR TITLE
[RFR]: SelectArrayInput don't translate when optionText is a React Component

### DIFF
--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -140,7 +140,6 @@ export class SelectArrayInput extends Component {
         if (React.isValidElement(optionText))
             return React.cloneElement(optionText, {
                 record: choice,
-                translate,
             });
         const choiceName =
             typeof optionText === 'function'

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -135,20 +135,30 @@ export class SelectArrayInput extends Component {
         this.props.input.onChange(event.target.value);
         this.setState({ value: event.target.value });
     };
+    renderMenuItemOption = choice => {
+        const { optionText, translate, translateChoice } = this.props;
+        if (React.isValidElement(optionText))
+            return React.cloneElement(optionText, {
+                record: choice,
+                translate,
+            });
+        const choiceName =
+            typeof optionText === 'function'
+                ? optionText(choice)
+                : get(choice, optionText);
+        return translateChoice
+            ? translate(choiceName, { _: choiceName })
+            : choiceName;
+    };
 
     renderMenuItem = choice => {
-        const { optionText, optionValue, translate } = this.props;
-        const choiceName = React.isValidElement(optionText) // eslint-disable-line no-nested-ternary
-            ? React.cloneElement(optionText, { record: choice })
-            : typeof optionText === 'function'
-              ? optionText(choice)
-              : get(choice, optionText);
+        const { optionValue } = this.props;
         return (
             <MenuItem
                 key={get(choice, optionValue)}
                 value={get(choice, optionValue)}
             >
-                {translate(choiceName, { _: choiceName })}
+                {this.renderMenuItemOption(choice)}
             </MenuItem>
         );
     };
@@ -240,6 +250,7 @@ SelectArrayInput.propTypes = {
     resource: PropTypes.string,
     source: PropTypes.string,
     translate: PropTypes.func.isRequired,
+    translateChoice: PropTypes.bool,
 };
 
 SelectArrayInput.defaultProps = {
@@ -248,6 +259,7 @@ SelectArrayInput.defaultProps = {
     options: {},
     optionText: 'name',
     optionValue: 'id',
+    translateChoice: true,
 };
 
 const EnhancedSelectArrayInput = compose(

--- a/packages/ra-ui-materialui/src/input/SelectInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectInput.js
@@ -134,7 +134,6 @@ export class SelectInput extends Component {
         if (React.isValidElement(optionText))
             return React.cloneElement(optionText, {
                 record: choice,
-                translate,
             });
         const choiceName =
             typeof optionText === 'function'

--- a/packages/ra-ui-materialui/src/input/SelectInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectInput.js
@@ -129,27 +129,30 @@ export class SelectInput extends Component {
 
         return choices;
     };
+    renderMenuItemOption = choice => {
+        const { optionText, translate, translateChoice } = this.props;
+        if (React.isValidElement(optionText))
+            return React.cloneElement(optionText, {
+                record: choice,
+                translate,
+            });
+        const choiceName =
+            typeof optionText === 'function'
+                ? optionText(choice)
+                : get(choice, optionText);
+        return translateChoice
+            ? translate(choiceName, { _: choiceName })
+            : choiceName;
+    };
 
     renderMenuItem = choice => {
-        const {
-            optionText,
-            optionValue,
-            translate,
-            translateChoice,
-        } = this.props;
-        const choiceName = React.isValidElement(optionText) // eslint-disable-line no-nested-ternary
-            ? React.cloneElement(optionText, { record: choice })
-            : typeof optionText === 'function'
-              ? optionText(choice)
-              : get(choice, optionText);
+        const { optionValue } = this.props;
         return (
             <MenuItem
                 key={get(choice, optionValue)}
                 value={get(choice, optionValue)}
             >
-                {translateChoice
-                    ? translate(choiceName, { _: choiceName })
-                    : choiceName}
+                {this.renderMenuItemOption(choice)}
             </MenuItem>
         );
     };
@@ -218,7 +221,7 @@ SelectInput.propTypes = {
     resource: PropTypes.string,
     source: PropTypes.string,
     translate: PropTypes.func.isRequired,
-    translateChoice: PropTypes.bool.isRequired,
+    translateChoice: PropTypes.bool,
 };
 
 SelectInput.defaultProps = {


### PR DESCRIPTION
The translate option did not check if the optionText is a component. Component clones should not be translated. Added `translate` prop to clone properties. 