### PR TITLE
Impossible to call a TextInput with an input attribut

### DIFF
--- a/packages/ra-ui-materialui/src/input/TextInput.js
+++ b/packages/ra-ui-materialui/src/input/TextInput.js
@@ -48,12 +48,9 @@ export class TextInput extends Component {
             type,
             ...rest
         } = this.props;
-        if (typeof meta === 'undefined') {
-            throw new Error(
-                "The TextInput component wasn't called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/react-admin/Inputs.html#writing-your-own-input-component for details."
-            );
-        }
-        const { touched, error } = meta;
+
+        const touched = meta ? meta.touched : false
+        const error = meta ? meta.error : false
 
         return (
             <TextField


### PR DESCRIPTION
Impossible to call TextInput with input attribute (to put a value to the TextInput).


My call:

```
<TextInput
                        label="Tifiz Number"
                        source="name"
                        input={{
                            value: value.name,
                        }}
                        translate={translate}
                        validate={validateRequired}
                    />
```

I have the following error message:
```

Error: The TextInput component wasn't called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/react-admin/Inputs.html#writing-your-own-input-component for details.
TextInput.render
/home/oem/Documents/software/ticatag/ticatag-front/packages/ra-ui-materialui/lib/input/TextInput.js:109
  106 |     rest = (0, _objectWithoutProperties3.default)(_props, ['className', 'input', 'isRequired', 'label', 'meta', 'options', 'resource', 'source', 'type', 'value']);
  107 | 
  108 | if (typeof meta === 'undefined') {
> 109 |     throw new Error("The TextInput component wasn't called within a redux-form <Field>. Did you decorate it and forget to add the addField prop to your component? See https://marmelab.com/react-admin/Inputs.html#writing-your-own-input-component for details.");
  110 | }  
```

My TextInput is call inside a redux-form, because call inside a SimpleForm (SimpleForm call redux-form)

![image](https://user-images.githubusercontent.com/173393/38347190-3b6fa0b6-389a-11e8-8ac5-e2637a57fd40.png)

The link given on the error message (https://marmelab.com/react-admin/Inputs.html#writing-your-own-input-component), redirect to PAGE NOT FOUND

With my modiication, I can set a value to my TextInput.
