### PR TITLE
[RFR] ReferenceInputController this.props missing in componentWillMount

### DIFF
--- a/packages/ra-core/src/controller/input/ReferenceInputController.js
+++ b/packages/ra-core/src/controller/input/ReferenceInputController.js
@@ -105,7 +105,7 @@ export class ReferenceInputController extends Component {
     }
 
     componentDidMount() {
-        this.fetchReferenceAndOptions();
+        this.fetchReferenceAndOptions(this.props);
     }
 
     componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
ReferenceInputController this.props missing in componentWillMount so it will not fetch the options on mount. 