### PR TITLE
[RFR] Fix DatagridBody too aggressive cache rules

### DIFF
--- a/examples/demo/src/fakeServer/rest.js
+++ b/examples/demo/src/fakeServer/rest.js
@@ -5,6 +5,9 @@ import generateData from 'data-generator';
 export default () => {
     const data = generateData({ serializeDate: true });
     const restServer = new FakeRest.FetchServer('http://localhost:4000');
+    if (window) {
+        window.restServer = restServer; // give way to update data in the console
+    }
     restServer.init(data);
     restServer.toggleLogging(); // logging is off by default, enable it
     fetchMock.mock('begin:http://localhost:4000', restServer.getHandler());

--- a/packages/ra-data-fakerest/src/index.js
+++ b/packages/ra-data-fakerest/src/index.js
@@ -45,6 +45,9 @@ function log(type, resource, params, response) {
 export default (data, loggingEnabled = false) => {
     const restServer = new FakeRest.Server();
     restServer.init(data);
+    if (window) {
+        window.restServer = restServer; // give way to update data in the console
+    }
 
     function getResponse(type, resource, params) {
         switch (type) {

--- a/packages/ra-ui-materialui/src/list/DatagridBody.js
+++ b/packages/ra-ui-materialui/src/list/DatagridBody.js
@@ -73,9 +73,15 @@ DatagridBody.defaultProps = {
     ids: [],
 };
 
+const areArraysEqual = (arr1, arr2) =>
+    arr1.length == arr2.length && arr1.every((v, i) => v === arr2[i]);
+
 const PureDatagridBody = shouldUpdate(
     (props, nextProps) =>
-        props.version !== nextProps.version || nextProps.isLoading === false
+        props.version !== nextProps.version ||
+        nextProps.isLoading === false ||
+        !areArraysEqual(props.ids, nextProps.ids) ||
+        props.data !== nextProps.data
 )(DatagridBody);
 
 // trick material-ui Table into thinking this is one of the child type it supports


### PR DESCRIPTION
When used in a form, `<ReferenceManyField>` does not pass a `version` prop to its child. The caching of `<Datagrid>` is optimized for when it receives a `version`... So the `<ReferenceManyField>` does not refresh properly (see #1648).

This change introduces larger, yet less powerful, caching rules for `<DatagridBody>`.

Closes #1648