### PR TITLE
NotFound with permission

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -60,9 +60,7 @@ const Admin = ({
     sagaMiddleware.run(saga);
 
     const logout = authClient ? createElement(logoutButton || Logout) : null;
-    const catchAll = authClient
-        ? createElement(customCatchAll || NotFoundWithPermission)
-        : customCatchAll;
+    const catchAll = customCatchAll;
 
     return (
         <Provider store={store}>

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -60,7 +60,9 @@ const Admin = ({
     sagaMiddleware.run(saga);
 
     const logout = authClient ? createElement(logoutButton || Logout) : null;
-    const catchAll = authClient ? createElement(customCatchAll || NotFoundWithPermission) : customCatchAll;
+    const catchAll = authClient
+        ? createElement(customCatchAll || NotFoundWithPermission)
+        : customCatchAll;
 
     return (
         <Provider store={store}>

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -60,7 +60,9 @@ const Admin = ({
     sagaMiddleware.run(saga);
 
     const logout = authClient ? createElement(logoutButton || Logout) : null;
-    const catchAll = customCatchAll;
+    const catchAll = authClient
+        ? createElement(customCatchAll || NotFoundWithPermission)
+        : customCatchAll;
 
     return (
         <Provider store={store}>

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -17,6 +17,7 @@ import Menu from './mui/layout/Menu';
 import Logout from './mui/auth/Logout';
 import TranslationProvider from './i18n/TranslationProvider';
 import AdminRoutes from './AdminRoutes';
+import NotFoundWithPermission from './mui/auth/NotFoundWithPermission';
 
 const Admin = ({
     appLayout,
@@ -30,7 +31,7 @@ const Admin = ({
     locale,
     messages = {},
     menu = Menu,
-    catchAll,
+    catchAll: customCatchAll,
     restClient,
     theme,
     title = 'Admin on REST',
@@ -59,6 +60,7 @@ const Admin = ({
     sagaMiddleware.run(saga);
 
     const logout = authClient ? createElement(logoutButton || Logout) : null;
+    const catchAll = authClient ? createElement(customCatchAll || NotFoundWithPermission) : customCatchAll;
 
     return (
         <Provider store={store}>

--- a/src/mui/auth/NotFoundWithPermission.js
+++ b/src/mui/auth/NotFoundWithPermission.js
@@ -11,7 +11,7 @@ const NotFoundWithPermission = ({ location }) => (
 );
 
 NotFoundWithPermission.propTypes = {
-    location: PropTypes.object
+    location: PropTypes.object,
 };
 
 export default withRouter(NotFoundWithPermission);

--- a/src/mui/auth/NotFoundWithPermission.js
+++ b/src/mui/auth/NotFoundWithPermission.js
@@ -1,12 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import Restricted from '../../auth/Restricted';
 import NotFound from '../layout/NotFound';
 
 const NotFoundWithPermission = ({ location }) => (
-    <Restricted location={location} >
+    <Restricted location={location}>
         <NotFound />
     </Restricted>
 );
+
+NotFoundWithPermission.propTypes = {
+    location: PropTypes.object
+};
 
 export default withRouter(NotFoundWithPermission);

--- a/src/mui/auth/NotFoundWithPermission.js
+++ b/src/mui/auth/NotFoundWithPermission.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+import Restricted from '../../auth/Restricted';
+import NotFound from '../layout/NotFound';
+
+const NotFoundWithPermission = ({ location }) => (
+    <Restricted location={location} >
+        <NotFound />
+    </Restricted>
+);
+
+export default withRouter(NotFoundWithPermission);


### PR DESCRIPTION
At the moment the `NotFound` page/component doesn't check for authentication. This means that when an app is using authentication and a user hits a 404, the `NotFound` page is shown whether they are authenticated or not. Clicking any resource links would kick the user our to `/login` but that doesn't seem the most user friendly.

This PR just wraps the regular `NotFound` page with a `Restricted` then set that as the default `catchAll` if provided with an `authClient`. If an unauthenticated user hits the `NotFound` page they are then automatically redirected to the `/login` page.