### PR TITLE
[RFR] ReferenceArrayInput label not rendered, because it's initialized with empty string

### DIFF
--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.js
@@ -45,7 +45,7 @@ export const ReferenceArrayInputView = ({
     error,
     input,
     isLoading,
-    label = '',
+    label,
     meta,
     onChange,
     options,


### PR DESCRIPTION
Fixes topic. 