### PR TITLE
[RFR] Introduce onFailure meta to handle failure side effects

### DIFF
--- a/docs/Actions.md
+++ b/docs/Actions.md
@@ -279,6 +279,12 @@ export const commentApprove = (id, data, basePath) => ({
 +            redirectTo: '/comments',
 +            basePath,
 +        },
++        onFailure: {
++            notification: {
++                body: 'resources.comments.notification.approved_failure',
++                level: 'warning',
++            },
++        },
     },
 });
 ```

--- a/examples/demo/src/reviews/AcceptButton.js
+++ b/examples/demo/src/reviews/AcceptButton.js
@@ -17,7 +17,10 @@ class AcceptButton extends Component {
         const { record, translate } = this.props;
         return record && record.status === 'pending' ? (
             <Button color="primary" onClick={this.handleApprove}>
-                <ThumbUp color="primary" style={{ paddingRight: '0.5em' }} />
+                <ThumbUp
+                    color="primary"
+                    style={{ paddingRight: '0.5em', color: 'green' }}
+                />
                 {translate('resources.reviews.action.accept')}
             </Button>
         ) : (

--- a/examples/demo/src/reviews/ApproveButton.js
+++ b/examples/demo/src/reviews/ApproveButton.js
@@ -4,10 +4,21 @@ import { connect } from 'react-redux';
 import IconButton from 'material-ui/IconButton';
 import ThumbUp from 'material-ui-icons/ThumbUp';
 import ThumbDown from 'material-ui-icons/ThumbDown';
+import { withStyles } from 'material-ui/styles';
+
 import {
     reviewApprove as reviewApproveAction,
     reviewReject as reviewRejectAction,
 } from './reviewActions';
+
+const styles = {
+    accepted: {
+        color: 'green',
+    },
+    rejected: {
+        color: 'red',
+    },
+};
 
 class ApproveButton extends Component {
     handleApprove = () => {
@@ -21,20 +32,28 @@ class ApproveButton extends Component {
     };
 
     render() {
-        const { record } = this.props;
+        const { record, classes } = this.props;
         return (
             <span>
                 <IconButton
                     onClick={this.handleApprove}
                     disabled={record.status === 'accepted'}
                 >
-                    <ThumbUp color="action" />
+                    <ThumbUp
+                        className={
+                            record.status === 'accepted' ? classes.accepted : ''
+                        }
+                    />
                 </IconButton>
                 <IconButton
                     onClick={this.handleReject}
                     disabled={record.status === 'rejected'}
                 >
-                    <ThumbDown color="action" />
+                    <ThumbDown
+                        className={
+                            record.status === 'rejected' ? classes.rejected : ''
+                        }
+                    />
                 </IconButton>
             </span>
         );
@@ -42,6 +61,7 @@ class ApproveButton extends Component {
 }
 
 ApproveButton.propTypes = {
+    classes: PropTypes.object,
     record: PropTypes.object,
     reviewApprove: PropTypes.func,
     reviewReject: PropTypes.func,
@@ -50,4 +70,4 @@ ApproveButton.propTypes = {
 export default connect(null, {
     reviewApprove: reviewApproveAction,
     reviewReject: reviewRejectAction,
-})(ApproveButton);
+})(withStyles(styles)(ApproveButton));

--- a/examples/demo/src/reviews/RejectButton.js
+++ b/examples/demo/src/reviews/RejectButton.js
@@ -17,7 +17,10 @@ class AcceptButton extends Component {
         const { record, translate } = this.props;
         return record && record.status === 'pending' ? (
             <Button color="primary" onClick={this.handleApprove}>
-                <ThumbDown color="primary" style={{ paddingRight: '0.5em' }} />
+                <ThumbDown
+                    color="primary"
+                    style={{ paddingRight: '0.5em', color: 'red' }}
+                />
                 {translate('resources.reviews.action.reject')}
             </Button>
         ) : (

--- a/examples/demo/src/reviews/reviewActions.js
+++ b/examples/demo/src/reviews/reviewActions.js
@@ -19,6 +19,12 @@ export const reviewApprove = (id, data, basePath) => ({
             redirectTo: '/reviews',
             basePath,
         },
+        onFailure: {
+            notification: {
+                body: 'resources.reviews.notification.approved_error',
+                level: 'warning',
+            },
+        },
     },
 });
 
@@ -40,6 +46,12 @@ export const reviewReject = (id, data, basePath) => ({
             },
             redirectTo: '/reviews',
             basePath,
+        },
+        onFailure: {
+            notification: {
+                body: 'resources.reviews.notification.rejected_error',
+                level: 'warning',
+            },
         },
     },
 });

--- a/examples/demo/src/reviews/reviewSaga.js
+++ b/examples/demo/src/reviews/reviewSaga.js
@@ -1,26 +1,15 @@
-import { all, put, takeEvery } from 'redux-saga/effects';
-import { showNotification } from 'react-admin';
+import { all, takeEvery } from 'redux-saga/effects';
 import { REVIEW_APPROVE_FAILURE, REVIEW_REJECT_FAILURE } from './reviewActions';
 
 export default function* reviewSaga() {
     yield all([
         takeEvery(REVIEW_APPROVE_FAILURE, function*({ error }) {
-            yield put(
-                showNotification(
-                    'resources.reviews.notification.approved_error',
-                    'warning'
-                )
-            );
             console.error(error);
+            yield all([]);
         }),
         takeEvery(REVIEW_REJECT_FAILURE, function*({ error }) {
-            yield put(
-                showNotification(
-                    'resources.reviews.notification.rejected_error',
-                    'warning'
-                )
-            );
             console.error(error);
+            yield all([]);
         }),
     ]);
 }

--- a/packages/ra-core/src/actions/dataActions.js
+++ b/packages/ra-core/src/actions/dataActions.js
@@ -18,7 +18,17 @@ export const CRUD_GET_LIST_SUCCESS = 'RA/CRUD_GET_LIST_SUCCESS';
 export const crudGetList = (resource, pagination, sort, filter) => ({
     type: CRUD_GET_LIST,
     payload: { pagination, sort, filter },
-    meta: { resource, fetch: GET_LIST },
+    meta: {
+        resource,
+        fetch: GET_LIST,
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
+        },
+    },
 });
 
 export const CRUD_GET_ONE = 'RA/CRUD_GET_ONE';
@@ -29,7 +39,19 @@ export const CRUD_GET_ONE_SUCCESS = 'RA/CRUD_GET_ONE_SUCCESS';
 export const crudGetOne = (resource, id, basePath) => ({
     type: CRUD_GET_ONE,
     payload: { id },
-    meta: { resource, fetch: GET_ONE, basePath },
+    meta: {
+        resource,
+        fetch: GET_ONE,
+        basePath,
+        onFailure: {
+            notification: {
+                body: 'ra.notification.item_doesnt_exist',
+                level: 'warning',
+            },
+            redirectTo: 'list',
+            refresh: true,
+        },
+    },
 });
 
 export const CRUD_CREATE = 'RA/CRUD_CREATE';
@@ -53,6 +75,13 @@ export const crudCreate = (resource, data, basePath, redirectTo = 'edit') => ({
             },
             redirectTo,
             basePath,
+        },
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
         },
     },
 });
@@ -86,6 +115,13 @@ export const crudUpdate = (
             },
             redirectTo,
             basePath,
+        },
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
         },
     },
 });
@@ -121,6 +157,13 @@ export const crudUpdateMany = (
             refresh,
             unselectAll: true,
         },
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
+        },
     },
 });
 
@@ -153,6 +196,13 @@ export const crudDelete = (
             redirectTo,
             basePath,
         },
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
+        },
     },
 });
 
@@ -180,6 +230,13 @@ export const crudDeleteMany = (resource, ids, basePath, refresh = true) => ({
             refresh,
             unselectAll: true,
         },
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
+        },
     },
 });
 
@@ -196,6 +253,13 @@ export const crudGetMany = (resource, ids) => ({
     meta: {
         resource,
         fetch: GET_MANY,
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
+        },
     },
 });
 
@@ -217,6 +281,13 @@ export const crudGetMatching = (
         resource: reference,
         relatedTo,
         fetch: GET_LIST,
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
+        },
     },
 });
 
@@ -244,5 +315,12 @@ export const crudGetManyReference = (
         resource: reference,
         relatedTo,
         fetch: GET_MANY_REFERENCE,
+        onFailure: {
+            notification: {
+                body: 'ra.notification.http_error',
+                level: 'warning',
+            },
+            refresh: true,
+        },
     },
 });

--- a/packages/ra-core/src/sideEffect/error.js
+++ b/packages/ra-core/src/sideEffect/error.js
@@ -1,26 +1,13 @@
 import { all, put, takeEvery } from 'redux-saga/effects';
-import { push } from 'react-router-redux';
-import {
-    CRUD_CREATE_FAILURE,
-    CRUD_DELETE_FAILURE,
-    CRUD_DELETE_MANY_FAILURE,
-    CRUD_GET_LIST_FAILURE,
-    CRUD_GET_MANY_FAILURE,
-    CRUD_GET_MANY_REFERENCE_FAILURE,
-    CRUD_GET_ONE_SUCCESS,
-    CRUD_GET_ONE_FAILURE,
-    CRUD_UPDATE_FAILURE,
-    CRUD_UPDATE_MANY_FAILURE,
-} from '../actions/dataActions';
+import { CRUD_GET_ONE_SUCCESS } from '../actions/dataActions';
 import { showNotification } from '../actions/notificationActions';
-import { refreshView } from '../actions/uiActions';
 
 /**
  * Side effects for fetch responses
  *
- * Mostly error handling
+ * Mostly corenr case handling
  */
-function* handleResponse({ type, requestPayload, error, payload, meta }) {
+function* handleResponse({ type, requestPayload, payload }) {
     switch (type) {
         case CRUD_GET_ONE_SUCCESS:
             if (
@@ -32,37 +19,6 @@ function* handleResponse({ type, requestPayload, error, payload, meta }) {
                 );
             }
             break;
-        case CRUD_GET_ONE_FAILURE:
-            return meta.basePath
-                ? yield all([
-                      put(
-                          showNotification(
-                              'ra.notification.item_doesnt_exist',
-                              'warning'
-                          )
-                      ),
-                      put(push(meta.basePath)),
-                  ])
-                : yield all([]);
-        case CRUD_GET_LIST_FAILURE:
-        case CRUD_GET_MANY_FAILURE:
-        case CRUD_GET_MANY_REFERENCE_FAILURE:
-        case CRUD_CREATE_FAILURE:
-        case CRUD_UPDATE_FAILURE:
-        case CRUD_UPDATE_MANY_FAILURE:
-        case CRUD_DELETE_FAILURE:
-        case CRUD_DELETE_MANY_FAILURE: {
-            console.error(error); // eslint-disable-line no-console
-            const errorMessage =
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error';
-
-            return yield [
-                put(refreshView()),
-                put(showNotification(errorMessage, 'warning')),
-            ];
-        }
         default:
             return yield all([]);
     }

--- a/packages/ra-core/src/sideEffect/fetch.js
+++ b/packages/ra-core/src/sideEffect/fetch.js
@@ -17,7 +17,7 @@ export function* handleFetch(dataProvider, action) {
     const {
         type,
         payload,
-        meta: { fetch: fetchMeta, onSuccess, ...meta },
+        meta: { fetch: fetchMeta, onSuccess, onFailure, ...meta },
     } = action;
     const restType = fetchMeta;
 
@@ -62,6 +62,7 @@ export function* handleFetch(dataProvider, action) {
             requestPayload: payload,
             meta: {
                 ...meta,
+                ...onFailure,
                 fetchResponse: restType,
                 fetchStatus: FETCH_ERROR,
             },

--- a/packages/ra-core/src/sideEffect/notification.js
+++ b/packages/ra-core/src/sideEffect/notification.js
@@ -4,10 +4,22 @@ import { showNotification } from '../actions/notificationActions';
 /**
  * Notification Side Effects
  */
-function* handleNotification({ meta: { notification, optimistic } }) {
-    const { body, level = 'info', messageArgs = {} } = notification;
+function* handleNotification({ error, meta: { notification, optimistic } }) {
+    const { body, level, messageArgs = {} } = notification;
+    if (error) {
+        return yield put(
+            showNotification(
+                typeof error === 'string' ? error : error.message || body,
+                level || 'warning',
+                {
+                    messageArgs,
+                    undoable: false,
+                }
+            )
+        );
+    }
     yield put(
-        showNotification(body, level, {
+        showNotification(body, level || 'info', {
             messageArgs,
             undoable: optimistic,
         })


### PR DESCRIPTION
- [x] Unroll failure side effects in `fetch` saga
- [x] Move failure side effects from the `error` saga to data action creators
- [x] Use and apply on the `demo` example
- [x] Document failure side effects

Action creators can now declare failure side effects alongside success side effects, in the `meta` property:

```js
export const crudDeleteMany = (resource, ids, basePath, refresh = true) => ({
    type: CRUD_DELETE_MANY,
    payload: { ids },
    meta: {
        resource,
        fetch: DELETE_MANY,
        onSuccess: {
            notification: {
                body: 'ra.notification.deleted',
                level: 'info',
                messageArgs: {
                    smart_count: ids.length,
                },
            },
            basePath,
            refresh,
            unselectAll: true,
        },
        onFailure: {
            notification: {
                body: 'ra.notification.http_error',
                level: 'warning',
            },
            refresh: true,
        },
    },
});
```

This removes the need for custom sagas in many cases.