### PR TITLE
Permits the Grids not have Bulk

### DIFF
--- a/packages/ra-ui-materialui/src/list/List.js
+++ b/packages/ra-ui-materialui/src/list/List.js
@@ -142,7 +142,6 @@ export const ListView = ({
                                 basePath,
                                 currentSort,
                                 data,
-                                hasBulkActions: !!bulkActions,
                                 ids,
                                 isLoading,
                                 onSelect,


### PR DESCRIPTION
Permits to the Grids not to have Bulk with the attribute hasBulk={false}