### PR TITLE
[RFR] Remove support for children component in SelectArrayInput

### DIFF
--- a/examples/simple/src/posts.js
+++ b/examples/simple/src/posts.js
@@ -246,9 +246,7 @@ export const PostEdit = props => (
             </FormTab>
             <FormTab label="post.form.miscellaneous">
                 <ReferenceArrayInput reference="tags" source="tags">
-                    <SelectArrayInput>
-                        <ChipField source="name" />
-                    </SelectArrayInput>
+                    <SelectArrayInput optionText="name" />
                 </ReferenceArrayInput>
                 <DateInput source="published_at" options={{ locale: 'pt' }} />
                 <SelectInput

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.js
@@ -5,6 +5,7 @@ import Select from 'material-ui/Select';
 import { MenuItem } from 'material-ui/Menu';
 import Input, { InputLabel } from 'material-ui/Input';
 import { FormControl, FormHelperText } from 'material-ui/Form';
+import Chip from 'material-ui/Chip';
 import { withStyles } from 'material-ui/styles';
 import compose from 'recompose/compose';
 import classnames from 'classnames';
@@ -164,7 +165,6 @@ export class SelectArrayInput extends Component {
 
     render() {
         const {
-            children,
             choices,
             classes,
             className,
@@ -210,13 +210,13 @@ export class SelectArrayInput extends Component {
                                 .filter(choice =>
                                     selected.includes(get(choice, optionValue))
                                 )
-                                .map(choice =>
-                                    React.cloneElement(children, {
-                                        key: get(choice, optionValue),
-                                        record: choice,
-                                        className: classes.chip,
-                                    })
-                                )}
+                                .map(choice => (
+                                    <Chip
+                                        key={get(choice, optionValue)}
+                                        label={get(choice, optionText)}
+                                        className={classes.chip}
+                                    />
+                                ))}
                         </div>
                     )}
                     {...options}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.js
@@ -181,35 +181,6 @@ describe('<SelectArrayInput />', () => {
         assert.equal(helperText.childAt(0).text(), 'Can i help you?');
     });
 
-    describe('rendering children', () => {
-        it('should render its children', () => {
-            const wrapper = shallow(
-                <SelectArrayInput
-                    {...defaultProps}
-                    input={{ value: ['M'] }}
-                    choices={[
-                        { id: 'M', name: 'Male' },
-                        { id: 'F', name: 'Female' },
-                    ]}
-                >
-                    <ChipField source="name" />
-                </SelectArrayInput>
-            )
-                .find('WithStyles(Select)')
-                .dive()
-                .dive()
-                .dive()
-                .dive()
-                .find('SelectInput')
-                .dive();
-            expect(wrapper.find('ChipField')).toHaveLength(1);
-            expect(wrapper.find('ChipField').prop('record')).toEqual({
-                id: 'M',
-                name: 'Male',
-            });
-        });
-    });
-
     describe('error message', () => {
         it('should not be displayed if field is pristine', () => {
             const wrapper = shallow(

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.js
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import { SelectArrayInput } from './SelectArrayInput';
-import { ChipField } from '../field/ChipField';
 
 describe('<SelectArrayInput />', () => {
     const defaultProps = {


### PR DESCRIPTION
Because it would make it unusable in most use cases, and because the documentation is not updated at all.

Reverts #1549
Closes #1690